### PR TITLE
Update TRL utilities for new PPOTrainer API

### DIFF
--- a/TRL_INTEGRATION_FIX.md
+++ b/TRL_INTEGRATION_FIX.md
@@ -19,7 +19,8 @@
 Added comprehensive utility functions to handle the `generation_config` issue:
 
 - **`fix_generation_config()`**: Fixes a single model by adding the missing `generation_config` attribute
-- **`prepare_models_for_ppo()`**: Prepares all required models (model, ref_model, reward_model, value_model) with proper `generation_config`
+- **`prepare_models_for_ppo()`**: Prepares policy, reference, and value models with proper `generation_config`
+- **`create_simple_value_model()`** / **`create_simple_reward_model()`**: Lightweight scoring heads that satisfy the TRL 0.23.0+ interface
 - **`check_trl_compatibility()`**: Checks TRL version and provides warnings/recommendations
 - **`validate_ppo_setup()`**: Validates the complete PPO setup for common issues
 
@@ -42,8 +43,11 @@ ref_model.generation_config = generation_config
 
 **After (fixed code)**:
 ```python
-# Use utility function to prepare all models with proper generation_config
-model, ref_model, reward_model, value_model, tokenizer = prepare_models_for_ppo(model_name)
+# Use utility function to prepare policy, reference, and value models
+policy_model, ref_model, value_model, tokenizer = prepare_models_for_ppo(model_name)
+
+# Build a reward model compatible with TRL's get_reward helper
+reward_model = create_simple_reward_model(tokenizer, base_model=policy_model)
 ```
 
 ### 3. Added Compatibility Checking
@@ -83,11 +87,11 @@ The fix now uses proper semantic versioning with the `packaging` library instead
 - ✅ Fixed variable shadowing issue (`version` → `trl_version_str`)
 
 ### 2. **Automatic Model Preparation**
-The `prepare_models_for_ppo()` function handles all the complexity:
-- Loads tokenizer with proper pad token setup
-- Creates all required models
-- Automatically sets `generation_config` on all models
-- Returns everything ready for PPOTrainer
+The `prepare_models_for_ppo()` and `create_simple_reward_model()` helpers handle all the complexity:
+- Load the tokenizer with proper pad token setup
+- Create policy and reference models with valid `generation_config`
+- Produce value and reward models that expose `base_model_prefix` and `score`
+- Return everything ready for `PPOTrainer`
 
 ### 3. **Robust Generation Config**
 The utility creates a comprehensive `GenerationConfig`:
