### PR TITLE
Emit standardized JSONL events from TRL callback

### DIFF
--- a/JSONL_IMPLEMENTATION_SUMMARY.md
+++ b/JSONL_IMPLEMENTATION_SUMMARY.md
@@ -1,0 +1,210 @@
+# TRL Callback JSONL Event Emission Implementation
+
+## Overview
+
+This implementation addresses the issue where the TRL callback only wrote CSV/JSON summaries but lacked per-step JSONL logs compatible with TRLAdapter or the Event schema. The solution adds standardized JSONL event emission that follows proper research standards and enables seamless downstream analysis.
+
+## Problem Statement
+
+**Original Issue**: `src/rldk/integrations/trl/callbacks.py` only wrote CSV/JSON summaries; it lacked per-step JSONL logs compatible with TRLAdapter or the Event schema, making downstream analyses cumbersome.
+
+**Solution**: Implement standardized JSONL event emission from TRL callback that:
+- Follows the Event schema for consistency
+- Is compatible with TRLAdapter for data loading
+- Provides per-step granularity for detailed analysis
+- Maintains research-grade data quality
+
+## Implementation Details
+
+### 1. Enhanced RLDKCallback Class
+
+**New Parameters**:
+- `enable_jsonl_logging: bool = True` - Enable/disable JSONL event emission
+- `jsonl_log_interval: int = 1` - Control logging frequency (default: every step)
+
+**New Methods**:
+- `_setup_jsonl_logging()` - Initialize JSONL file and logging
+- `_emit_jsonl_event()` - Emit standardized JSONL events
+- `_close_jsonl_file()` - Proper file cleanup
+
+### 2. Event Schema Integration
+
+The implementation leverages the existing Event schema (`src/rldk/io/event_schema.py`) to ensure:
+- **Consistency**: All events follow the same structure
+- **Compatibility**: Events work with existing analysis tools
+- **Extensibility**: Easy to add new metrics or metadata
+
+**Event Structure**:
+```json
+{
+  "step": 10,
+  "wall_time": 100.0,
+  "metrics": {
+    "loss": 0.5,
+    "reward_mean": 0.8,
+    "kl_mean": 0.05,
+    "entropy_mean": 0.9,
+    "clip_frac": 0.1,
+    "grad_norm": 0.1,
+    "lr": 0.001,
+    "value_loss": 0.3,
+    "policy_loss": 0.2
+  },
+  "rng": {
+    "seed": 42
+  },
+  "data_slice": {
+    "tokens_in": 1000,
+    "tokens_out": 500
+  },
+  "model_info": {
+    "run_id": "rldk_run_1234567890",
+    "git_sha": "abc123def456",
+    "phase": "train"
+  },
+  "notes": [
+    "High clipping fraction detected",
+    "Large gradient norm detected"
+  ]
+}
+```
+
+### 3. TRLAdapter Compatibility
+
+The emitted JSONL events are fully compatible with the TRLAdapter:
+- **Automatic Detection**: TRLAdapter can automatically detect and load the files
+- **Standardized Format**: Events contain all required fields for TRLAdapter
+- **Seamless Integration**: No additional processing needed for downstream analysis
+
+### 4. Research-Grade Features
+
+**Data Quality**:
+- **Immediate Flushing**: Events are written immediately to prevent data loss
+- **Error Handling**: Graceful handling of missing metrics or schema issues
+- **Validation**: Events are validated against the Event schema
+
+**Performance**:
+- **Configurable Intervals**: Control logging frequency to balance detail vs. performance
+- **Efficient I/O**: Minimal overhead with direct JSONL writing
+- **Memory Management**: Proper file cleanup and resource management
+
+**Monitoring**:
+- **Health Indicators**: Automatic generation of training health notes
+- **Alert Integration**: JSONL events include notes for training issues
+- **Metadata Preservation**: Complete run information preserved
+
+## Usage Examples
+
+### Basic Usage
+```python
+from rldk.integrations.trl.callbacks import RLDKCallback
+
+# Enable JSONL logging (default)
+callback = RLDKCallback(
+    output_dir="./rldk_logs",
+    enable_jsonl_logging=True,
+    jsonl_log_interval=1  # Log every step
+)
+```
+
+### Advanced Configuration
+```python
+callback = RLDKCallback(
+    output_dir="./rldk_logs",
+    enable_jsonl_logging=True,
+    jsonl_log_interval=5,  # Log every 5 steps
+    log_interval=10,       # Detailed logging every 10 steps
+    run_id="my_experiment_001"
+)
+```
+
+### Disable JSONL Logging
+```python
+callback = RLDKCallback(
+    output_dir="./rldk_logs",
+    enable_jsonl_logging=False  # Disable JSONL logging
+)
+```
+
+## File Output
+
+The callback generates the following files:
+- `{run_id}_events.jsonl` - Per-step JSONL events (new)
+- `{run_id}_metrics.csv` - Summary metrics (existing)
+- `{run_id}_metrics.json` - Summary metrics (existing)
+- `{run_id}_alerts.json` - Training alerts (existing)
+- `{run_id}_final_report.json` - Final analysis (existing)
+
+## Downstream Analysis
+
+### Using TRLAdapter
+```python
+from rldk.adapters.trl import TRLAdapter
+
+# Load JSONL events
+adapter = TRLAdapter("rldk_logs/my_experiment_001_events.jsonl")
+df = adapter.load()
+
+# Analyze training progression
+print(f"Steps: {df['step'].min()} - {df['step'].max()}")
+print(f"Reward progression: {df['reward_mean'].tolist()}")
+```
+
+### Using Event Schema
+```python
+from rldk.io.event_schema import Event, dataframe_to_events
+
+# Convert to Event objects
+events = dataframe_to_events(df, run_id="my_experiment_001")
+
+# Process events
+for event in events:
+    print(f"Step {event.step}: {event.metrics}")
+```
+
+### Direct JSONL Processing
+```python
+import json
+
+# Read JSONL directly
+with open("rldk_logs/my_experiment_001_events.jsonl", "r") as f:
+    for line in f:
+        event = json.loads(line)
+        print(f"Step {event['step']}: Loss={event['metrics']['loss']}")
+```
+
+## Testing
+
+Comprehensive tests are included in `tests/test_trl_callbacks.py`:
+
+- **JSONL Logging**: Basic functionality and configuration
+- **Event Structure**: Validation of Event schema compliance
+- **TRLAdapter Compatibility**: End-to-end compatibility testing
+- **Interval Control**: Verification of logging frequency
+- **Error Handling**: Graceful handling of edge cases
+- **File Management**: Proper file creation and cleanup
+
+## Benefits for Researchers
+
+1. **Standardized Data**: All events follow the same schema for consistency
+2. **Granular Analysis**: Per-step data enables detailed training analysis
+3. **Tool Compatibility**: Works seamlessly with existing RLDK tools
+4. **Performance Monitoring**: Built-in health indicators and alerts
+5. **Reproducibility**: Complete metadata preservation for experiments
+6. **Flexibility**: Configurable logging to balance detail and performance
+
+## Migration Guide
+
+### For Existing Users
+- **Backward Compatible**: Existing functionality unchanged
+- **Opt-in Feature**: JSONL logging enabled by default but can be disabled
+- **No Breaking Changes**: All existing APIs remain the same
+
+### For New Users
+- **Default Behavior**: JSONL logging enabled automatically
+- **Immediate Benefits**: Get detailed training logs without configuration
+- **Future-Proof**: Compatible with all RLDK analysis tools
+
+## Conclusion
+
+This implementation provides a robust, research-grade solution for TRL training log emission. The standardized JSONL events enable seamless downstream analysis while maintaining compatibility with existing tools and workflows. The implementation follows best practices for data quality, performance, and extensibility, making it suitable for production research environments.

