### PR TITLE
Debug checkpoint diff value head detection

### DIFF
--- a/src/rldk/artifacts/ckpt_diff.py
+++ b/src/rldk/artifacts/ckpt_diff.py
@@ -109,12 +109,18 @@ def diff_checkpoints(ckpt_a: str, ckpt_b: str) -> Dict[str, Any]:
     # Handle infinite values in L2 norms for percentile calculations
     finite_l2_norms = l2_norms[np.isfinite(l2_norms)]
     
+    # Handle empty cosine_similarities array (e.g., when all common params have shape mismatches)
+    if len(cosine_similarities) > 0:
+        avg_cosine = float(np.mean(cosine_similarities))
+    else:
+        avg_cosine = 0.0  # Default to 0 when no comparable tensors exist
+    
     summary = {
         "num_params": len(differences),
         "num_common_params": len(common_param_names),
         "num_only_in_a": len(only_in_a),
         "num_only_in_b": len(only_in_b),
-        "avg_cosine": float(np.mean(cosine_similarities)),
+        "avg_cosine": avg_cosine,
     }
     
     if len(finite_l2_norms) > 0:
@@ -140,6 +146,10 @@ def diff_checkpoints(ckpt_a: str, ckpt_b: str) -> Dict[str, Any]:
         notes.append(f"Checkpoint B has {len(only_in_b)} unique parameters: {list(only_in_b)}")
     if len(common_param_names) > 0:
         notes.append(f"Both checkpoints share {len(common_param_names)} parameters")
+    
+    # Report if no comparable parameters exist (all have shape mismatches)
+    if len(cosine_similarities) == 0 and len(common_param_names) > 0:
+        notes.append("No comparable parameters found - all common parameters have shape mismatches")
 
     # Check for optimizer states
     optimizer_keys = [k for k in state_a.keys() if "optimizer" in k.lower()]

--- a/src/rldk/artifacts/ckpt_diff.py
+++ b/src/rldk/artifacts/ckpt_diff.py
@@ -24,43 +24,80 @@ def diff_checkpoints(ckpt_a: str, ckpt_b: str) -> Dict[str, Any]:
     if not isinstance(state_b, OrderedDict):
         state_b = OrderedDict(state_b)
 
-    # Get common parameter names
-    param_names = set(state_a.keys()) & set(state_b.keys())
+    # Get all parameter names from both checkpoints
+    all_param_names = set(state_a.keys()) | set(state_b.keys())
+    common_param_names = set(state_a.keys()) & set(state_b.keys())
+    only_in_a = set(state_a.keys()) - set(state_b.keys())
+    only_in_b = set(state_b.keys()) - set(state_a.keys())
 
-    if not param_names:
-        raise ValueError("No common parameters found between checkpoints")
+    if not all_param_names:
+        raise ValueError("No parameters found in either checkpoint")
 
     # Compute differences
     differences = []
     l2_norms = []
     cosine_similarities = []
 
-    for name in param_names:
-        param_a = state_a[name]
-        param_b = state_b[name]
+    for name in all_param_names:
+        if name in common_param_names:
+            # Parameter exists in both checkpoints
+            param_a = state_a[name]
+            param_b = state_b[name]
 
-        # Ensure same shape
-        if param_a.shape != param_b.shape:
-            continue
+            # Ensure same shape
+            if param_a.shape != param_b.shape:
+                differences.append({
+                    "name": name, 
+                    "l2": float('inf'), 
+                    "cosine": 0.0,
+                    "note": f"Shape mismatch: {param_a.shape} vs {param_b.shape}"
+                })
+                continue
 
-        # Compute L2 norm of difference
-        diff = param_a - param_b
-        l2_norm = torch.norm(diff).item()
+            # Compute L2 norm of difference
+            diff = param_a - param_b
+            l2_norm = torch.norm(diff).item()
 
