### PR TITLE
Add CI gates for reward health checks

### DIFF
--- a/.github/workflows/health-gate.yml
+++ b/.github/workflows/health-gate.yml
@@ -44,16 +44,9 @@ jobs:
     - name: Test gate with failing health (should fail)
       run: |
         # This should exit with code 3 and fail the job
-        rldk reward-health gate --from test_health_data/health.json || exit_code=$?
-        if [ $exit_code -ne 3 ]; then
-          echo "Expected exit code 3, got $exit_code"
-          exit 1
-        fi
-      continue-on-error: true
-    
-    - name: Verify job failed as expected
-      if: failure()
-      run: echo "✅ Job failed as expected for failing health data"
+        rldk reward-health gate --from test_health_data/health.json
+        echo "❌ Expected gate to fail with exit code 3, but it succeeded"
+        exit 1
     
     - name: Generate synthetic passing health data
       run: |

--- a/.github/workflows/health-gate.yml
+++ b/.github/workflows/health-gate.yml
@@ -1,0 +1,109 @@
+name: Reward Health Gate
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  health-gate:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+    
+    - name: Install package
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[dev]"
+    
+    - name: Create test data directory
+      run: mkdir -p test_health_data
+    
+    - name: Generate synthetic failing health data
+      run: |
+        cat > test_health_data/health.json << 'EOF'
+        {
+          "passed": false,
+          "warnings": ["High reward variance detected"],
+          "failures": ["Reward drift detected (p=0.05)"]
+        }
+        EOF
+    
+    - name: Test gate with failing health (should fail)
+      run: |
+        # This should exit with code 3 and fail the job
+        rldk reward-health gate --from test_health_data/health.json || exit_code=$?
+        if [ $exit_code -ne 3 ]; then
+          echo "Expected exit code 3, got $exit_code"
+          exit 1
+        fi
+      continue-on-error: true
+    
+    - name: Verify job failed as expected
+      if: failure()
+      run: echo "✅ Job failed as expected for failing health data"
+    
+    - name: Generate synthetic passing health data
+      run: |
+        cat > test_health_data/health.json << 'EOF'
+        {
+          "passed": true,
+          "warnings": ["Minor calibration drift"],
+          "failures": []
+        }
+        EOF
+    
+    - name: Test gate with passing health (should pass)
+      run: |
+        # This should exit with code 0 and pass
+        rldk reward-health gate --from test_health_data/health.json
+        echo "✅ Gate passed as expected for passing health data"
+
+  health-gate-fixed:
+    runs-on: ubuntu-latest
+    needs: health-gate
+    if: always() && needs.health-gate.result == 'failure'
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+        cache: 'pip'
+    
+    - name: Install package
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[dev]"
+    
+    - name: Create test data directory
+      run: mkdir -p test_health_data
+    
+    - name: Generate fixed health data
+      run: |
+        cat > test_health_data/health.json << 'EOF'
+        {
+          "passed": true,
+          "warnings": [],
+          "failures": []
+        }
+        EOF
+    
+    - name: Test gate with fixed health (should pass)
+      run: |
+        rldk reward-health gate --from test_health_data/health.json
+        echo "✅ Gate passed with fixed configuration"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # RL Debug Kit (rldk)
 