--- a/src/rldk/integrations/trl/callbacks.py
+++ b/src/rldk/integrations/trl/callbacks.py
@@ -139,14 +139,14 @@ class RLDKCallback(TrainerCallback):
         self.step_start_time = time.time()
         self.run_start_time = time.time()
         
-        # JSONL logging setup
-        self.jsonl_file = None
-        if self.enable_jsonl_logging:
-            self._setup_jsonl_logging()
-        
         # Generate run ID if not provided
         self.run_id = run_id or f"rldk_run_{int(time.time())}"
         self.current_metrics.run_id = self.run_id
+        
+        # JSONL logging setup (after run_id is initialized)
+        self.jsonl_file = None
+        if self.enable_jsonl_logging:
+            self._setup_jsonl_logging()
         
         # Alert system
         self.alerts: List[Dict[str, Any]] = []
@@ -441,6 +441,12 @@ class RLDKCallback(TrainerCallback):
         """Setup JSONL logging file."""
         if not EVENT_SCHEMA_AVAILABLE:
             warnings.warn("Event schema not available, JSONL logging disabled")
+            self.enable_jsonl_logging = False
+            return
+        
+        # Safety check: ensure run_id is available
+        if not hasattr(self, 'run_id') or self.run_id is None:
+            warnings.warn("run_id not available, JSONL logging disabled")
             self.enable_jsonl_logging = False
             return
         

--- a/src/rldk/integrations/trl/callbacks.py
+++ b/src/rldk/integrations/trl/callbacks.py
@@ -115,6 +115,12 @@ class RLDKCallback(TrainerCallback):
         self.output_dir = Path(output_dir) if output_dir else Path("./rldk_logs")
         self.output_dir.mkdir(parents=True, exist_ok=True)
         
+        # Validate log intervals
+        if log_interval <= 0:
+            raise ValueError("log_interval must be positive")
+        if jsonl_log_interval <= 0:
+            raise ValueError("jsonl_log_interval must be positive")
+        
         self.log_interval = log_interval
         self.enable_checkpoint_analysis = enable_checkpoint_analysis
         self.enable_resource_monitoring = enable_resource_monitoring
@@ -241,7 +247,9 @@ class RLDKCallback(TrainerCallback):
         self.metrics_history.append(RLDKMetrics(**self.current_metrics.to_dict()))
         
         # Emit JSONL event if enabled and at the right interval
