### PR TITLE
Fix replay module import style

### DIFF
--- a/src/rldk/replay/__init__.py
+++ b/src/rldk/replay/__init__.py
@@ -1,6 +1,6 @@
 """Seeded replay utility for training runs."""
 
-from rldk.replay.replay import (
+from .replay import (
     replay,
     ReplayReport,
     _compare_metrics,


### PR DESCRIPTION
Fix import error in replay module by changing absolute import to relative import.

---
<a href="https://cursor.com/background-agent?bcId=bc-521403ae-38da-464b-a50d-156782e726e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-521403ae-38da-464b-a50d-156782e726e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

