### PR TITLE
Fix TRL integration compatibility issues with AutoModelForCausalLMWithValueHead

### DIFF
--- a/src/rldk/integrations/trl/utils.py
+++ b/src/rldk/integrations/trl/utils.py
@@ -19,11 +19,11 @@ def fix_generation_config(
     tokenizer: AutoTokenizer,
     generation_config: Optional[GenerationConfig] = None
 ) -> "AutoModelForCausalLMWithValueHead":
-    """Fix missing generation_config attribute on TRL models.
+    """Fix missing generation_config and base_model_prefix attributes on TRL models.
     
     This is a common issue with TRL 0.23.0+ where AutoModelForCausalLMWithValueHead
     doesn't have a generation_config attribute by default, causing AttributeError
-    when PPOTrainer tries to access it.
+    when PPOTrainer tries to access it. Also fixes missing base_model_prefix.
     
     Args:
         model: The TRL model to fix
@@ -31,7 +31,7 @@ def fix_generation_config(
         generation_config: Optional custom generation config. If None, creates a default one.
         
     Returns:
-        The model with generation_config attribute set
+        The model with generation_config and base_model_prefix attributes set
         
     Raises:
         ImportError: If TRL is not available
@@ -57,6 +57,19 @@ def fix_generation_config(
     
     # Set the generation_config attribute
     model.generation_config = generation_config
+    
+    # PPOTrainer expects this attribute to exist directly on the model
+    if not hasattr(model, 'base_model_prefix'):
+        if hasattr(model, 'pretrained_model') and hasattr(model.pretrained_model, 'base_model_prefix'):
+            model.base_model_prefix = model.pretrained_model.base_model_prefix
+        else:
+            model.base_model_prefix = "transformer"
+    
+    if hasattr(model, 'base_model_prefix') and not hasattr(model, model.base_model_prefix):
+        if hasattr(model, 'pretrained_model') and hasattr(model.pretrained_model, model.base_model_prefix):
+            setattr(model, model.base_model_prefix, getattr(model.pretrained_model, model.base_model_prefix))
+        elif hasattr(model, 'pretrained_model') and hasattr(model.pretrained_model, 'transformer'):
+            setattr(model, 'transformer', model.pretrained_model.transformer)
     
     return model
 


### PR DESCRIPTION
# Fix TRL integration compatibility issues with AutoModelForCausalLMWithValueHead

## Summary
Extends the `fix_generation_config` utility function to address missing `base_model_prefix` and backbone component attributes that cause `AttributeError` exceptions when using RLDK with TRL 0.23.0+ and PPOTrainer.

**Key changes:**
- Adds `base_model_prefix` attribute to TRL models when missing, using either the pretrained model's prefix or defaulting to "transformer"
- Exposes the backbone component (e.g., `transformer`) directly on the model when PPOTrainer expects it
- Maintains backward compatibility with existing TRL versions
- Updates function documentation to reflect expanded functionality

**Root cause:** TRL 0.23.0+ changed the internal structure of `AutoModelForCausalLMWithValueHead`, where PPOTrainer expects certain attributes to exist directly on the model but they're now nested within `pretrained_model`.

## Review & Testing Checklist for Human
- [ ] **Test with actual TRL PPOTrainer integration** - Verify the fix resolves AttributeError exceptions when training with RLDKCallback
- [ ] **Verify no regressions** - Ensure existing TRL integration examples in `/examples/trl_integration/` still work correctly  
- [ ] **Test attribute side effects** - Check that the dynamically added attributes don't interfere with TRL's internal operations or cause unexpected behavior
- [ ] **Test across model types** - Verify the fix works with different model architectures beyond GPT-2 (e.g., different base_model_prefix values)

### Test Plan Recommendation
1. Run `examples/trl_integration/basic_ppo_integration.py` to ensure the fix resolves the original AttributeError
2. Test with different model types that may have different `base_model_prefix` values
3. Verify that existing working TRL integrations continue to function

### Notes
- This fix uses dynamic attribute assignment which carries some risk of unintended side effects
- The fallback logic has multiple conditional paths that should be tested thoroughly
- Changes were developed and tested during comprehensive RLDK evaluation session

**Link to Devin run:** https://app.devin.ai/sessions/289d6fec3d7b4b799cb5d36010c2b2a5  
**Requested by:** @adityachallapally