-        if self.enable_jsonl_logging and state.global_step % self.jsonl_log_interval == 0:
+        if (self.enable_jsonl_logging and 
+            self.jsonl_log_interval > 0 and 
+            state.global_step % self.jsonl_log_interval == 0):
             self._emit_jsonl_event(state, logs)
         
         # Check for alerts AFTER metrics are stored

--- a/src/rldk/integrations/trl/callbacks.py
+++ b/src/rldk/integrations/trl/callbacks.py
@@ -21,6 +21,15 @@ except ImportError:
     PPOTrainer = None
     PPOTrainerClass = None
 
+# Import Event schema for proper JSONL emission
+try:
+    from ...io.event_schema import Event, create_event_from_row
+    EVENT_SCHEMA_AVAILABLE = True
+except ImportError:
+    EVENT_SCHEMA_AVAILABLE = False
+    Event = None
+    create_event_from_row = None
+
 
 @dataclass
 class RLDKMetrics:
@@ -85,6 +94,8 @@ class RLDKCallback(TrainerCallback):
         enable_checkpoint_analysis: bool = True,
         enable_resource_monitoring: bool = True,
         run_id: Optional[str] = None,
+        enable_jsonl_logging: bool = True,
+        jsonl_log_interval: int = 1,
     ):
         """Initialize RLDK callback.
         
@@ -107,6 +118,8 @@ class RLDKCallback(TrainerCallback):
         self.log_interval = log_interval
         self.enable_checkpoint_analysis = enable_checkpoint_analysis
         self.enable_resource_monitoring = enable_resource_monitoring
+        self.enable_jsonl_logging = enable_jsonl_logging
+        self.jsonl_log_interval = jsonl_log_interval
         
         # Default alert thresholds
         self.alert_thresholds = {
@@ -126,6 +139,11 @@ class RLDKCallback(TrainerCallback):
         self.step_start_time = time.time()
         self.run_start_time = time.time()
         
+        # JSONL logging setup
+        self.jsonl_file = None
+        if self.enable_jsonl_logging:
+            self._setup_jsonl_logging()
+        
         # Generate run ID if not provided
         self.run_id = run_id or f"rldk_run_{int(time.time())}"
         self.current_metrics.run_id = self.run_id
@@ -136,6 +154,8 @@ class RLDKCallback(TrainerCallback):
         print(f"🚀 RLDK Callback initialized - Run ID: {self.run_id}")
         print(f"📊 Output directory: {self.output_dir}")
         print(f"⚠️  Alert thresholds: {self.alert_thresholds}")
+        if self.enable_jsonl_logging:
+            print(f"📝 JSONL logging enabled - interval: {self.jsonl_log_interval}")
     
     def on_train_begin(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
         """Called at the beginning of training."""
@@ -220,6 +240,10 @@ class RLDKCallback(TrainerCallback):
         # Store metrics AFTER log values are applied
         self.metrics_history.append(RLDKMetrics(**self.current_metrics.to_dict()))
         
+        # Emit JSONL event if enabled and at the right interval
+        if self.enable_jsonl_logging and state.global_step % self.jsonl_log_interval == 0:
+            self._emit_jsonl_event(state, logs)
+        
         # Check for alerts AFTER metrics are stored
         self._check_alerts()
     
@@ -234,6 +258,9 @@ class RLDKCallback(TrainerCallback):
     def on_train_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
         """Called at the end of training."""
         print("🏁 RLDK: Training completed")
+        
+        # Close JSONL file
+        self._close_jsonl_file()
         
         # Final analysis
         self._generate_final_report()
@@ -409,6 +436,70 @@ class RLDKCallback(TrainerCallback):
             json.dump(report, f, indent=2)
         
         print(f"📋 Final Report: {report}")
+    
+    def _setup_jsonl_logging(self):
+        """Setup JSONL logging file."""
+        if not EVENT_SCHEMA_AVAILABLE:
+            warnings.warn("Event schema not available, JSONL logging disabled")
+            self.enable_jsonl_logging = False
+            return
+        
+        jsonl_path = self.output_dir / f"{self.run_id}_events.jsonl"
+        self.jsonl_file = open(jsonl_path, "w")
+        print(f"📝 JSONL events will be written to: {jsonl_path}")
+    
+    def _emit_jsonl_event(self, state: TrainerState, logs: Dict[str, float]):
+        """Emit a standardized JSONL event compatible with Event schema and TRLAdapter."""
+        if not self.jsonl_file or not EVENT_SCHEMA_AVAILABLE:
+            return
+        
+        try:
+            # Create event data compatible with TRLAdapter expectations
+            event_data = {
+                "step": state.global_step,
+                "phase": "train",
+                "wall_time": self.current_metrics.wall_time,
+                "reward_mean": self.current_metrics.reward_mean,
+                "reward_std": self.current_metrics.reward_std,
+                "kl_mean": self.current_metrics.kl_mean,
+                "kl_std": self.current_metrics.kl_std,
+                "entropy_mean": self.current_metrics.entropy_mean,
+                "clip_frac": self.current_metrics.clip_frac,
+                "grad_norm": self.current_metrics.grad_norm,
+                "lr": self.current_metrics.learning_rate,
+                "loss": self.current_metrics.loss,
+                "value_loss": self.current_metrics.value_loss,
+                "policy_loss": self.current_metrics.policy_loss,
+                "tokens_in": self.current_metrics.tokens_in,
+                "tokens_out": self.current_metrics.tokens_out,
+                "seed": self.current_metrics.seed,
+                "run_id": self.current_metrics.run_id,
+                "git_sha": self.current_metrics.git_sha,
+                "epoch": self.current_metrics.epoch,
+                "step_time": self.current_metrics.step_time,
+                "gpu_memory_used": self.current_metrics.gpu_memory_used,
+                "gpu_memory_allocated": self.current_metrics.gpu_memory_allocated,
+                "cpu_memory_used": self.current_metrics.cpu_memory_used,
+                "training_stability_score": self.current_metrics.training_stability_score,
+                "convergence_indicator": self.current_metrics.convergence_indicator,
+            }
+            
+            # Create Event object using the schema
+            event = create_event_from_row(event_data, self.run_id, self.current_metrics.git_sha)
+            
+            # Write JSONL line
+            json_line = event.to_json()
+            self.jsonl_file.write(json_line + "\n")
+            self.jsonl_file.flush()  # Ensure immediate write
+            
+        except Exception as e:
+            warnings.warn(f"Failed to emit JSONL event: {e}")
+    
+    def _close_jsonl_file(self):
+        """Close the JSONL file."""
+        if self.jsonl_file:
+            self.jsonl_file.close()
+            self.jsonl_file = None
 
 
 class RLDKMonitor(RLDKCallback):

--- a/tests/test_trl_callbacks.py
+++ b/tests/test_trl_callbacks.py
@@ -50,6 +50,7 @@ class TestRLDKCallbackJSONL:
         jsonl_path = jsonl_files[0]
         assert callback.run_id in jsonl_path.name
         assert jsonl_path.exists()
+        assert "None" not in jsonl_path.name  # Ensure run_id is properly set
 
     def test_jsonl_event_emission(self):
         """Test that JSONL events are emitted correctly."""
@@ -308,3 +309,19 @@ class TestRLDKCallbackJSONL:
         
         # Verify file is closed
         assert callback.jsonl_file is None
+    
+    def test_jsonl_initialization_order(self):
+        """Test that JSONL setup happens after run_id initialization."""
+        callback = RLDKCallback(output_dir=self.output_dir)
+        
+        # Verify run_id is set before JSONL file is created
+        assert callback.run_id is not None
+        assert callback.run_id != "None"
+        
+        # Verify JSONL file name contains the proper run_id
+        jsonl_files = list(self.output_dir.glob("*_events.jsonl"))
+        assert len(jsonl_files) == 1
+        
+        jsonl_path = jsonl_files[0]
+        assert callback.run_id in jsonl_path.name
+        assert "None" not in jsonl_path.name

--- a/tests/test_trl_callbacks.py
+++ b/tests/test_trl_callbacks.py
@@ -325,3 +325,60 @@ class TestRLDKCallbackJSONL:
         jsonl_path = jsonl_files[0]
         assert callback.run_id in jsonl_path.name
         assert "None" not in jsonl_path.name
+    
+    def test_jsonl_log_interval_validation(self):
+        """Test that jsonl_log_interval validation works correctly."""
+        # Test valid intervals
+        callback = RLDKCallback(output_dir=self.output_dir, jsonl_log_interval=1)
+        assert callback.jsonl_log_interval == 1
+        
+        callback = RLDKCallback(output_dir=self.output_dir, jsonl_log_interval=5)
+        assert callback.jsonl_log_interval == 5
+        
+        # Test invalid intervals
+        with pytest.raises(ValueError, match="jsonl_log_interval must be positive"):
+            RLDKCallback(output_dir=self.output_dir, jsonl_log_interval=0)
+        
+        with pytest.raises(ValueError, match="jsonl_log_interval must be positive"):
+            RLDKCallback(output_dir=self.output_dir, jsonl_log_interval=-1)
+    
+    def test_log_interval_validation(self):
+        """Test that log_interval validation works correctly."""
+        # Test valid intervals
+        callback = RLDKCallback(output_dir=self.output_dir, log_interval=1)
+        assert callback.log_interval == 1
+        
+        callback = RLDKCallback(output_dir=self.output_dir, log_interval=10)
+        assert callback.log_interval == 10
+        
+        # Test invalid intervals
+        with pytest.raises(ValueError, match="log_interval must be positive"):
+            RLDKCallback(output_dir=self.output_dir, log_interval=0)
+        
+        with pytest.raises(ValueError, match="log_interval must be positive"):
+            RLDKCallback(output_dir=self.output_dir, log_interval=-1)
+    
+    def test_jsonl_emission_with_zero_interval(self):
+        """Test that JSONL emission handles zero interval gracefully."""
+        # This test verifies the defensive check in on_log method
+        # Even though the constructor should prevent this, we test the defensive check
+        
+        # Create a callback with a valid interval first
+        callback = RLDKCallback(output_dir=self.output_dir, jsonl_log_interval=1)
+        
+        # Manually set jsonl_log_interval to 0 to test defensive check
+        callback.jsonl_log_interval = 0
+        
+        # Mock training step
+        from unittest.mock import Mock
+        state = Mock()
+        state.global_step = 1
+        
+        logs = {'train_loss': 0.5}
+        
+        # This should not raise ZeroDivisionError due to defensive check
+        try:
+            callback.on_log(Mock(), state, Mock(), logs)
+            print("✅ JSONL emission with zero interval handled gracefully")
+        except ZeroDivisionError:
+            pytest.fail("ZeroDivisionError should not occur with defensive check")

--- a/tests/test_trl_callbacks.py
+++ b/tests/test_trl_callbacks.py
@@ -1,0 +1,310 @@
+"""Tests for TRL callbacks JSONL event emission."""
+
+import pytest
+import tempfile
+import json
+import os
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from rldk.integrations.trl.callbacks import RLDKCallback, RLDKMetrics
+from rldk.io.event_schema import Event
+
+
+class TestRLDKCallbackJSONL:
+    """Test JSONL event emission functionality."""
+
+    def setup_method(self):
+        """Setup test environment."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.output_dir = Path(self.temp_dir)
+        
+    def teardown_method(self):
+        """Cleanup test environment."""
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_jsonl_logging_enabled(self):
+        """Test that JSONL logging is enabled by default."""
+        callback = RLDKCallback(output_dir=self.output_dir)
+        assert callback.enable_jsonl_logging is True
+        assert callback.jsonl_log_interval == 1
+
+    def test_jsonl_logging_disabled(self):
+        """Test that JSONL logging can be disabled."""
+        callback = RLDKCallback(
+            output_dir=self.output_dir,
+            enable_jsonl_logging=False
+        )
+        assert callback.enable_jsonl_logging is False
+        assert callback.jsonl_file is None
+
+    def test_jsonl_file_creation(self):
+        """Test that JSONL file is created correctly."""
+        callback = RLDKCallback(output_dir=self.output_dir)
+        
+        # Check that JSONL file was created
+        jsonl_files = list(self.output_dir.glob("*_events.jsonl"))
+        assert len(jsonl_files) == 1
+        
+        jsonl_path = jsonl_files[0]
+        assert callback.run_id in jsonl_path.name
+        assert jsonl_path.exists()
+
+    def test_jsonl_event_emission(self):
+        """Test that JSONL events are emitted correctly."""
+        callback = RLDKCallback(
+            output_dir=self.output_dir,
+            jsonl_log_interval=1
+        )
+        
+        # Mock trainer state and logs
+        state = Mock()
+        state.global_step = 10
+        state.epoch = 1.0
+        
+        logs = {
+            'train_loss': 0.5,
+            'learning_rate': 0.001,
+            'grad_norm': 0.1,
+            'ppo/rewards/mean': 0.8,
+            'ppo/rewards/std': 0.2,
+            'ppo/policy/kl_mean': 0.05,
+            'ppo/policy/entropy': 0.9,
+            'ppo/policy/clipfrac': 0.1,
+            'ppo/val/value_loss': 0.3,
+            'ppo/val/policy_loss': 0.2,
+        }
+        
+        # Update current metrics
+        callback.current_metrics.step = 10
+        callback.current_metrics.epoch = 1.0
+        callback.current_metrics.loss = 0.5
+        callback.current_metrics.learning_rate = 0.001
+        callback.current_metrics.grad_norm = 0.1
+        callback.current_metrics.reward_mean = 0.8
+        callback.current_metrics.reward_std = 0.2
+        callback.current_metrics.kl_mean = 0.05
+        callback.current_metrics.entropy_mean = 0.9
+        callback.current_metrics.clip_frac = 0.1
+        callback.current_metrics.value_loss = 0.3
+        callback.current_metrics.policy_loss = 0.2
+        callback.current_metrics.wall_time = 100.0
+        
+        # Emit JSONL event
+        callback._emit_jsonl_event(state, logs)
+        
+        # Check that event was written
+        jsonl_files = list(self.output_dir.glob("*_events.jsonl"))
+        assert len(jsonl_files) == 1
+        
+        with open(jsonl_files[0], 'r') as f:
+            lines = f.readlines()
+            assert len(lines) == 1
+            
+            # Parse the JSONL line
+            event_data = json.loads(lines[0])
+            
+            # Verify Event schema structure
+            assert "step" in event_data
+            assert "wall_time" in event_data
+            assert "metrics" in event_data
+            assert "rng" in event_data
+            assert "data_slice" in event_data
+            assert "model_info" in event_data
+            assert "notes" in event_data
+            
+            # Verify specific values
+            assert event_data["step"] == 10
+            assert event_data["wall_time"] == 100.0
+            assert event_data["metrics"]["loss"] == 0.5
+            assert event_data["metrics"]["reward_mean"] == 0.8
+            assert event_data["metrics"]["kl_mean"] == 0.05
+            assert event_data["model_info"]["run_id"] == callback.run_id
+            assert event_data["model_info"]["phase"] == "train"
+
+    def test_jsonl_event_compatibility_with_trl_adapter(self):
+        """Test that emitted JSONL events are compatible with TRLAdapter."""
+        callback = RLDKCallback(
+            output_dir=self.output_dir,
+            jsonl_log_interval=1
+        )
+        
+        # Mock trainer state and logs
+        state = Mock()
+        state.global_step = 5
+        state.epoch = 0.5
+        
+        logs = {
+            'train_loss': 0.6,
+            'learning_rate': 0.0005,
+            'grad_norm': 0.15,
+            'ppo/rewards/mean': 0.7,
+            'ppo/rewards/std': 0.25,
+            'ppo/policy/kl_mean': 0.08,
+            'ppo/policy/entropy': 0.85,
+            'ppo/policy/clipfrac': 0.12,
+        }
+        
+        # Update current metrics
+        callback.current_metrics.step = 5
+        callback.current_metrics.epoch = 0.5
+        callback.current_metrics.loss = 0.6
+        callback.current_metrics.learning_rate = 0.0005
+        callback.current_metrics.grad_norm = 0.15
+        callback.current_metrics.reward_mean = 0.7
+        callback.current_metrics.reward_std = 0.25
+        callback.current_metrics.kl_mean = 0.08
+        callback.current_metrics.entropy_mean = 0.85
+        callback.current_metrics.clip_frac = 0.12
+        callback.current_metrics.wall_time = 50.0
+        callback.current_metrics.tokens_in = 1000
+        callback.current_metrics.tokens_out = 500
+        callback.current_metrics.seed = 42
+        callback.current_metrics.git_sha = "abc123"
+        
+        # Emit JSONL event
+        callback._emit_jsonl_event(state, logs)
+        
+        # Close the file to ensure it's written
+        callback._close_jsonl_file()
+        
+        # Test that TRLAdapter can read the file
+        from rldk.adapters.trl import TRLAdapter
+        
+        jsonl_files = list(self.output_dir.glob("*_events.jsonl"))
+        assert len(jsonl_files) == 1
+        
+        adapter = TRLAdapter(jsonl_files[0])
+        assert adapter.can_handle()
+        
+        df = adapter.load()
+        assert len(df) == 1
+        assert df["step"].iloc[0] == 5
+        assert df["reward_mean"].iloc[0] == 0.7
+        assert df["kl_mean"].iloc[0] == 0.08
+        assert df["wall_time"].iloc[0] == 50.0
+
+    def test_jsonl_logging_interval(self):
+        """Test that JSONL logging respects the interval setting."""
+        callback = RLDKCallback(
+            output_dir=self.output_dir,
+            jsonl_log_interval=3  # Log every 3 steps
+        )
+        
+        state = Mock()
+        logs = {'train_loss': 0.5}
+        
+        # Update current metrics
+        callback.current_metrics.loss = 0.5
+        callback.current_metrics.wall_time = 10.0
+        
+        # Step 1 - should not log (step % 3 != 0)
+        state.global_step = 1
+        callback._emit_jsonl_event(state, logs)
+        
+        # Step 3 - should log (step % 3 == 0)
+        state.global_step = 3
+        callback._emit_jsonl_event(state, logs)
+        
+        # Step 6 - should log (step % 3 == 0)
+        state.global_step = 6
+        callback._emit_jsonl_event(state, logs)
+        
+        # Close file and check
+        callback._close_jsonl_file()
+        
+        jsonl_files = list(self.output_dir.glob("*_events.jsonl"))
+        assert len(jsonl_files) == 1
+        
+        with open(jsonl_files[0], 'r') as f:
+            lines = f.readlines()
+            assert len(lines) == 2  # Only steps 3 and 6 should be logged
+
+    def test_jsonl_event_notes_generation(self):
+        """Test that notes are generated based on training health indicators."""
+        callback = RLDKCallback(output_dir=self.output_dir)
+        
+        state = Mock()
+        state.global_step = 10
+        
+        # Set metrics that should trigger notes
+        callback.current_metrics.clip_frac = 0.25  # > 0.2 threshold
+        callback.current_metrics.grad_norm = 15.0  # > 10.0 threshold
+        callback.current_metrics.kl_mean = 0.25  # > 0.2 threshold
+        callback.current_metrics.wall_time = 100.0
+        
+        logs = {'train_loss': 0.5}
+        
+        # Emit JSONL event
+        callback._emit_jsonl_event(state, logs)
+        
+        # Close file and check notes
+        callback._close_jsonl_file()
+        
+        jsonl_files = list(self.output_dir.glob("*_events.jsonl"))
+        with open(jsonl_files[0], 'r') as f:
+            event_data = json.loads(f.readline())
+            notes = event_data["notes"]
+            
+            assert "High clipping fraction detected" in notes
+            assert "Large gradient norm detected" in notes
+            assert "High KL divergence detected" in notes
+
+    def test_jsonl_event_with_missing_metrics(self):
+        """Test that JSONL events handle missing metrics gracefully."""
+        callback = RLDKCallback(output_dir=self.output_dir)
+        
+        state = Mock()
+        state.global_step = 1
+        
+        # Don't set any metrics
+        callback.current_metrics.wall_time = 10.0
+        
+        logs = {}
+        
+        # Emit JSONL event
+        callback._emit_jsonl_event(state, logs)
+        
+        # Close file and check
+        callback._close_jsonl_file()
+        
+        jsonl_files = list(self.output_dir.glob("*_events.jsonl"))
+        with open(jsonl_files[0], 'r') as f:
+            event_data = json.loads(f.readline())
+            
+            # Should still have the basic structure
+            assert "step" in event_data
+            assert "wall_time" in event_data
+            assert "metrics" in event_data
+            assert "model_info" in event_data
+            
+            # Metrics should be empty or have None values
+            metrics = event_data["metrics"]
+            assert len(metrics) == 0 or all(v is None for v in metrics.values())
+
+    @patch('rldk.integrations.trl.callbacks.EVENT_SCHEMA_AVAILABLE', False)
+    def test_jsonl_logging_without_event_schema(self):
+        """Test that JSONL logging is disabled when Event schema is not available."""
+        callback = RLDKCallback(output_dir=self.output_dir)
+        
+        # Should be disabled when Event schema is not available
+        assert callback.enable_jsonl_logging is False
+        assert callback.jsonl_file is None
+
+    def test_jsonl_file_cleanup(self):
+        """Test that JSONL file is properly closed on training end."""
+        callback = RLDKCallback(output_dir=self.output_dir)
+        
+        # Verify file is open
+        assert callback.jsonl_file is not None
+        
+        # Mock training end
+        args = Mock()
+        state = Mock()
+        control = Mock()
+        
+        callback.on_train_end(args, state, control)
+        
+        # Verify file is closed
+        assert callback.jsonl_file is None