@@ -119,15 +123,16 @@ generation_config = GenerationConfig(
 
 ### Basic Usage
 ```python
-from rldk.integrations.trl import prepare_models_for_ppo
+from rldk.integrations.trl import prepare_models_for_ppo, create_simple_reward_model
 
-# Prepare all models with one function call
-model, ref_model, reward_model, value_model, tokenizer = prepare_models_for_ppo("gpt2")
+# Prepare policy, reference, and value models with one call
+policy_model, ref_model, value_model, tokenizer = prepare_models_for_ppo("gpt2")
+reward_model = create_simple_reward_model(tokenizer, base_model=policy_model)
 
 # Now safe to use with PPOTrainer
 trainer = PPOTrainer(
     args=ppo_config,
-    model=model,
+    model=policy_model,
     ref_model=ref_model,
     reward_model=reward_model,
     value_model=value_model,

--- a/examples/trl_integration/basic_ppo_integration.py
+++ b/examples/trl_integration/basic_ppo_integration.py
@@ -17,6 +17,7 @@ from rldk.integrations.trl import (
     PPOMonitor,
     RLDKCallback,
     check_trl_compatibility,
+    create_simple_reward_model,
     prepare_models_for_ppo,
 )
 from rldk.utils.math_utils import safe_divide
@@ -126,18 +127,18 @@ def test_basic_ppo_integration():
     )
 
     # Use utility function to prepare all models with proper generation_config
-    # This fixes the AttributeError: 'AutoModelForCausalLMWithValueHead' object has no attribute 'generation_config'
-    # Note: Same model is used for both policy and value heads (standard approach)
-    model, ref_model, reward_model, tokenizer = prepare_models_for_ppo(model_name)
+    policy_model, ref_model, value_model, tokenizer = prepare_models_for_ppo(model_name)
+
+    # Create a simple reward model compatible with TRL's get_reward helper
+    reward_model = create_simple_reward_model(tokenizer, base_model=policy_model)
 
     # Create PPO trainer with new API
-    # Use the same model for both policy and value heads to avoid base_model_prefix AttributeError in TRL 0.23.0+
     trainer = PPOTrainer(
         args=ppo_config,
-        model=model,  # Policy model
+        model=policy_model,  # Policy model
         ref_model=ref_model,
         reward_model=reward_model,
-        value_model=model,  # Use same model for value head (standard approach)
+        value_model=value_model,
         processing_class=tokenizer,
         train_dataset=dataset,
         callbacks=[rldk_callback, ppo_monitor, checkpoint_monitor],

--- a/src/rldk/integrations/trl/__init__.py
+++ b/src/rldk/integrations/trl/__init__.py
@@ -5,6 +5,8 @@ from .dashboard import RLDKDashboard
 from .monitors import CheckpointMetrics, CheckpointMonitor, PPOMetrics, PPOMonitor
 from .utils import (
     check_trl_compatibility,
+    create_simple_reward_model,
+    create_simple_value_model,
     fix_generation_config,
     prepare_models_for_ppo,
     validate_ppo_setup,
@@ -21,6 +23,8 @@ __all__ = [
     "RLDKDashboard",
     "fix_generation_config",
     "prepare_models_for_ppo",
+    "create_simple_value_model",
+    "create_simple_reward_model",
     "check_trl_compatibility",
     "validate_ppo_setup",
 ]

--- a/src/rldk/integrations/trl/utils.py
+++ b/src/rldk/integrations/trl/utils.py
@@ -1,9 +1,20 @@
 """Utility functions for TRL integration."""
 
-from typing import Optional
+from __future__ import annotations
 
+import copy
+from typing import Optional, Tuple, Union
+
+import torch
 from packaging import version
-from transformers import AutoTokenizer, GenerationConfig
+from torch import nn
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    GenerationConfig,
+    PreTrainedModel,
+    PreTrainedTokenizerBase,
+)
 
 try:
     from trl import AutoModelForCausalLMWithValueHead
@@ -14,128 +25,340 @@ except ImportError:
 
 
 def fix_generation_config(
-    model: "AutoModelForCausalLMWithValueHead",
-    tokenizer: AutoTokenizer,
-    generation_config: Optional[GenerationConfig] = None
-) -> "AutoModelForCausalLMWithValueHead":
-    """Fix missing generation_config and base_model_prefix attributes on TRL models.
+    model: PreTrainedModel,
+    tokenizer: PreTrainedTokenizerBase,
+    generation_config: Optional[GenerationConfig] = None,
+) -> PreTrainedModel:
+    """Ensure a model exposes a usable :class:`~transformers.GenerationConfig`.
 
-    This is a common issue with TRL 0.23.0+ where AutoModelForCausalLMWithValueHead
-    doesn't have a generation_config or base_model_prefix attribute by default, 
-    causing AttributeError when PPOTrainer tries to access them.
+    Newer versions of TRL and Transformers expect policy models to always expose a
+    ``generation_config`` with sensible defaults. Older checkpoints – especially
+    those loaded through TRL wrappers – sometimes omit this attribute which causes
+    the PPO trainer to crash when it prepares stopping criteria.  This helper
+    attaches a generation configuration and mirrors the ``base_model_prefix`` so
+    downstream utilities can locate the underlying backbone module.
 
     Args:
-        model: The TRL model to fix
-        tokenizer: The tokenizer used with the model
-        generation_config: Optional custom generation config. If None, creates a default one.
+        model: Model to update. Any :class:`~transformers.PreTrainedModel` works.
+        tokenizer: Tokenizer associated with the model.
+        generation_config: Optional configuration to attach.  When ``None`` a
+            conservative default is built from the tokenizer.
 
     Returns:
-        The model with generation_config and base_model_prefix attributes set
-
-    Raises:
-        ImportError: If TRL is not available
-        AttributeError: If model doesn't have required attributes
+        The provided ``model`` for fluent-style usage.
     """
-    if not TRL_AVAILABLE:
-        raise ImportError("TRL is required for this function. Install with: pip install trl")
 
-    if not isinstance(model, AutoModelForCausalLMWithValueHead):
-        raise AttributeError("Model must be an AutoModelForCausalLMWithValueHead instance")
+    if not hasattr(model, "config"):
+        raise AttributeError("Model is missing a Transformers configuration and cannot expose generation settings.")
 
-    # Create generation config if not provided
     if generation_config is None:
         generation_config = GenerationConfig(
             eos_token_id=tokenizer.eos_token_id,
             pad_token_id=tokenizer.pad_token_id,
-            bos_token_id=getattr(tokenizer, 'bos_token_id', None),
-            max_length=512,  # Default max length
-            do_sample=True,  # Enable sampling for generation
-            temperature=1.0,  # Default temperature
-            top_p=1.0,  # Default top_p
+            bos_token_id=getattr(tokenizer, "bos_token_id", None),
+            max_length=min(getattr(tokenizer, "model_max_length", 1024) or 1024, 1024),
+            do_sample=True,
+            temperature=1.0,
+            top_p=1.0,
         )
 
-    # Set the generation_config attribute
     model.generation_config = generation_config
 
-    # Fix missing base_model_prefix attribute (required by PPOTrainer)
-    if not hasattr(model, 'base_model_prefix'):
-        # The AutoModelForCausalLMWithValueHead wraps a pretrained_model that has the base_model_prefix
-        if hasattr(model, 'pretrained_model') and hasattr(model.pretrained_model, 'base_model_prefix'):
+    # Mirror the backbone attribute when possible so PPOTrainer can reach the
+    # base transformer module regardless of wrapper structure.
+    if not hasattr(model, "base_model_prefix"):
+        if hasattr(model, "pretrained_model") and hasattr(model.pretrained_model, "base_model_prefix"):
             model.base_model_prefix = model.pretrained_model.base_model_prefix
         else:
-            # Fallback: try to infer from the model name or use a default
-            model_name = getattr(model, 'name_or_path', '').lower()
-            if 'gpt2' in model_name or 'gpt' in model_name:
-                model.base_model_prefix = "transformer"
-            elif 'llama' in model_name:
-                model.base_model_prefix = "model"
-            else:
-                model.base_model_prefix = "transformer"  # Default fallback
+            model.base_model_prefix = _infer_base_model_prefix(getattr(model, "name_or_path", ""))
 
-    # Fix missing base model attribute (required by PPOTrainer)
-    # The PPOTrainer expects the model to have an attribute with the name of base_model_prefix
-    if hasattr(model, 'base_model_prefix') and hasattr(model, 'pretrained_model'):
+    if hasattr(model, "pretrained_model"):
         base_model_prefix = model.base_model_prefix
-        if not hasattr(model, base_model_prefix):
-            # Add the base model attribute by referencing the pretrained_model's attribute
-            if hasattr(model.pretrained_model, base_model_prefix):
-                setattr(model, base_model_prefix, getattr(model.pretrained_model, base_model_prefix))
+        if not hasattr(model, base_model_prefix) and hasattr(model.pretrained_model, base_model_prefix):
+            setattr(model, base_model_prefix, getattr(model.pretrained_model, base_model_prefix))
 
-    # Fix missing gradient checkpointing attribute (required by PPOTrainer)
-    if not hasattr(model, 'is_gradient_checkpointing'):
-        if hasattr(model, 'pretrained_model') and hasattr(model.pretrained_model, 'is_gradient_checkpointing'):
+        if not hasattr(model, "is_gradient_checkpointing") and hasattr(
+            model.pretrained_model, "is_gradient_checkpointing"
+        ):
             model.is_gradient_checkpointing = model.pretrained_model.is_gradient_checkpointing
-        else:
-            model.is_gradient_checkpointing = False  # Default to False
+    elif not hasattr(model, "is_gradient_checkpointing"):
+        model.is_gradient_checkpointing = False
 
     return model
 
 
 def prepare_models_for_ppo(
     model_name: str,
-    tokenizer: Optional[AutoTokenizer] = None,
-    generation_config: Optional[GenerationConfig] = None
-) -> tuple["AutoModelForCausalLMWithValueHead", "AutoModelForCausalLMWithValueHead",
-           "AutoModelForCausalLMWithValueHead", AutoTokenizer]:
-    """Prepare all required models for PPO training with proper generation_config.
+    tokenizer: Optional[PreTrainedTokenizerBase] = None,
+    generation_config: Optional[GenerationConfig] = None,
+    *,
+    policy_model_kwargs: Optional[dict] = None,
+    ref_model_kwargs: Optional[dict] = None,
+    value_model_kwargs: Optional[dict] = None,
+) -> Tuple[PreTrainedModel, PreTrainedModel, nn.Module, PreTrainedTokenizerBase]:
+    """Instantiate a minimal set of models compatible with TRL's PPO trainer.
 
-    This function creates and configures all the models needed for PPO training,
-    ensuring they have the required generation_config attribute to avoid AttributeError.
-    
-    Note: The same model is used for both policy and value heads (standard approach).
-    This avoids the base_model_prefix AttributeError in TRL 0.23.0+.
+    The modern TRL API expects individual modules for the policy, reference,
+    value, and reward networks.  This helper focuses on the policy, reference
+    and value components.  The returned tokenizer can be passed directly to the
+    trainer as the ``processing_class``.  See :func:`create_simple_reward_model`
+    for a reward model that complements the output of this function.
 
     Args:
-        model_name: Name or path of the base model
-        tokenizer: Optional tokenizer. If None, will be loaded from model_name
-        generation_config: Optional custom generation config
+        model_name: Pretrained identifier or local path for the policy model.
+        tokenizer: Optional tokenizer instance. When omitted a matching
+            tokenizer is loaded and padded with ``eos_token`` if required.
+        generation_config: Optional generation configuration applied to both the
+            policy and reference models.
+        policy_model_kwargs: Extra keyword arguments forwarded to
+            :func:`AutoModelForCausalLM.from_pretrained` when instantiating the
+            policy.
+        ref_model_kwargs: Keyword arguments used for the reference model. When
+            ``None`` they default to ``policy_model_kwargs``.
+        value_model_kwargs: Additional options passed to
+            :func:`create_simple_value_model`.
 
     Returns:
-        Tuple of (model, ref_model, reward_model, tokenizer)
+        ``(policy_model, ref_model, value_model, tokenizer)``
 
     Raises:
-        ImportError: If TRL is not available
+        ImportError: If TRL is not available in the runtime environment.
     """
+
     if not TRL_AVAILABLE:
         raise ImportError("TRL is required for this function. Install with: pip install trl")
 
-    # Load tokenizer if not provided
+    policy_kwargs = dict(policy_model_kwargs or {})
+    reference_kwargs = dict(ref_model_kwargs or policy_kwargs)
+    value_kwargs = dict(value_model_kwargs or {})
+
+    tokenizer = _prepare_tokenizer(model_name, tokenizer)
+
+    policy_model = AutoModelForCausalLM.from_pretrained(model_name, **policy_kwargs)
+    policy_model = fix_generation_config(policy_model, tokenizer, generation_config)
+
+    ref_model = AutoModelForCausalLM.from_pretrained(model_name, **reference_kwargs)
+    ref_model = fix_generation_config(ref_model, tokenizer, generation_config)
+
+    base_model_override = value_kwargs.pop("base_model", policy_model)
+    value_model = create_simple_value_model(base_model_override, **value_kwargs)
+
+    return policy_model, ref_model, value_model, tokenizer
+
+
+def create_simple_value_model(
+    base_model: Union[str, PreTrainedModel],
+    *,
+    torch_dtype: Optional[torch.dtype] = None,
+    device_map: Optional[Union[str, dict]] = None,
+    head_init_std: float = 0.02,
+    freeze_backbone: bool = False,
+    **model_kwargs,
+) -> nn.Module:
+    """Create a lightweight value model compatible with TRL's PPO trainer.
+
+    The value model exposes a ``score`` head that maps token hidden states to a
+    single scalar per token – mirroring the behaviour expected by
+    :func:`trl.trainer.utils.get_reward`.  By default the backbone shares the
+    same architecture as the policy model.  Supplying an existing policy model
+    instance avoids an additional download while still copying the weights to
+    keep the modules independent during optimisation.
+
+    Args:
+        base_model: Either a model identifier understood by
+            :func:`AutoModelForCausalLM.from_pretrained` or an instantiated
+            :class:`~transformers.PreTrainedModel`.
+        torch_dtype: Optional dtype override when loading from a model name.
+        device_map: Device placement hint forwarded to ``from_pretrained`` when
+            ``base_model`` is a string.
+        head_init_std: Standard deviation used to initialise the linear value
+            head.  Set to ``0`` to start from zero predictions.
+        freeze_backbone: When ``True`` the backbone parameters are frozen.  This
+            can be useful when the value network should only train the scoring
+            head.
+        **model_kwargs: Additional arguments forwarded to
+            ``AutoModelForCausalLM.from_pretrained`` when ``base_model`` is a
+            string identifier.
+
+    Returns:
+        ``nn.Module`` exposing ``base_model_prefix`` and ``score`` attributes.
+    """
+
+    backbone = _load_backbone(base_model, torch_dtype=torch_dtype, device_map=device_map, **model_kwargs)
+    return _SimpleScoringModel(backbone, head_init_std=head_init_std, freeze_backbone=freeze_backbone)
+
+
+def create_simple_reward_model(
+    tokenizer: PreTrainedTokenizerBase,
+    base_model: Optional[Union[str, PreTrainedModel]] = None,
+    *,
+    torch_dtype: Optional[torch.dtype] = None,
+    device_map: Optional[Union[str, dict]] = None,
+    trainable: bool = False,
+    head_init_std: float = 0.0,
+    **model_kwargs,
+) -> nn.Module:
+    """Create a reward model compatible with :func:`trl.trainer.utils.get_reward`.
+
+    The reward model mirrors the value model but defaults to a frozen backbone
+    and zero-initialised head.  This produces deterministic rewards and avoids
+    accidental training of the reward network when optimising the policy.
+
+    Args:
+        tokenizer: Tokenizer associated with the base model. Used to infer the
+            default checkpoint when ``base_model`` is omitted.
+        base_model: Optional identifier or instantiated model to base the reward
+            network on.  When ``None`` the tokenizer's ``name_or_path`` is used.
+        torch_dtype: Optional dtype override when loading from a model name.
+        device_map: Device placement hint forwarded to ``from_pretrained`` when
+            ``base_model`` is a string.
+        trainable: Whether the returned module should require gradients.  The
+            default (``False``) freezes all parameters.
+        head_init_std: Standard deviation for the score head initialisation.
+            The default ``0.0`` initialises the head to return zero rewards.
+        **model_kwargs: Additional keyword arguments forwarded to
+            ``AutoModelForCausalLM.from_pretrained`` when a model name is used.
+
+    Returns:
+        Frozen reward model suitable for PPO training.
+    """
+
+    model_identifier = base_model if base_model is not None else _resolve_model_name_from_tokenizer(tokenizer)
+    backbone = _load_backbone(model_identifier, torch_dtype=torch_dtype, device_map=device_map, **model_kwargs)
+    reward_model = _SimpleScoringModel(backbone, head_init_std=head_init_std, freeze_backbone=not trainable)
+    if not trainable:
+        reward_model.eval()
+        for parameter in reward_model.parameters():
+            parameter.requires_grad = False
+    return reward_model
+
+
+def _prepare_tokenizer(model_name: str, tokenizer: Optional[PreTrainedTokenizerBase]) -> PreTrainedTokenizerBase:
     if tokenizer is None:
         tokenizer = AutoTokenizer.from_pretrained(model_name)
-        if tokenizer.pad_token is None:
+    if tokenizer.pad_token is None:
+        if tokenizer.eos_token is not None:
             tokenizer.pad_token = tokenizer.eos_token
+        elif tokenizer.unk_token is not None:
+            tokenizer.pad_token = tokenizer.unk_token
+        else:
+            raise ValueError(
+                "Tokenizer is missing a pad token and no suitable fallback (eos/unk) was found. "
+                "Please provide a tokenizer with explicit padding support."
+            )
+    return tokenizer
 
-    # Create models - use same model for policy and value heads
-    model = AutoModelForCausalLMWithValueHead.from_pretrained(model_name)
-    ref_model = AutoModelForCausalLMWithValueHead.from_pretrained(model_name)
-    reward_model = AutoModelForCausalLMWithValueHead.from_pretrained(model_name)
 
-    # Fix generation_config for all models
-    model = fix_generation_config(model, tokenizer, generation_config)
-    ref_model = fix_generation_config(ref_model, tokenizer, generation_config)
-    reward_model = fix_generation_config(reward_model, tokenizer, generation_config)
+def _resolve_model_name_from_tokenizer(tokenizer: PreTrainedTokenizerBase) -> str:
+    for attribute in ("name_or_path", "_name_or_path"):
+        value = getattr(tokenizer, attribute, None)
+        if value:
+            return value
+    init_kwargs = getattr(tokenizer, "init_kwargs", {}) or {}
+    value = init_kwargs.get("name_or_path")
+    if value:
+        return value
+    raise ValueError(
+        "Could not determine the base model name from the tokenizer. Please pass `base_model` explicitly."
+    )
 
-    return model, ref_model, reward_model, tokenizer
+
+def _load_backbone(
+    base_model: Union[str, PreTrainedModel],
+    *,
+    torch_dtype: Optional[torch.dtype] = None,
+    device_map: Optional[Union[str, dict]] = None,
+    **model_kwargs,
+) -> PreTrainedModel:
+    if isinstance(base_model, PreTrainedModel):
+        return copy.deepcopy(base_model)
+
+    load_kwargs = dict(model_kwargs)
+    if torch_dtype is not None:
+        load_kwargs.setdefault("torch_dtype", torch_dtype)
+    if device_map is not None:
+        load_kwargs.setdefault("device_map", device_map)
+
+    if not isinstance(base_model, str):
+        raise TypeError("base_model must be a model name or a PreTrainedModel instance")
+
+    return AutoModelForCausalLM.from_pretrained(base_model, **load_kwargs)
+
+
+def _infer_hidden_size(config) -> int:
+    for attribute in ("hidden_size", "n_embd", "d_model", "model_dim", "embed_dim", "word_embed_proj_dim"):
+        value = getattr(config, attribute, None)
+        if isinstance(value, int):
+            return value
+    hidden_sizes = getattr(config, "hidden_sizes", None)
+    if isinstance(hidden_sizes, (list, tuple)) and hidden_sizes:
+        return hidden_sizes[-1]
+    raise ValueError("Could not infer hidden size from model configuration")
+
+
+def _infer_base_model_prefix(model_name: str) -> str:
+    lowered = (model_name or "").lower()
+    if "llama" in lowered or "mistral" in lowered or "phi" in lowered:
+        return "model"
+    return "transformer"
+
+
+def _init_linear_head(linear: nn.Linear, std: float) -> None:
+    with torch.no_grad():
+        if std > 0:
+            linear.weight.normal_(mean=0.0, std=std)
+        else:
+            linear.weight.zero_()
+        if linear.bias is not None:
+            linear.bias.zero_()
+
+
+class _SimpleScoringModel(nn.Module):
+    """Minimal wrapper exposing ``score`` and ``base_model_prefix`` attributes."""
+
+    def __init__(self, backbone: PreTrainedModel, *, head_init_std: float, freeze_backbone: bool) -> None:
+        super().__init__()
+        if not isinstance(backbone, PreTrainedModel):
+            raise TypeError("backbone must be a Transformers PreTrainedModel instance")
+
+        self.config = backbone.config
+        if hasattr(self.config, "output_hidden_states"):
+            self.config.output_hidden_states = True
+
+        prefix = getattr(backbone, "base_model_prefix", None)
+        module = None
+        if prefix and hasattr(backbone, prefix):
+            module = getattr(backbone, prefix)
+        else:
+            for candidate in ("model", "transformer", backbone.__class__.__name__.lower()):
+                if hasattr(backbone, candidate):
+                    prefix = candidate
+                    module = getattr(backbone, candidate)
+                    break
+        if module is None:
+            prefix = "model"
+            module = backbone
+
+        self.base_model_prefix = prefix
+        setattr(self, prefix, module)
+
+        if freeze_backbone:
+            for parameter in module.parameters():
+                parameter.requires_grad = False
+
+        hidden_size = _infer_hidden_size(module.config if hasattr(module, "config") else self.config)
+        self.score = nn.Linear(hidden_size, 1)
+        _init_linear_head(self.score, std=head_init_std)
+
+    def forward(self, **kwargs):
+        backbone = getattr(self, self.base_model_prefix)
+        outputs = backbone(
+            output_hidden_states=True,
+            return_dict=True,
+            use_cache=False,
+            **kwargs,
+        )
+        return self.score(outputs.hidden_states[-1])
 
 
 def check_trl_compatibility() -> dict:
@@ -164,11 +387,11 @@ def check_trl_compatibility() -> dict:
 
         if trl_version_obj >= version.parse("0.23.0"):
             warnings_list.append(
-                "TRL 0.23.0+ has known issues with AutoModelForCausalLMWithValueHead.generation_config. "
-                "Use fix_generation_config() utility function."
+                "TRL 0.23.0+ expects explicit policy, value, and reward modules. Use the RLDK helpers "
+                "to automatically attach generation configs and scoring heads."
             )
             recommendations.append(
-                "Use prepare_models_for_ppo() or fix_generation_config() to avoid AttributeError"
+                "Use prepare_models_for_ppo() and create_simple_reward_model() to avoid manual patches"
             )
 
         if trl_version_obj < version.parse("0.7.0"):
@@ -207,53 +430,46 @@ def check_trl_compatibility() -> dict:
 
 
 def validate_ppo_setup(
-    model: "AutoModelForCausalLMWithValueHead",
-    ref_model: "AutoModelForCausalLMWithValueHead",
-    reward_model: "AutoModelForCausalLMWithValueHead",
-    tokenizer: AutoTokenizer
+    policy_model: nn.Module,
+    ref_model: Optional[nn.Module],
+    reward_model: Optional[nn.Module],
+    tokenizer: PreTrainedTokenizerBase,
+    value_model: Optional[nn.Module] = None,
 ) -> dict:
-    """Validate PPO setup for common issues.
+    """Validate a PPO configuration for common pitfalls."""
 
-    Args:
-        model: Main PPO model (used for both policy and value heads)
-        ref_model: Reference model
-        reward_model: Reward model
-        tokenizer: Tokenizer
+    issues: list[str] = []
+    warnings: list[str] = []
 
-    Returns:
-        Dictionary with validation results
-    """
-    issues = []
-    warnings = []
+    for name, candidate in (("policy_model", policy_model), ("ref_model", ref_model)):
+        if candidate is None:
+            continue
+        if not hasattr(candidate, "generation_config") or getattr(candidate, "generation_config") is None:
+            issues.append(f"{name} is missing a valid generation_config")
 
-    # Check generation_config attribute
-    for name, model_obj in [("model", model), ("ref_model", ref_model),
-                           ("reward_model", reward_model)]:
-        if not hasattr(model_obj, 'generation_config'):
-            issues.append(f"{name} missing generation_config attribute")
-        elif model_obj.generation_config is None:
-            warnings.append(f"{name} has None generation_config")
-
-    # Check tokenizer compatibility
-    if not hasattr(tokenizer, 'eos_token_id') or tokenizer.eos_token_id is None:
+    if not hasattr(tokenizer, "eos_token_id") or tokenizer.eos_token_id is None:
         issues.append("Tokenizer missing eos_token_id")
-
-    if not hasattr(tokenizer, 'pad_token_id') or tokenizer.pad_token_id is None:
+    if not hasattr(tokenizer, "pad_token_id") or tokenizer.pad_token_id is None:
         warnings.append("Tokenizer missing pad_token_id")
 
-    # Check model types
-    for name, model_obj in [("model", model), ("ref_model", ref_model),
-                           ("reward_model", reward_model)]:
-        if not isinstance(model_obj, AutoModelForCausalLMWithValueHead):
-            issues.append(f"{name} is not an AutoModelForCausalLMWithValueHead instance")
+    for name, candidate in (
+        ("value_model", value_model),
+        ("reward_model", reward_model),
+    ):
+        if candidate is None:
+            continue
+        if not hasattr(candidate, "base_model_prefix"):
+            issues.append(f"{name} missing base_model_prefix attribute")
+        if not hasattr(candidate, "score"):
+            issues.append(f"{name} missing score head compatible with TRL")
 
     return {
         "valid": len(issues) == 0,
         "issues": issues,
         "warnings": warnings,
         "recommendations": [
-            "Use fix_generation_config() to fix generation_config issues",
-            "Ensure all models are AutoModelForCausalLMWithValueHead instances",
-            "Check tokenizer has required token IDs"
-        ] if issues else []
+            "Ensure policy/ref models expose generation_config",
+            "Ensure value and reward models define base_model_prefix and score",
+            "Check tokenizer has required token IDs",
+        ] if issues else [],
     }


### PR DESCRIPTION
## Summary
- update `prepare_models_for_ppo` to return separate policy, reference, and value models with generation configs
- add simple reward/value model helpers plus supporting validation and tokenizer utilities
- refresh TRL integration docs and example to demonstrate the new workflow

## Testing
- python -m compileall src/rldk/integrations/trl

------
https://chatgpt.com/codex/tasks/task_e_68c88cab6f60832fbb1fd82dd798f778