### PR TITLE
Fix experiment tracker api documentation mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,9 @@ tracker.track_model(model, "gpt2_policy")
 tracker.set_seeds(42)
 
 # Add metadata
-tracker.add_metadata({
-    "learning_rate": 1e-5,
-    "batch_size": 32,
-    "epochs": 10
-})
+tracker.add_metadata("learning_rate", 1e-5)
+tracker.add_metadata("batch_size", 32)
+tracker.add_metadata("epochs", 10)
 
 tracker.finish_experiment()
 ```


### PR DESCRIPTION
Update `README.md` example for `ExperimentTracker.add_metadata` to prevent runtime errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-91d190f4-28e9-4b3a-a848-0e834d5a38fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-91d190f4-28e9-4b3a-a848-0e834d5a38fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