--- a/validate_jsonl_implementation.py
+++ b/validate_jsonl_implementation.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Validation script for TRL callback JSONL implementation.
+
+This script validates that the JSONL event emission works correctly
+without requiring full dependency installation.
+"""
+
+import sys
+import os
+import json
+import tempfile
+from pathlib import Path
+
+# Add src to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+
+def validate_imports():
+    """Validate that all required imports work."""
+    print("🔍 Validating imports...")
+    
+    try:
+        from rldk.integrations.trl.callbacks import RLDKCallback
+        print("✅ RLDKCallback import successful")
+        
+        from rldk.io.event_schema import Event, create_event_from_row
+        print("✅ Event schema import successful")
+        
+        from rldk.adapters.trl import TRLAdapter
+        print("✅ TRLAdapter import successful")
+        
+        return True
+    except Exception as e:
+        print(f"❌ Import failed: {e}")
+        return False
+
+def validate_jsonl_emission():
+    """Validate JSONL event emission."""
+    print("\n📝 Validating JSONL event emission...")
+    
+    try:
+        from rldk.integrations.trl.callbacks import RLDKCallback
+        from rldk.io.event_schema import Event, create_event_from_row
+        from rldk.adapters.trl import TRLAdapter
+        from unittest.mock import Mock
+        
+        # Create temporary directory
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_dir = Path(temp_dir)
+            
+            # Create callback
+            callback = RLDKCallback(
+                output_dir=output_dir,
+                enable_jsonl_logging=True,
+                jsonl_log_interval=1,
+                run_id="validation_test"
+            )
+            
+            # Check JSONL file creation
+            jsonl_files = list(output_dir.glob("*_events.jsonl"))
+            if len(jsonl_files) != 1:
+                print(f"❌ Expected 1 JSONL file, found {len(jsonl_files)}")
+                return False
+            
+            print("✅ JSONL file creation successful")
+            
+            # Mock training step
+            state = Mock()
+            state.global_step = 1
+            state.epoch = 0.1
+            
+            logs = {
+                'train_loss': 0.5,
+                'learning_rate': 0.001,
+                'ppo/rewards/mean': 0.8,
+                'ppo/policy/kl_mean': 0.05,
+            }
+            
+            # Update metrics
+            callback.current_metrics.step = 1
+            callback.current_metrics.loss = 0.5
+            callback.current_metrics.learning_rate = 0.001
+            callback.current_metrics.reward_mean = 0.8
+            callback.current_metrics.kl_mean = 0.05
+            callback.current_metrics.wall_time = 10.0
+            
+            # Emit event
+            callback._emit_jsonl_event(state, logs)
+            callback._close_jsonl_file()
+            
+            # Validate event structure
+            with open(jsonl_files[0], 'r') as f:
+                lines = f.readlines()
+                if len(lines) != 1:
+                    print(f"❌ Expected 1 event, found {len(lines)}")
+                    return False
+                
+                event_data = json.loads(lines[0])
+                
+                # Check required fields
+                required_fields = ["step", "wall_time", "metrics", "rng", "data_slice", "model_info", "notes"]
+                for field in required_fields:
+                    if field not in event_data:
+                        print(f"❌ Missing required field: {field}")
+                        return False
+                
+                # Check specific values
+                if event_data["step"] != 1:
+                    print(f"❌ Expected step 1, got {event_data['step']}")
+                    return False
+                
+                if event_data["metrics"]["loss"] != 0.5:
+                    print(f"❌ Expected loss 0.5, got {event_data['metrics']['loss']}")
+                    return False
+                
+                print("✅ JSONL event structure validation successful")
+            
+            # Test TRLAdapter compatibility
+            adapter = TRLAdapter(jsonl_files[0])
+            if not adapter.can_handle():
+                print("❌ TRLAdapter cannot handle generated file")
+                return False
+            
+            df = adapter.load()
+            if len(df) != 1:
+                print(f"❌ Expected 1 row in DataFrame, got {len(df)}")
+                return False
+            
+            print("✅ TRLAdapter compatibility validation successful")
+            
+            return True
+            
+    except Exception as e:
+        print(f"❌ JSONL emission validation failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+def main():
+    """Main validation function."""
+    print("🚀 TRL Callback JSONL Implementation Validation")
+    print("=" * 50)
+    
+    # Validate imports
+    if not validate_imports():
+        print("\n❌ Import validation failed")
+        return False
+    
+    # Validate JSONL emission
+    if not validate_jsonl_emission():
+        print("\n❌ JSONL emission validation failed")
+        return False
+    
+    print("\n🎉 All validations passed!")
+    print("✅ JSONL implementation is working correctly")
+    return True
+
+if __name__ == "__main__":
+    success = main()
+    sys.exit(0 if success else 1)

--- a/validate_jsonl_implementation.py
+++ b/validate_jsonl_implementation.py
@@ -62,6 +62,16 @@ def validate_jsonl_emission():
                 print(f"❌ Expected 1 JSONL file, found {len(jsonl_files)}")
                 return False
             
+            # Verify run_id is properly set in filename
+            jsonl_path = jsonl_files[0]
+            if "None" in jsonl_path.name:
+                print(f"❌ JSONL filename contains 'None': {jsonl_path.name}")
+                return False
+            
+            if callback.run_id not in jsonl_path.name:
+                print(f"❌ JSONL filename doesn't contain run_id: {jsonl_path.name}")
+                return False
+            
             print("✅ JSONL file creation successful")
             
             # Mock training step

--- a/validate_jsonl_implementation.py
+++ b/validate_jsonl_implementation.py
@@ -34,6 +34,52 @@ def validate_imports():
         print(f"❌ Import failed: {e}")
         return False
 
+def validate_parameter_validation():
+    """Validate that parameter validation works correctly."""
+    print("\n🔍 Validating parameter validation...")
+    
+    try:
+        from rldk.integrations.trl.callbacks import RLDKCallback
+        from unittest.mock import Mock
+        
+        # Test valid parameters
+        callback = RLDKCallback(
+            output_dir="./temp_test",
+            jsonl_log_interval=1,
+            log_interval=10
+        )
+        print("✅ Valid parameters accepted")
+        
+        # Test invalid jsonl_log_interval
+        try:
+            RLDKCallback(output_dir="./temp_test", jsonl_log_interval=0)
+            print("❌ Should have raised ValueError for jsonl_log_interval=0")
+            return False
+        except ValueError as e:
+            if "jsonl_log_interval must be positive" in str(e):
+                print("✅ jsonl_log_interval=0 correctly rejected")
+            else:
+                print(f"❌ Unexpected error message: {e}")
+                return False
+        
+        # Test invalid log_interval
+        try:
+            RLDKCallback(output_dir="./temp_test", log_interval=-1)
+            print("❌ Should have raised ValueError for log_interval=-1")
+            return False
+        except ValueError as e:
+            if "log_interval must be positive" in str(e):
+                print("✅ log_interval=-1 correctly rejected")
+            else:
+                print(f"❌ Unexpected error message: {e}")
+                return False
+        
+        return True
+        
+    except Exception as e:
+        print(f"❌ Parameter validation test failed: {e}")
+        return False
+
 def validate_jsonl_emission():
     """Validate JSONL event emission."""
     print("\n📝 Validating JSONL event emission...")
@@ -154,6 +200,11 @@ def main():
     # Validate imports
     if not validate_imports():
         print("\n❌ Import validation failed")
+        return False
+    
+    # Validate parameter validation
+    if not validate_parameter_validation():
+        print("\n❌ Parameter validation failed")
         return False
     
     # Validate JSONL emission


### PR DESCRIPTION
Emit standardized JSONL events from TRL callback to provide per-step, ingestible logs compatible with TRLAdapter and the Event schema for research analysis.

---
<a href="https://cursor.com/background-agent?bcId=bc-c758edfb-b775-49d6-a2c8-cbf51a92ee0b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c758edfb-b775-49d6-a2c8-cbf51a92ee0b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

