### PR TITLE
Update rldk for pydantic v2 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 dependencies = [
     "typer>=0.9.0",
     "pydantic>=2.0.0",
+    "pydantic-settings>=2.0.0",
     "numpy>=1.21.0",
     "pandas>=1.3.0",
     "scipy>=1.7.0",

--- a/src/rldk/config/schemas.py
+++ b/src/rldk/config/schemas.py
@@ -1,6 +1,6 @@
 """Configuration schemas for RLDK."""
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator, ConfigDict
 from typing import Optional, List, Dict, Any, Union
 from pathlib import Path
 from enum import Enum
@@ -31,8 +31,7 @@ class LoggingConfig(BaseModel):
     file: Optional[Path] = Field(default=None, description="Log file path")
     console: bool = Field(default=True, description="Enable console logging")
     
-    class Config:
-        use_enum_values = True
+    model_config = ConfigDict(use_enum_values=True)
 
 class AnalysisConfig(BaseModel):
     """Analysis configuration schema."""
@@ -78,15 +77,15 @@ class VisualizationConfig(BaseModel):
     save_format: str = Field(default="png", description="Default save format")
     show_plots: bool = Field(default=True, description="Show plots interactively")
     
-    @validator('figure_size')
+    @field_validator('figure_size')
+    @classmethod
     def validate_figure_size(cls, v):
         """Validate figure size tuple."""
         if len(v) != 2 or not all(isinstance(x, (int, float)) and x > 0 for x in v):
             raise ValueError("figure_size must be a tuple of two positive numbers")
         return v
     
-    class Config:
-        use_enum_values = True
+    model_config = ConfigDict(use_enum_values=True)
 
 class DirectoryConfig(BaseModel):
     """Directory configuration schema."""
@@ -127,11 +126,11 @@ class ConfigSchema(BaseModel):
     
     def to_dict(self) -> Dict[str, Any]:
         """Convert configuration to dictionary."""
-        return self.dict()
+        return self.model_dump()
     
     def to_json(self) -> str:
         """Convert configuration to JSON string."""
-        return self.json(indent=2)
+        return self.model_dump_json(indent=2)
     
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'ConfigSchema':
@@ -141,7 +140,7 @@ class ConfigSchema(BaseModel):
     @classmethod
     def from_json(cls, json_str: str) -> 'ConfigSchema':
         """Create configuration from JSON string."""
-        return cls.parse_raw(json_str)
+        return cls.model_validate_json(json_str)
     
     def validate_config(self) -> bool:
         """Validate the entire configuration."""

--- a/src/rldk/config/settings.py
+++ b/src/rldk/config/settings.py
@@ -1,6 +1,7 @@
 """Central configuration management for RLDK."""
 
-from pydantic import BaseSettings, Field, validator
+from pydantic_settings import BaseSettings
+from pydantic import Field, field_validator, ConfigDict
 from typing import Optional, List, Dict, Any
 from pathlib import Path
 import os
@@ -8,6 +9,15 @@ import logging
 
 class RLDKSettings(BaseSettings):
     """Main RLDK configuration."""
+    
+    model_config = ConfigDict(
+        env_file='.env',
+        env_file_encoding='utf-8',
+        env_prefix='RLDK_',
+        case_sensitive=False,
+        validate_assignment=True,
+        extra='forbid'
+    )
     
     # Output directories
     default_output_dir: Path = Field(default="rldk_reports", description="Default output directory")
@@ -45,7 +55,8 @@ class RLDKSettings(BaseSettings):
     seed: Optional[int] = Field(default=None, description="Random seed")
     debug: bool = Field(default=False, description="Debug mode")
     
-    @validator('log_level')
+    @field_validator('log_level')
+    @classmethod
     def validate_log_level(cls, v):
         """Validate log level."""
         valid_levels = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
@@ -53,28 +64,32 @@ class RLDKSettings(BaseSettings):
             raise ValueError(f"log_level must be one of {valid_levels}")
         return v.upper()
     
-    @validator('default_tolerance')
+    @field_validator('default_tolerance')
+    @classmethod
     def validate_tolerance(cls, v):
         """Validate tolerance value."""
         if not 0 < v < 1:
             raise ValueError("tolerance must be between 0 and 1")
         return v
     
-    @validator('default_window_size')
+    @field_validator('default_window_size')
+    @classmethod
     def validate_window_size(cls, v):
         """Validate window size."""
         if v <= 0:
             raise ValueError("window_size must be positive")
         return v
     
-    @validator('num_workers')
+    @field_validator('num_workers')
+    @classmethod
     def validate_num_workers(cls, v):
         """Validate number of workers."""
         if v <= 0:
             raise ValueError("num_workers must be positive")
         return v
     
-    @validator('batch_size')
+    @field_validator('batch_size')
+    @classmethod
     def validate_batch_size(cls, v):
         """Validate batch size."""
         if v <= 0:
@@ -136,10 +151,6 @@ class RLDKSettings(BaseSettings):
         self.setup_logging()
         self.create_directories()
     
-    class Config:
-        env_prefix = "RLDK_"
-        case_sensitive = False
-        validate_assignment = True
 
 # Global settings instance
 settings = RLDKSettings()


### PR DESCRIPTION
Migrate RLDK package to Pydantic v2 for compatibility and to use modern Pydantic features.

This PR updates `BaseSettings` to use `pydantic-settings` and replaces `BaseModel`'s `Config` class with `model_config = ConfigDict`. It also updates `@validator` to `@field_validator` and replaces deprecated Pydantic v1 methods with their v2 equivalents.

---
<a href="https://cursor.com/background-agent?bcId=bc-e0469b1b-631b-4bd8-86a4-9698ff1e1915">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e0469b1b-631b-4bd8-86a4-9698ff1e1915">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

