### PR TITLE
Fix profiler context initialization

### DIFF
--- a/profiler/profiler_context.py
+++ b/profiler/profiler_context.py
@@ -16,14 +16,18 @@ import torch
 class ProfilerContext:
     """Context manager for profiling training stages."""
     
-    def __init__(self, output_dir: str):
+    def __init__(self, output_dir: str, model_name: Optional[str] = None, config: Optional[Dict[str, Any]] = None):
         """
         Initialize profiler context.
         
         Args:
             output_dir: Directory to save stage profiling data
+            model_name: Name of the model being profiled (optional)
+            config: Configuration dictionary (optional)
         """
         self.output_dir = Path(output_dir)
+        self.model_name = model_name
+        self.config = config
         self.stages: Dict[str, List[float]] = {}
         self.current_stage: Optional[str] = None
         self.start_time: Optional[float] = None
@@ -80,6 +84,12 @@ class ProfilerContext:
             "timestamp": time.time()
         }
         
+        if self.model_name is not None:
+            stage_data["model_name"] = self.model_name
+        
+        if self.config is not None:
+            stage_data["config"] = self.config
+        
         with open(stage_times_path, 'w') as f:
             json.dump(stage_data, f, indent=2)
     
@@ -96,9 +106,17 @@ class ProfilerContext:
     
     def get_summary(self) -> Dict[str, Any]:
         """Get profiler context summary."""
-        return {
+        summary = {
             "output_dir": str(self.output_dir),
             "stages": list(self.stages.keys()),
             "average_times": self.get_average_times(),
             "total_stages": len(self.stages)
         }
+        
+        if self.model_name is not None:
+            summary["model_name"] = self.model_name
+        
+        if self.config is not None:
+            summary["config"] = self.config
+            
+        return summary


### PR DESCRIPTION
Add `model_name` and `config` parameters to `ProfilerContext` to support additional profiling context and fix `unexpected keyword argument` errors.

The `ProfilerContext` was being called with `model_name` and `config` in `train_hf_model.py` and `examples/train_hf_model.py`, leading to an `unexpected keyword argument` error. This change updates the `__init__`, `get_summary`, and `save_stage_times` methods to properly handle and store these optional parameters, enhancing the profiler's ability to provide more detailed context.

---
<a href="https://cursor.com/background-agent?bcId=bc-8fa5adb8-1abf-4c0d-9fad-1b0557cd8807">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8fa5adb8-1abf-4c0d-9fad-1b0557cd8807">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