+[![Reward Health Gate](https://github.com/your-org/rldk/workflows/Reward%20Health%20Gate/badge.svg)](https://github.com/your-org/rldk/actions/workflows/health-gate.yml)
+
 **The gold standard companion for LLM + RL** - a tiny, sharp kit that makes RL work reliable, explainable, and reproducible across any trainer or stack. No lock-in. Batteries included for determinism, drift, data, reward health, and evals.
 
 ## 🎯 North Star
@@ -629,6 +631,13 @@ rldk eval --run my_run --suite quick --no-wandb
 - Find which commit introduced a bug
 - Use metric-based or shell-based predicates
 - Automate regression testing in CI/CD
+
+### CI/CD Integration
+- **Reward Health Gate**: Automatically fail CI when reward health checks fail
+- Copy `.github/workflows/health-gate.yml` to your repository
+- Update the badge URL in README.md to point to your repository
+- The workflow tests both Python 3.10 and 3.11 with synthetic health data
+- Exit codes: 0 (passed), 3 (failed) - compatible with CI systems
 
 ### PPO Forensics
 - Detect KL spikes and controller failures

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # RL Debug Kit (rldk)
 
 [![Reward Health Gate](https://github.com/your-org/rldk/workflows/Reward%20Health%20Gate/badge.svg)](https://github.com/your-org/rldk/actions/workflows/health-gate.yml)
+<!-- Update the badge URL above to point to your repository -->
 
 **The gold standard companion for LLM + RL** - a tiny, sharp kit that makes RL work reliable, explainable, and reproducible across any trainer or stack. No lock-in. Batteries included for determinism, drift, data, reward health, and evals.
 

--- a/artifacts/health/health.json
+++ b/artifacts/health/health.json
@@ -1,0 +1,5 @@
+{
+  "passed": true,
+  "warnings": [],
+  "failures": []
+}

--- a/src/rldk/cli_reward.py
+++ b/src/rldk/cli_reward.py
@@ -122,7 +122,7 @@ def reward_health_run(
     scores: str = typer.Option(..., "--scores", help="Path to scores JSONL file"),
     config: Optional[str] = typer.Option(None, "--config", help="Path to health configuration YAML file"),
     out: str = typer.Option(..., "--out", help="Output directory for reports"),
-    gate: bool = typer.Option(False, "--gate", help="Enable CI gate mode with exit codes (0=pass, 1=warn, 2=fail)"),
+    gate: bool = typer.Option(False, "--gate", help="Enable CI gate mode with exit codes (0=pass, 1=warn, 2=fail). Use 'gate' subcommand for health.json-based gating."),
 ):
     """Run reward health analysis on scores data."""
     try:
@@ -227,10 +227,13 @@ def reward_health_run(
 def reward_health_gate(
     from_path: str = typer.Option(..., "--from", help="Path to health.json file"),
 ):
-    """Gate CI based on health.json results."""
+    """Gate CI based on health.json results (exit codes: 0=pass, 3=fail)."""
     try:
         typer.echo(f"Reading health data from: {from_path}")
         raise_on_failure(from_path)
+    except SystemExit:
+        # Re-raise SystemExit to preserve exit codes from raise_on_failure
+        raise
     except Exception as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)

--- a/src/rldk/cli_reward.py
+++ b/src/rldk/cli_reward.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from rldk.reward.drift import compare_models
 from rldk.reward.health import health
+from rldk.reward.health.exit_codes import raise_on_failure
 from rldk.io.writers import write_json, write_png, mkdir_reports
 from rldk.io.schemas import validate, RewardDriftReportV1
 from rldk.io.reward_writers import generate_reward_health_report
@@ -217,3 +218,16 @@ def reward_health_run(
             raise typer.Exit(2)
         else:
             raise typer.Exit(1)
+
+
+@reward_health_app.command(name="gate")
+def reward_health_gate(
+    from_path: str = typer.Option(..., "--from", help="Path to health.json file"),
+):
+    """Gate CI based on health.json results."""
+    try:
+        typer.echo(f"Reading health data from: {from_path}")
+        raise_on_failure(from_path)
+    except Exception as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)

--- a/src/rldk/cli_reward.py
+++ b/src/rldk/cli_reward.py
@@ -211,6 +211,9 @@ def reward_health_run(
                 typer.echo("GATE: FAIL")
             raise typer.Exit(exit_code)
     
+    except typer.Exit:
+        # Re-raise typer.Exit to preserve intended exit codes
+        raise
     except Exception as e:
         typer.echo(f"Error: {e}", err=True)
         if gate:

--- a/src/rldk/reward/health/exit_codes.py
+++ b/src/rldk/reward/health/exit_codes.py
@@ -1,0 +1,76 @@
+"""Exit code mapping for reward health gates."""
+
+import json
+import sys
+from pathlib import Path
+from typing import Dict, Any
+
+
+def get_exit_code(passed: bool) -> int:
+    """
+    Map health status to exit codes.
+    
+    Args:
+        passed: Whether the health check passed
+        
+    Returns:
+        Exit code: 0 for passed=True, 3 for passed=False
+    """
+    return 0 if passed else 3
+
+
+def raise_on_failure(health_path: str) -> None:
+    """
+    Read health.json and exit with appropriate code based on passed field.
+    
+    Args:
+        health_path: Path to health.json file
+        
+    Raises:
+        SystemExit: With exit code 0 (passed) or 3 (failed)
+    """
+    health_file = Path(health_path)
+    
+    if not health_file.exists():
+        print(f"Error: Health file not found at {health_path}", file=sys.stderr)
+        sys.exit(1)
+    
+    try:
+        with open(health_file, 'r') as f:
+            health_data: Dict[str, Any] = json.load(f)
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON in health file: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: Failed to read health file: {e}", file=sys.stderr)
+        sys.exit(1)
+    
+    if 'passed' not in health_data:
+        print("Error: 'passed' field missing from health data", file=sys.stderr)
+        sys.exit(1)
+    
+    passed = health_data['passed']
+    exit_code = get_exit_code(passed)
+    
+    # Print summary
+    warnings = health_data.get('warnings', [])
+    failures = health_data.get('failures', [])
+    
+    if passed:
+        print("✅ Health check passed")
+        if warnings:
+            print(f"  Warnings: {len(warnings)}")
+            for warning in warnings:
+                print(f"    - {warning}")
+    else:
+        print("🚨 Health check failed")
+        if failures:
+            print(f"  Failures: {len(failures)}")
+            for failure in failures:
+                print(f"    - {failure}")
+        if warnings:
+            print(f"  Warnings: {len(warnings)}")
+            for warning in warnings:
+                print(f"    - {warning}")
+    
+    sys.exit(exit_code)

--- a/tests/reward_health/__init__.py
+++ b/tests/reward_health/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for reward health functionality."""

--- a/tests/reward_health/test_gate.py
+++ b/tests/reward_health/test_gate.py
@@ -1,0 +1,163 @@
+"""Tests for reward health gate functionality."""
+
+import json
+import pytest
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from rldk.reward.health.exit_codes import get_exit_code, raise_on_failure
+
+
+class TestExitCodeMapping:
+    """Test exit code mapping functionality."""
+    
+    def test_get_exit_code_passed_true(self):
+        """Test that passed=True returns exit code 0."""
+        assert get_exit_code(True) == 0
+    
+    def test_get_exit_code_passed_false(self):
+        """Test that passed=False returns exit code 3."""
+        assert get_exit_code(False) == 3
+
+
+class TestRaiseOnFailure:
+    """Test raise_on_failure function."""
+    
+    def test_raise_on_failure_passed_true(self):
+        """Test that passed=True exits with code 0."""
+        health_data = {
+            "passed": True,
+            "warnings": ["Minor issue"],
+            "failures": []
+        }
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump(health_data, f)
+            health_path = f.name
+        
+        try:
+            with patch('sys.exit') as mock_exit:
+                with patch('sys.stderr'):
+                    raise_on_failure(health_path)
+                mock_exit.assert_called_once_with(0)
+        finally:
+            Path(health_path).unlink()
+    
+    def test_raise_on_failure_passed_false(self):
+        """Test that passed=False exits with code 3."""
+        health_data = {
+            "passed": False,
+            "warnings": ["Warning message"],
+            "failures": ["Failure message"]
+        }
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump(health_data, f)
+            health_path = f.name
+        
+        try:
+            with patch('sys.exit') as mock_exit:
+                with patch('sys.stderr'):
+                    raise_on_failure(health_path)
+                mock_exit.assert_called_once_with(3)
+        finally:
+            Path(health_path).unlink()
+    
+    def test_raise_on_failure_file_not_found(self):
+        """Test that missing file exits with code 1."""
+        with patch('sys.exit') as mock_exit:
+            with patch('sys.stderr'):
+                raise_on_failure("nonexistent.json")
+            mock_exit.assert_called_once_with(1)
+    
+    def test_raise_on_failure_invalid_json(self):
+        """Test that invalid JSON exits with code 1."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            f.write("invalid json content")
+            health_path = f.name
+        
+        try:
+            with patch('sys.exit') as mock_exit:
+                with patch('sys.stderr'):
+                    raise_on_failure(health_path)
+                mock_exit.assert_called_once_with(1)
+        finally:
+            Path(health_path).unlink()
+    
+    def test_raise_on_failure_missing_passed_field(self):
+        """Test that missing 'passed' field exits with code 1."""
+        health_data = {
+            "warnings": ["Warning message"],
+            "failures": []
+        }
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump(health_data, f)
+            health_path = f.name
+        
+        try:
+            with patch('sys.exit') as mock_exit:
+                with patch('sys.stderr'):
+                    raise_on_failure(health_path)
+                mock_exit.assert_called_once_with(1)
+        finally:
+            Path(health_path).unlink()
+    
+    def test_raise_on_failure_with_warnings_and_failures(self):
+        """Test output formatting with warnings and failures."""
+        health_data = {
+            "passed": False,
+            "warnings": ["Warning 1", "Warning 2"],
+            "failures": ["Failure 1", "Failure 2"]
+        }
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump(health_data, f)
+            health_path = f.name
+        
+        try:
+            with patch('sys.exit') as mock_exit:
+                with patch('sys.stderr'):
+                    with patch('builtins.print') as mock_print:
+                        raise_on_failure(health_path)
+                        
+                        # Check that appropriate messages were printed
+                        print_calls = [call[0][0] for call in mock_print.call_args_list]
+                        assert "🚨 Health check failed" in print_calls
+                        assert "Failures: 2" in print_calls
+                        assert "Warnings: 2" in print_calls
+                        assert "Failure 1" in print_calls
+                        assert "Warning 1" in print_calls
+                        
+                mock_exit.assert_called_once_with(3)
+        finally:
+            Path(health_path).unlink()
+    
+    def test_raise_on_failure_passed_with_warnings(self):
+        """Test output formatting when passed=True with warnings."""
+        health_data = {
+            "passed": True,
+            "warnings": ["Warning 1", "Warning 2"],
+            "failures": []
+        }
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump(health_data, f)
+            health_path = f.name
+        
+        try:
+            with patch('sys.exit') as mock_exit:
+                with patch('sys.stderr'):
+                    with patch('builtins.print') as mock_print:
+                        raise_on_failure(health_path)
+                        
+                        # Check that appropriate messages were printed
+                        print_calls = [call[0][0] for call in mock_print.call_args_list]
+                        assert "✅ Health check passed" in print_calls
+                        assert "Warnings: 2" in print_calls
+                        assert "Warning 1" in print_calls
+                        
+                mock_exit.assert_called_once_with(0)
+        finally:
+            Path(health_path).unlink()


### PR DESCRIPTION
Add CI gates for reward health checks to automatically fail GitHub Actions when detectors return `passed: false`.

---
<a href="https://cursor.com/background-agent?bcId=bc-7518f478-7e1a-4a40-a00b-51d8d36f2c6e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7518f478-7e1a-4a40-a00b-51d8d36f2c6e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

