### PR TITLE
Fix missing imports and syntax errors

### DIFF
--- a/src/rldk/evals/metrics.py
+++ b/src/rldk/evals/metrics.py
@@ -2,6 +2,7 @@
 
 from typing import Dict, Tuple, Any
 import numpy as np
+import pandas as pd
 import warnings
 from scipy import stats
 from scipy.stats import bootstrap

--- a/tests/unit/test_utils_error_handling.py
+++ b/tests/unit/test_utils_error_handling.py
@@ -713,17 +713,18 @@ class TestErrorHandlingIntegration:
     def test_error_formatting_with_chain(self):
         """Test error formatting with error chain."""
         original_error = ValueError("Original error")
-        rldk_error = ValidationError(
-            "Validation failed",
-            suggestion="Check input",
-            error_code="VALIDATION_ERROR"
-        ) from original_error
-        
-        message = format_error_message(rldk_error)
-        
-        assert "❌ Validation failed" in message
-        assert "💡 Suggestion: Check input" in message
-        assert "🔍 Error Code: VALIDATION_ERROR" in message
+        try:
+            raise ValidationError(
+                "Validation failed",
+                suggestion="Check input",
+                error_code="VALIDATION_ERROR"
+            ) from original_error
+        except ValidationError as rldk_error:
+            message = format_error_message(rldk_error)
+            
+            assert "❌ Validation failed" in message
+            assert "💡 Suggestion: Check input" in message
+            assert "🔍 Error Code: VALIDATION_ERROR" in message
     
     def test_multiple_decorators(self):
         """Test combining multiple decorators."""


### PR DESCRIPTION
Add missing `import pandas` to `src/rldk/evals/metrics.py` and fix exception chaining syntax in `tests/unit/test_utils_error_handling.py`.

The exception chaining fix addresses a syntax error where `from original_error` was incorrectly used with a constructor assignment instead of a `raise` statement, which is the correct Python syntax for exception chaining. The pandas import resolves a runtime error where DataFrame attributes were accessed without the module being imported.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ce1e2ba-b58d-483d-9a47-71476ac324e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4ce1e2ba-b58d-483d-9a47-71476ac324e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