-        # Compute cosine similarity
-        norm_a = torch.norm(param_a).item()
-        norm_b = torch.norm(param_b).item()
+            # Compute cosine similarity
+            norm_a = torch.norm(param_a).item()
+            norm_b = torch.norm(param_b).item()
 
-        if norm_a > 0 and norm_b > 0:
-            dot_product = torch.dot(param_a.flatten(), param_b.flatten()).item()
-            cosine_sim = dot_product / (norm_a * norm_b)
-        else:
-            cosine_sim = 1.0 if l2_norm == 0 else 0.0
+            if norm_a > 0 and norm_b > 0:
+                dot_product = torch.dot(param_a.flatten(), param_b.flatten()).item()
+                cosine_sim = dot_product / (norm_a * norm_b)
+            else:
+                cosine_sim = 1.0 if l2_norm == 0 else 0.0
 
-        differences.append({"name": name, "l2": l2_norm, "cosine": cosine_sim})
+            differences.append({"name": name, "l2": l2_norm, "cosine": cosine_sim})
 
-        l2_norms.append(l2_norm)
-        cosine_similarities.append(cosine_sim)
+            l2_norms.append(l2_norm)
+            cosine_similarities.append(cosine_sim)
+            
+        elif name in only_in_a:
+            # Parameter only exists in checkpoint A
+            param_a = state_a[name]
+            l2_norm = torch.norm(param_a).item()
+            differences.append({
+                "name": name, 
+                "l2": l2_norm, 
+                "cosine": 0.0,
+                "note": "Only in checkpoint A"
+            })
+            l2_norms.append(l2_norm)
+            cosine_similarities.append(0.0)
+            
+        elif name in only_in_b:
+            # Parameter only exists in checkpoint B
+            param_b = state_b[name]
+            l2_norm = torch.norm(param_b).item()
+            differences.append({
+                "name": name, 
+                "l2": l2_norm, 
+                "cosine": 0.0,
+                "note": "Only in checkpoint B"
+            })
+            l2_norms.append(l2_norm)
+            cosine_similarities.append(0.0)
 
     # Sort by L2 norm (descending)
     differences.sort(key=lambda x: x["l2"], reverse=True)
@@ -68,17 +105,41 @@ def diff_checkpoints(ckpt_a: str, ckpt_b: str) -> Dict[str, Any]:
     # Compute summary statistics
     l2_norms = np.array(l2_norms)
     cosine_similarities = np.array(cosine_similarities)
-
+    
+    # Handle infinite values in L2 norms for percentile calculations
+    finite_l2_norms = l2_norms[np.isfinite(l2_norms)]
+    
     summary = {
         "num_params": len(differences),
+        "num_common_params": len(common_param_names),
+        "num_only_in_a": len(only_in_a),
+        "num_only_in_b": len(only_in_b),
         "avg_cosine": float(np.mean(cosine_similarities)),
-        "l2_p05": float(np.percentile(l2_norms, 5)),
-        "l2_p50": float(np.percentile(l2_norms, 50)),
-        "l2_p95": float(np.percentile(l2_norms, 95)),
     }
+    
+    if len(finite_l2_norms) > 0:
+        summary.update({
+            "l2_p05": float(np.percentile(finite_l2_norms, 5)),
+            "l2_p50": float(np.percentile(finite_l2_norms, 50)),
+            "l2_p95": float(np.percentile(finite_l2_norms, 95)),
+        })
+    else:
+        summary.update({
+            "l2_p05": 0.0,
+            "l2_p50": 0.0,
+            "l2_p95": 0.0,
+        })
 
     # Generate notes
     notes = []
+
+    # Report parameter differences
+    if only_in_a:
+        notes.append(f"Checkpoint A has {len(only_in_a)} unique parameters: {list(only_in_a)}")
+    if only_in_b:
+        notes.append(f"Checkpoint B has {len(only_in_b)} unique parameters: {list(only_in_b)}")
+    if len(common_param_names) > 0:
+        notes.append(f"Both checkpoints share {len(common_param_names)} parameters")
 
     # Check for optimizer states
     optimizer_keys = [k for k in state_a.keys() if "optimizer" in k.lower()]

