### PR TITLE
Fix import error for write_drift_card

### DIFF
--- a/src/rldk/io/__init__.py
+++ b/src/rldk/io/__init__.py
@@ -2,7 +2,7 @@
 
 from .schema import TrainingMetrics, MetricsSchema
 from .readers import read_metrics_jsonl, write_metrics_jsonl
-from .writers import write_json, write_png, mkdir_reports
+from .writers import write_json, write_png, mkdir_reports, write_drift_card
 
 __all__ = [
     "TrainingMetrics",
@@ -12,4 +12,5 @@ __all__ = [
     "write_json",
     "write_png",
     "mkdir_reports",
+    "write_drift_card",
 ]

--- a/src/rldk/io/writers.py
+++ b/src/rldk/io/writers.py
@@ -32,3 +32,92 @@ def write_png(fig: plt.Figure, path: Union[str, Path]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     
     fig.savefig(path, dpi=150, bbox_inches='tight')
+
+
+def write_drift_card(drift_data: Dict[str, Any], output_dir: Union[str, Path]) -> None:
+    """Write drift card to both JSON and markdown formats.
+    
+    Args:
+        drift_data: Dictionary containing drift analysis data with keys like:
+            - diverged: bool indicating if divergence was detected
+            - first_step: int step where divergence first occurred
+            - tripped_signals: list of signals that triggered
+            - signals_monitored: list of all signals monitored
+            - k_consecutive: number of consecutive violations required
+            - window_size: rolling window size for analysis
+            - tolerance: z-score threshold used
+        output_dir: Directory to write the drift card files
+    """
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    
+    # Ensure required keys are present for compatibility with tests
+    card_data = drift_data.copy()
+    if "tripped_signals" not in card_data:
+        card_data["tripped_signals"] = []
+    
+    # Write JSON format
+    write_json(card_data, output_path / "drift_card.json")
+    
+    # Write markdown format
+    md_content = _generate_drift_card_md(card_data)
+    with open(output_path / "drift_card.md", 'w') as f:
+        f.write(md_content)
+
+
+def _generate_drift_card_md(drift_data: Dict[str, Any]) -> str:
+    """Generate markdown content for drift card."""
+    lines = []
+    lines.append("# Drift Detection Card")
+    lines.append("")
+    
+    if drift_data.get("diverged", False):
+        lines.append("## 🚨 Drift Detected")
+        lines.append("")
+        first_step = drift_data.get("first_step", "unknown")
+        lines.append(f"Divergence detected at step {first_step}.")
+        
+        tripped_signals = drift_data.get("tripped_signals", [])
+        if tripped_signals:
+            lines.append("")
+            lines.append("### Tripped Signals")
+            for signal in tripped_signals:
+                lines.append(f"- {signal}")
+    else:
+        lines.append("## ✅ No Drift Detected")
+        lines.append("")
+        lines.append("The runs appear to be consistent within the specified tolerance.")
+    
+    lines.append("")
+    lines.append("## 📁 Report Location")
+    lines.append("")
+    lines.append(f"Full report saved to: `{drift_data.get('output_path', 'drift_card.md')}`")
+    
+    lines.append("")
+    lines.append("## 🔍 Analysis Parameters")
+    lines.append("")
+    
+    if "signals_monitored" in drift_data:
+        signals = drift_data["signals_monitored"]
+        if isinstance(signals, list):
+            signals_str = ", ".join(signals)
+        else:
+            signals_str = str(signals)
+        lines.append(f"- **Signals monitored:** {signals_str}")
+    
+    if "tolerance" in drift_data:
+        lines.append(f"- **Tolerance:** {drift_data['tolerance']}")
+    
+    if "k_consecutive" in drift_data:
+        lines.append(f"- **Consecutive violations required:** {drift_data['k_consecutive']}")
+    
+    if "window_size" in drift_data:
+        lines.append(f"- **Window size:** {drift_data['window_size']}")
+    
+    if drift_data.get("diverged", False):
+        total_events = len(drift_data.get("tripped_signals", []))
+    else:
+        total_events = 0
+    lines.append(f"- **Total divergence events:** {total_events}")
+    
+    return "\n".join(lines)


### PR DESCRIPTION
Add `write_drift_card` function to `rldk.io.writers` to resolve `ImportError` in tests and enable drift report generation.

The existing test suite failed with `ImportError` because `write_drift_card` was expected but not implemented. This PR introduces the function, which generates both JSON and human-readable Markdown reports for drift analysis, ensuring test compatibility and providing necessary reporting functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-5cdfe365-7334-4e0b-9962-bb44c5ed33c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5cdfe365-7334-4e0b-9962-bb44c5ed33c4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

