### PR TITLE
Fix PyTorch 2.6+ checkpoint compatibility with weights_only parameter

### DIFF
--- a/src/rldk/integrations/openrlhf/monitors.py
+++ b/src/rldk/integrations/openrlhf/monitors.py
@@ -375,7 +375,7 @@ class OpenRLHFCheckpointMonitor:
         try:
             # Try to load as PyTorch checkpoint
             if checkpoint_path.suffix == '.pt' or checkpoint_path.suffix == '.pth':
-                checkpoint = torch.load(checkpoint_path, map_location='cpu')
+                checkpoint = torch.load(checkpoint_path, map_location='cpu', weights_only=False)
                 return checkpoint.get('metadata', {})
             
             # Try to load as JSON metadata
@@ -393,7 +393,7 @@ class OpenRLHFCheckpointMonitor:
         try:
             # Basic validation - check if checkpoint can be loaded
             if checkpoint_path.suffix in ['.pt', '.pth']:
-                checkpoint = torch.load(checkpoint_path, map_location='cpu')
+                checkpoint = torch.load(checkpoint_path, map_location='cpu', weights_only=False)
                 if isinstance(checkpoint, dict) and 'model' in checkpoint:
                     return 1.0  # Valid checkpoint
                 else:

--- a/src/rldk/io/consolidated_readers.py
+++ b/src/rldk/io/consolidated_readers.py
@@ -173,7 +173,7 @@ def read_checkpoint(path: Union[str, Path]) -> Dict[str, torch.Tensor]:
 
     try:
         # Load checkpoint to CPU
-        checkpoint = torch.load(path, map_location="cpu")
+        checkpoint = torch.load(path, map_location="cpu", weights_only=False)
 
         # Handle different checkpoint formats
         if isinstance(checkpoint, dict):
@@ -207,7 +207,7 @@ def read_reward_head(dir_path: Union[str, Path]) -> Callable[[List[str]], List[f
 
     try:
         # Load model to CPU
-        model = torch.load(model_path, map_location="cpu")
+        model = torch.load(model_path, map_location="cpu", weights_only=False)
 
         # Create model-dependent scoring function
         def score_prompts(prompts: List[str]) -> List[float]:

--- a/src/rldk/io/readers.py
+++ b/src/rldk/io/readers.py
@@ -113,7 +113,7 @@ def read_checkpoint(path: Union[str, Path]) -> Dict[str, torch.Tensor]:
 
     try:
         # Load checkpoint to CPU
-        checkpoint = torch.load(path, map_location="cpu")
+        checkpoint = torch.load(path, map_location="cpu", weights_only=False)
 
         # Handle different checkpoint formats
         if isinstance(checkpoint, dict):
@@ -147,7 +147,7 @@ def read_reward_head(dir_path: Union[str, Path]) -> Callable[[List[str]], List[f
 
     try:
         # Load model to CPU
-        model = torch.load(model_path, map_location="cpu")
+        model = torch.load(model_path, map_location="cpu", weights_only=False)
 
         # Create model-dependent scoring function
         def score_prompts(prompts: List[str]) -> List[float]:


### PR DESCRIPTION
# Fix PyTorch 2.6+ checkpoint compatibility with weights_only parameter

## Summary
Adds `weights_only=False` parameter to all `torch.load()` calls across the codebase to maintain compatibility with PyTorch 2.6+. Starting with PyTorch 2.6, `torch.load()` defaults to `weights_only=True` for security reasons, but this breaks existing code that loads checkpoints containing non-tensor objects (optimizers, metadata, etc.).

**Files changed:**
- `src/rldk/io/consolidated_readers.py` - 2 torch.load() calls
- `src/rldk/io/readers.py` - 2 torch.load() calls  
- `src/rldk/integrations/openrlhf/monitors.py` - 2 torch.load() calls

## Review & Testing Checklist for Human
- [ ] **Test with PyTorch 2.6+** - Verify that checkpoint loading actually works with newer PyTorch versions
- [ ] **Security review** - Consider security implications of `weights_only=False` when loading untrusted checkpoints
- [ ] **Functional testing** - Test checkpoint comparison (`rldk diff-ckpt`) and reward model loading still work correctly
- [ ] **Optimization review** - Check if some torch.load() calls could use `weights_only=True` for better security (if they only load tensors)

### Notes
- This change maintains existing behavior while preventing PyTorch 2.6+ compatibility issues
- `weights_only=False` allows loading arbitrary Python objects, which has security implications for untrusted checkpoints
- The change was applied mechanically to all torch.load() calls - some might not need it
- **Session info**: Requested by @adityachallapally, Link to Devin run: https://app.devin.ai/sessions/289d6fec3d7b4b799cb5d36010c2b2a5