--- a/src/rldk/cli_forensics.py
+++ b/src/rldk/cli_forensics.py
@@ -114,7 +114,12 @@ def diff_ckpt(
 
         # Print summary
         summary = report["summary"]
-        typer.echo(f"Parameters compared: {summary['num_params']}")
+        typer.echo(f"Total parameters: {summary['num_params']}")
+        typer.echo(f"Common parameters: {summary['num_common_params']}")
+        if summary['num_only_in_a'] > 0:
+            typer.echo(f"Only in checkpoint A: {summary['num_only_in_a']}")
+        if summary['num_only_in_b'] > 0:
+            typer.echo(f"Only in checkpoint B: {summary['num_only_in_b']}")
         typer.echo(f"Average cosine similarity: {summary['avg_cosine']:.4f}")
         typer.echo(
             f"L2 norm percentiles - 5%: {summary['l2_p05']:.6f}, 50%: {summary['l2_p50']:.6f}, 95%: {summary['l2_p95']:.6f}"
@@ -123,9 +128,15 @@ def diff_ckpt(
         if report["top_movers"]:
             typer.echo("\nTop parameter changes:")
             for i, mover in enumerate(report["top_movers"][:5]):
-                typer.echo(
-                    f"  {i+1}. {mover['name']}: L2={mover['l2']:.6f}, cosine={mover['cosine']:.4f}"
-                )
+                note = mover.get('note', '')
+                if note:
+                    typer.echo(
+                        f"  {i+1}. {mover['name']}: L2={mover['l2']:.6f}, cosine={mover['cosine']:.4f} ({note})"
+                    )
+                else:
+                    typer.echo(
+                        f"  {i+1}. {mover['name']}: L2={mover['l2']:.6f}, cosine={mover['cosine']:.4f}"
+                    )
 
     except Exception as e:
         typer.echo(f"Error: {e}", err=True)

--- a/src/rldk/io/schemas.py
+++ b/src/rldk/io/schemas.py
@@ -88,9 +88,12 @@ CkptDiffReportV1 = {
         "version": {"type": "string"},
         "summary": {
             "type": "object",
-            "required": ["num_params", "avg_cosine", "l2_p05", "l2_p50", "l2_p95"],
+            "required": ["num_params", "num_common_params", "num_only_in_a", "num_only_in_b", "avg_cosine", "l2_p05", "l2_p50", "l2_p95"],
             "properties": {
                 "num_params": {"type": "integer"},
+                "num_common_params": {"type": "integer"},
+                "num_only_in_a": {"type": "integer"},
+                "num_only_in_b": {"type": "integer"},
                 "avg_cosine": {"type": "number"},
                 "l2_p05": {"type": "number"},
                 "l2_p50": {"type": "number"},
@@ -106,6 +109,7 @@ CkptDiffReportV1 = {
                     "name": {"type": "string"},
                     "l2": {"type": "number"},
                     "cosine": {"type": "number"},
+                    "note": {"type": "string"},
                 },
             },
         },


### PR DESCRIPTION
Fix checkpoint diff to correctly detect differences when parameters are unique to one checkpoint.

The previous implementation of `diff_checkpoints` only compared parameters present in *both* checkpoints. This meant that if a checkpoint had unique parameters (e.g., a `value_head`), these differences were ignored, leading to an incorrect cosine similarity of 1.0000. The fix modifies the comparison logic to account for parameters unique to either checkpoint, reporting them and contributing to the overall difference.

---
<a href="https://cursor.com/background-agent?bcId=bc-a9058842-26b0-4df6-87e6-85075e0ed82c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a9058842-26b0-4df6-87e6-85075e0ed82c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

