### PR TITLE
Improve CLI error handling and path validation for forensics commands

### DIFF
--- a/src/rldk/cli.py
+++ b/src/rldk/cli.py
@@ -61,11 +61,13 @@ from rldk.utils.error_handling import (
     RLDKTimeoutError,
     ValidationError,
     format_error_message,
+    format_structured_error_message,
     log_error_with_context,
     print_troubleshooting_tips,
     print_usage_examples,
     validate_adapter_source,
     validate_file_path,
+    validate_training_run_directory,
 )
 from rldk.utils.progress import print_operation_status, timed_operation_context
 from rldk.utils.runtime import with_timeout
@@ -124,41 +126,83 @@ def forensics_compare_runs(
         if verbose:
             typer.echo("\nDetecting formats...")
 
+        # Validate input paths
+        try:
+            validated_run_a = validate_training_run_directory(run_a)
+            validated_run_b = validate_training_run_directory(run_b)
+        except ValidationError as e:
+            typer.echo(format_error_message(e), err=True)
+            raise typer.Exit(1)
+        except Exception as e:
+            typer.echo(
+                format_structured_error_message(
+                    "Path validation failed",
+                    f"{run_a}, {run_b}",
+                    "Valid training run directories or files",
+                    f"Error accessing paths: {e}",
+                    "Check that both paths exist and you have read permissions"
+                ),
+                err=True
+            )
+            raise typer.Exit(1)
+
         # Scan both runs with enhanced error handling
         try:
-            scan_a = scan_logs(run_a)
+            scan_a = scan_logs(validated_run_a)
             if verbose:
                 typer.echo(f"  Run A: Successfully loaded {len(scan_a.get('rules_fired', []))} anomaly rules")
         except (ValidationError, AdapterError) as e:
-            typer.echo(f"Error loading Run A - Format/Validation issue: {e}", err=True)
-            typer.echo("Check that data contains required RL fields like 'step', 'reward'")
-            raise typer.Exit(1)
-        except (FileNotFoundError, PermissionError) as e:
-            typer.echo(f"Error loading Run A - File access issue: {e}", err=True)
-            typer.echo("Ensure the path exists and is accessible")
+            typer.echo(
+                format_structured_error_message(
+                    "Run A loading failed",
+                    str(validated_run_a),
+                    "Training logs with RL fields (step, reward, etc.)",
+                    f"Format/validation issue: {e}",
+                    "Check that Run A contains valid RL training data"
+                ),
+                err=True
+            )
             raise typer.Exit(1)
         except Exception as e:
-            typer.echo(f"Error loading Run A: {e}", err=True)
-            typer.echo("Supported formats: JSONL, CSV, JSON, Parquet files or directories")
-            typer.echo("Use --verbose flag for detailed format detection info")
+            typer.echo(
+                format_structured_error_message(
+                    "Unexpected error loading Run A",
+                    str(validated_run_a),
+                    "Successful log loading",
+                    f"Error: {e}",
+                    "Check log file format and try again, or use --verbose for more details"
+                ),
+                err=True
+            )
             raise typer.Exit(1)
 
         try:
-            scan_b = scan_logs(run_b)
+            scan_b = scan_logs(validated_run_b)
             if verbose:
                 typer.echo(f"  Run B: Successfully loaded {len(scan_b.get('rules_fired', []))} anomaly rules")
         except (ValidationError, AdapterError) as e:
-            typer.echo(f"Error loading Run B - Format/Validation issue: {e}", err=True)
-            typer.echo("Check that data contains required RL fields like 'step', 'reward'")
-            raise typer.Exit(1)
-        except (FileNotFoundError, PermissionError) as e:
-            typer.echo(f"Error loading Run B - File access issue: {e}", err=True)
-            typer.echo("Ensure the path exists and is accessible")
+            typer.echo(
+                format_structured_error_message(
+                    "Run B loading failed",
+                    str(validated_run_b),
+                    "Training logs with RL fields (step, reward, etc.)",
+                    f"Format/validation issue: {e}",
+                    "Check that Run B contains valid RL training data"
+                ),
+                err=True
+            )
             raise typer.Exit(1)
         except Exception as e:
-            typer.echo(f"Error loading Run B: {e}", err=True)
-            typer.echo("Supported formats: JSONL, CSV, JSON, Parquet files or directories")
-            typer.echo("Use --verbose flag for detailed format detection info")
+            typer.echo(
+                format_structured_error_message(
+                    "Unexpected error loading Run B",
+                    str(validated_run_b),
+                    "Successful log loading",
+                    f"Error: {e}",
+                    "Check log file format and try again, or use --verbose for more details"
+                ),
+                err=True
+            )
             raise typer.Exit(1)
 
         # Create comparison report
@@ -206,13 +250,19 @@ def forensics_compare_runs(
                     for key, value in stats.items():
                         typer.echo(f"    {key}: {value}")
 
+    except typer.Exit:
+        raise
     except Exception as e:
-        typer.echo(f"Error: {e}", err=True)
-        typer.echo("\nTroubleshooting:")
-        typer.echo("- Ensure paths exist and are accessible")
-        typer.echo("- Check that data contains RL training metrics")
-        typer.echo("- Use --verbose flag for detailed format detection info")
-        typer.echo("- Supported formats: JSONL, CSV, JSON, Parquet")
+        typer.echo(
+            format_structured_error_message(
+                "Unexpected error",
+                f"{run_a}, {run_b}",
+                "Successful run comparison",
+                f"Unexpected error: {e}",
+                "Please report this issue with the full error message"
+            ),
+            err=True
+        )
         raise typer.Exit(1)
 
 
@@ -226,9 +276,50 @@ def forensics_diff_ckpt(
         typer.echo("Comparing checkpoints:")
         typer.echo(f"  Checkpoint A: {ckpt_a}")
         typer.echo(f"  Checkpoint B: {ckpt_b}")
+        
+        # Validate checkpoint files
+        try:
+            ckpt_a_path = validate_file_path(ckpt_a, must_exist=True)
+            ckpt_b_path = validate_file_path(ckpt_b, must_exist=True)
+            
+            # Check if files are likely checkpoint files
+            checkpoint_extensions = ['.pt', '.pth', '.bin', '.safetensors', '.ckpt']
+            if ckpt_a_path.suffix not in checkpoint_extensions:
+                typer.echo(f"Warning: {ckpt_a} may not be a checkpoint file (extension: {ckpt_a_path.suffix})")
+            if ckpt_b_path.suffix not in checkpoint_extensions:
+                typer.echo(f"Warning: {ckpt_b} may not be a checkpoint file (extension: {ckpt_b_path.suffix})")
+                
+        except ValidationError as e:
+            typer.echo(format_error_message(e), err=True)
+            raise typer.Exit(1)
+        except Exception as e:
+            typer.echo(
+                format_structured_error_message(
+                    "Checkpoint validation failed",
+                    f"{ckpt_a}, {ckpt_b}",
+                    "Valid checkpoint files (.pt, .pth, .bin, .safetensors, .ckpt)",
+                    f"Error accessing files: {e}",
+                    "Check that both checkpoint files exist and you have read permissions"
+                ),
+                err=True
+            )
+            raise typer.Exit(1)
 
         # Diff checkpoints
-        report = diff_checkpoints(ckpt_a, ckpt_b)
+        try:
+            report = diff_checkpoints(ckpt_a_path, ckpt_b_path)
+        except Exception as e:
+            typer.echo(
+                format_structured_error_message(
+                    "Checkpoint comparison failed",
+                    f"{ckpt_a_path}, {ckpt_b_path}",
+                    "Successful checkpoint comparison",
+                    f"Error during comparison: {e}",
+                    "Ensure both files are valid PyTorch checkpoint files"
+                ),
+                err=True
+            )
+            raise typer.Exit(1)
 
         # Validate report
         validate(CkptDiffReportV1, report)
@@ -297,9 +388,52 @@ def forensics_env_audit(
     """Audit environment for determinism and reproducibility."""
     try:
         typer.echo(f"Auditing environment for: {repo_or_run}")
+        
+        # Validate input path
+        try:
+            validated_path = validate_file_path(repo_or_run, must_exist=True)
+            if not validated_path.is_dir():
+                raise ValidationError(
+                    format_structured_error_message(
+                        "Invalid input type",
+                        str(validated_path),
+                        "Directory (repository or run directory)",
+                        "File",
+                        "Provide a directory path for environment audit"
+                    ),
+                    error_code="EXPECTED_DIRECTORY"
+                )
+        except ValidationError as e:
+            typer.echo(format_error_message(e), err=True)
+            raise typer.Exit(1)
+        except Exception as e:
+            typer.echo(
+                format_structured_error_message(
+                    "Path validation failed",
+                    repo_or_run,
+                    "Valid directory path",
+                    f"Error accessing path: {e}",
+                    "Check that the path exists and you have read permissions"
+                ),
+                err=True
+            )
+            raise typer.Exit(1)
 
         # Run audit
-        determinism_card, lock_content = audit_environment(repo_or_run)
+        try:
+            determinism_card, lock_content = audit_environment(validated_path)
+        except Exception as e:
+            typer.echo(
+                format_structured_error_message(
+                    "Environment audit failed",
+                    str(validated_path),
+                    "Successful environment analysis",
+                    f"Error during audit: {e}",
+                    "Ensure the directory is accessible and contains valid project files"
+                ),
+                err=True
+            )
+            raise typer.Exit(1)
 
         # Validate determinism card
         validate(DeterminismCardV1, determinism_card)
@@ -329,8 +463,19 @@ def forensics_env_audit(
             for hint in determinism_card["nondeterminism_hints"][:3]:
                 typer.echo(f"    - {hint}")
 
+    except typer.Exit:
+        raise
     except Exception as e:
-        typer.echo(f"Error: {e}", err=True)
+        typer.echo(
+            format_structured_error_message(
+                "Unexpected error",
+                repo_or_run,
+                "Successful environment audit",
+                f"Unexpected error: {e}",
+                "Please report this issue with the full error message"
+            ),
+            err=True
+        )
         raise typer.Exit(1)
 
 
@@ -341,9 +486,53 @@ def forensics_log_scan(
     """Scan training logs for PPO anomalies and issues."""
     try:
         typer.echo(f"Scanning logs: {run_or_export}")
+        
+        # Validate input path and directory contents
+        try:
+            validated_path = validate_training_run_directory(run_or_export)
+        except ValidationError as e:
+            typer.echo(format_error_message(e), err=True)
+            raise typer.Exit(1)
+        except Exception as e:
+            typer.echo(
+                format_structured_error_message(
+                    "Path validation failed",
+                    run_or_export,
+                    "Valid training run directory or file",
+                    f"Error accessing path: {e}",
+                    "Check that the path exists and you have read permissions"
+                ),
+                err=True
+            )
+            raise typer.Exit(1)
 
         # Scan logs
-        report = scan_logs(run_or_export)
+        try:
+            report = scan_logs(validated_path)
+        except (ValidationError, AdapterError) as e:
+            typer.echo(
+                format_structured_error_message(
+                    "Log scanning failed",
+                    str(validated_path),
+                    "Training logs with standard RL fields (step, reward, etc.)",
+                    f"Data format issue: {e}",
+                    "Ensure logs contain RL training metrics or use 'rldk validate-format' to check data"
+                ),
+                err=True
+            )
+            raise typer.Exit(1)
+        except Exception as e:
+            typer.echo(
+                format_structured_error_message(
+                    "Unexpected error during log scanning",
+                    str(validated_path),
+                    "Successful log analysis",
+                    f"Error: {e}",
+                    "Check log file format and try again, or contact support if issue persists"
+                ),
+                err=True
+            )
+            raise typer.Exit(1)
 
         # Validate report
         validate(PPOScanReportV1, report)
@@ -372,8 +561,19 @@ def forensics_log_scan(
         if report.get("earliest_step"):
             typer.echo(f"Earliest step with data: {report['earliest_step']}")
 
+    except typer.Exit:
+        raise
     except Exception as e:
-        typer.echo(f"Error: {e}", err=True)
+        typer.echo(
+            format_structured_error_message(
+                "Unexpected error",
+                run_or_export,
+                "Successful log scan operation",
+                f"Unexpected error: {e}",
+                "Please report this issue with the full error message"
+            ),
+            err=True
+        )
         raise typer.Exit(1)
 
 
@@ -384,14 +584,70 @@ def forensics_doctor(
     """Run comprehensive diagnostics on a training run or repository."""
     try:
         typer.echo(f"Running diagnostics on: {run_or_repo}")
+        
+        # Validate input path
+        try:
+            validated_path = validate_file_path(run_or_repo, must_exist=True)
+            if not validated_path.is_dir():
+                raise ValidationError(
+                    format_structured_error_message(
+                        "Invalid input type",
+                        str(validated_path),
+                        "Directory (repository or training run)",
+                        "File",
+                        "Provide a directory path for comprehensive diagnostics"
+                    ),
+                    error_code="EXPECTED_DIRECTORY"
+                )
+        except ValidationError as e:
+            typer.echo(format_error_message(e), err=True)
+            raise typer.Exit(1)
+        except Exception as e:
+            typer.echo(
+                format_structured_error_message(
+                    "Path validation failed",
+                    run_or_repo,
+                    "Valid directory path",
+                    f"Error accessing path: {e}",
+                    "Check that the path exists and you have read permissions"
+                ),
+                err=True
+            )
+            raise typer.Exit(1)
 
         # Run env audit
         typer.echo("\n1. Environment audit...")
-        determinism_card, lock_content = audit_environment(run_or_repo)
+        try:
+            determinism_card, lock_content = audit_environment(validated_path)
+        except Exception as e:
+            typer.echo(
+                format_structured_error_message(
+                    "Environment audit failed",
+                    str(validated_path),
+                    "Successful environment analysis",
+                    f"Error during audit: {e}",
+                    "Ensure the directory is accessible and contains valid project files"
+                ),
+                err=True
+            )
+            raise typer.Exit(1)
 
         # Run log scan
         typer.echo("2. Log scan...")
-        scan_report = scan_logs(run_or_repo)
+        try:
+            scan_report = scan_logs(validated_path)
+        except (ValidationError, AdapterError) as e:
+            typer.echo(
+                format_structured_error_message(
+                    "Log scan failed",
+                    str(validated_path),
+                    "Directory with training logs",
+                    f"No valid training logs found: {e}",
+                    "Ensure directory contains training log files (.jsonl, .log, .csv) or skip log analysis"
+                ),
+                err=True
+            )
+            scan_report = {"rules_fired": [], "note": "Log scan skipped due to missing training files"}
 
         # Write outputs
         mkdir_reports()
@@ -423,8 +679,19 @@ def forensics_doctor(
                     f"  - Training logs show {len(scan_report.get('rules_fired', []))} anomalies"
                 )
 
+    except typer.Exit:
+        raise
     except Exception as e:
-        typer.echo(f"Error: {e}", err=True)
+        typer.echo(
+            format_structured_error_message(
+                "Unexpected error",
+                run_or_repo,
+                "Successful diagnostic operation",
+                f"Unexpected error: {e}",
+                "Please report this issue with the full error message"
+            ),
+            err=True
+        )
         raise typer.Exit(1)
 
 

--- a/src/rldk/utils/__init__.py
+++ b/src/rldk/utils/__init__.py
@@ -12,6 +12,7 @@ from .error_handling import (
     ValidationError,
     check_dependencies,
     format_error_message,
+    format_structured_error_message,
     handle_graceful_degradation,
     log_error_with_context,
     print_troubleshooting_tips,
@@ -23,6 +24,7 @@ from .error_handling import (
     validate_data_format,
     validate_file_path,
     validate_required_fields,
+    validate_training_run_directory,
     with_retry,
 )
 from .progress import (
@@ -115,8 +117,10 @@ __all__ = [
     "EvaluationError",
     "RLDKTimeoutError",
     "format_error_message",
+    "format_structured_error_message",
     "log_error_with_context",
     "validate_file_path",
+    "validate_training_run_directory",
     "sanitize_path",
     "validate_data_format",
     "validate_required_fields",

--- a/src/rldk/utils/error_handling.py
+++ b/src/rldk/utils/error_handling.py
@@ -407,7 +407,7 @@ def validate_training_run_directory(path: Union[str, Path]) -> Path:
     
     if path_obj.is_file():
         # Single file - validate it's a supported format
-        supported_extensions = ['.jsonl', '.log', '.csv', '.json', '.parquet']
+        supported_extensions = ['.jsonl', '.log', '.csv', '.json', '.parquet', '.txt']
         if path_obj.suffix not in supported_extensions:
             raise ValidationError(
                 format_structured_error_message(
@@ -427,7 +427,8 @@ def validate_training_run_directory(path: Union[str, Path]) -> Path:
             list(path_obj.glob("*.log")) +
             list(path_obj.glob("*.csv")) +
             list(path_obj.glob("*.json")) +
-            list(path_obj.glob("*.parquet"))
+            list(path_obj.glob("*.parquet")) +
+            list(path_obj.glob("*.txt"))
         )
         
         if not training_files:
@@ -440,7 +441,7 @@ def validate_training_run_directory(path: Union[str, Path]) -> Path:
                 format_structured_error_message(
                     "No training files found",
                     str(path_obj),
-                    "Directory containing training log files (.jsonl, .log, .csv, .json, .parquet)",
+                    "Directory containing training log files (.jsonl, .log, .csv, .json, .parquet, .txt)",
                     found_description,
                     "Ensure the directory contains training log files or use 'rldk ingest' to convert your data"
                 ),

--- a/src/rldk/utils/error_handling.py
+++ b/src/rldk/utils/error_handling.py
@@ -381,3 +381,81 @@ def safe_ratio(numerator: float, denominator: float, fallback: float = 0.0) -> f
         The ratio or fallback value
     """
     return safe_divide(numerator, denominator, fallback)
+
+
+def format_structured_error_message(
+    error_type: str,
+    path: str,
+    expected: str,
+    found: str,
+    suggestion: str,
+    error_code: Optional[str] = None
+) -> str:
+    """Format error message in the structured format requested by user."""
+    message = f"Error: {error_type}: {path}\n"
+    message += f"Expected: {expected}\n"
+    message += f"Found: {found}\n"
+    message += f"Suggestion: {suggestion}"
+    if error_code:
+        message += f"\nError Code: {error_code}"
+    return message
+
+
+def validate_training_run_directory(path: Union[str, Path]) -> Path:
+    """Validate that directory contains training run files."""
+    path_obj = validate_file_path(path, must_exist=True)
+    
+    if path_obj.is_file():
+        # Single file - validate it's a supported format
+        supported_extensions = ['.jsonl', '.log', '.csv', '.json', '.parquet']
+        if path_obj.suffix not in supported_extensions:
+            raise ValidationError(
+                format_structured_error_message(
+                    "Unsupported file format",
+                    str(path_obj),
+                    f"Training log file with extension: {', '.join(supported_extensions)}",
+                    f"File with extension: {path_obj.suffix}",
+                    f"Use a file with one of these extensions: {', '.join(supported_extensions)}"
+                ),
+                error_code="UNSUPPORTED_FILE_FORMAT"
+            )
+        return path_obj
+    
+    if path_obj.is_dir():
+        training_files = (
+            list(path_obj.glob("*.jsonl")) +
+            list(path_obj.glob("*.log")) +
+            list(path_obj.glob("*.csv")) +
+            list(path_obj.glob("*.json")) +
+            list(path_obj.glob("*.parquet"))
+        )
+        
+        if not training_files:
+            all_files = list(path_obj.glob("*"))
+            found_description = f"Directory with {len(all_files)} files" if all_files else "Empty directory"
+            if all_files:
+                found_description += f" (extensions: {', '.join(set(f.suffix for f in all_files if f.suffix))})"
+            
+            raise ValidationError(
+                format_structured_error_message(
+                    "No training files found",
+                    str(path_obj),
+                    "Directory containing training log files (.jsonl, .log, .csv, .json, .parquet)",
+                    found_description,
+                    "Ensure the directory contains training log files or use 'rldk ingest' to convert your data"
+                ),
+                error_code="NO_TRAINING_FILES_FOUND"
+            )
+        
+        return path_obj
+    
+    raise ValidationError(
+        format_structured_error_message(
+            "Invalid path type",
+            str(path_obj),
+            "File or directory",
+            "Neither file nor directory",
+            "Provide a valid file or directory path"
+        ),
+        error_code="INVALID_PATH_TYPE"
+    )


### PR DESCRIPTION
# Improve CLI error handling and path validation for forensics commands

## Summary
Enhanced error handling across all RLDK forensics commands (`log-scan`, `env-audit`, `doctor`, `compare-runs`, `diff-ckpt`) with structured error messages and comprehensive path validation. All error messages now follow a consistent "Error/Expected/Found/Suggestion" format to provide clearer guidance to users.

**Key changes:**
- Added `format_structured_error_message()` function for consistent error formatting
- Added `validate_training_run_directory()` function with comprehensive validation for training data paths
- Updated all forensics commands to use proper path validation before operations
- Improved exception handling with specific error types and helpful suggestions
- Added graceful degradation where possible (e.g., doctor command continues with partial results)

**Error message format now follows:**
```
Error: [error_type]: [path]
Expected: [what was expected]
Found: [what was actually found]
Suggestion: [how to fix it]
```

## Review & Testing Checklist for Human
- [ ] **Test forensics commands with invalid paths** - Verify error messages are helpful and actionable (test with non-existent paths, empty directories, files with wrong extensions)
- [ ] **Test forensics commands with valid inputs** - Ensure existing functionality still works correctly and no regressions were introduced
- [ ] **Verify error message consistency** - Check that all forensics commands use the new structured error format appropriately
- [ ] **Test edge cases** - Try symlinks, permission issues, special characters in paths, and mixed file types in directories

### Test Plan
1. Run `rldk forensics log-scan /nonexistent/path` - should show structured error
2. Run `rldk forensics log-scan /tmp/empty_dir` - should suggest adding training files  
3. Run `rldk forensics log-scan file.txt` - should show unsupported format error
4. Test existing valid workflows to ensure no breaking changes
5. Run existing unit tests to verify no regressions

### Notes
- This PR focuses specifically on the forensics commands as requested
- New error handling functions are exported in `utils/__init__.py` for broader usage
- Some commands mix existing `validate_file_path` errors with new structured errors - this is intentional to maintain compatibility while improving UX
- The `doctor` command now continues with partial results if log scanning fails, providing more resilient diagnostics

**Requested by:** @adityachallapally  
**Link to Devin run:** https://app.devin.ai/sessions/97932b4e427641249529f05419e430be