### PR TITLE
fix: ensure TRL metrics jsonl handles extended fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,10 @@ df = ingest_runs("wandb://project/run_id", adapter_hint="wandb")
 df = ingest_runs("path/to/openrlhf_logs", adapter_hint="openrlhf")
 ```
 
+> **Note:** Training and replay tooling expect per-step metrics in JSONL format
+> (one record per line). If you have legacy aggregated JSON logs you can convert
+> them using `python tools/json_to_jsonl.py legacy_metrics.json`.
+
 ### **CLI Commands**
 Comprehensive command-line interface for all functionality:
 

--- a/docs/COMPREHENSIVE_PPO_FORENSICS_SUMMARY.md
+++ b/docs/COMPREHENSIVE_PPO_FORENSICS_SUMMARY.md
@@ -179,7 +179,7 @@ The system generates several types of output files:
 - `*_comprehensive_analysis.json`: Full analysis results
 - `*_health_summary.json`: Concise health summary
 - `*_comprehensive_metrics.csv`: All metrics in CSV format
-- `*_comprehensive_metrics.json`: All metrics in JSON format
+- `*_comprehensive_metrics.jsonl`: All metrics in JSONL format
 
 ### Checkpoint Files
 - `*_comprehensive_analysis_step_*.json`: Analysis at each checkpoint

--- a/docs/DASHBOARD_UPDATE_HOOKS_IMPLEMENTATION.md
+++ b/docs/DASHBOARD_UPDATE_HOOKS_IMPLEMENTATION.md
@@ -45,12 +45,12 @@ def update_data(self):
     """Update dashboard data from files."""
     # Load metrics data
     if self.run_id:
-        metrics_files = list(self.output_dir.glob(f"{self.run_id}_metrics.json"))
+        metrics_files = list(self.output_dir.glob(f"{self.run_id}_metrics.jsonl"))
         alerts_files = list(self.output_dir.glob(f"{self.run_id}_alerts.json"))
         ppo_files = list(self.output_dir.glob(f"{self.run_id}_ppo_metrics.csv"))
         checkpoint_files = list(self.output_dir.glob(f"{self.run_id}_checkpoint_summary.csv"))
     else:
-        metrics_files = list(self.output_dir.glob("*_metrics.json"))
+        metrics_files = list(self.output_dir.glob("*_metrics.jsonl"))
         alerts_files = list(self.output_dir.glob("*_alerts.json"))
         ppo_files = list(self.output_dir.glob("*_ppo_metrics.csv"))
         checkpoint_files = list(self.output_dir.glob("*_checkpoint_summary.csv"))
@@ -66,7 +66,7 @@ def update_data(self):
 **Implementation**:
 - Converts `RLDKMetrics` objects to dictionaries
 - Adds to local dashboard storage
-- Immediately saves to persistent JSON files
+- Immediately appends to persistent JSONL files
 - Handles existing data gracefully
 
 ```python
@@ -78,10 +78,11 @@ def add_metrics(self, metrics: RLDKMetrics):
     
     # Save to file immediately for persistence
     if self.run_id:
-        metrics_file = self.output_dir / f"{self.run_id}_metrics.json"
+        metrics_file = self.output_dir / f"{self.run_id}_metrics.jsonl"
         try:
-            # Load existing data, add new metrics, save back
-            # ...
+            # Append the new record as a JSON line
+            with open(metrics_file, "a") as f:
+                f.write(json.dumps(metrics_dict) + "\n")
             print(f"📊 Added metrics for step {metrics.step} to dashboard")
         except Exception as e:
             print(f"Error saving metrics to file: {e}")
@@ -216,7 +217,7 @@ The implementation works with the existing file structure:
 
 ```
 output_dir/
-├── {run_id}_metrics.json      # Training metrics
+├── {run_id}_metrics.jsonl     # Training metrics (per-step JSONL)
 ├── {run_id}_alerts.json       # Training alerts
 ├── {run_id}_ppo_metrics.csv   # PPO-specific metrics
 └── {run_id}_checkpoint_summary.csv  # Checkpoint data

--- a/docs/JSONL_IMPLEMENTATION_SUMMARY.md
+++ b/docs/JSONL_IMPLEMENTATION_SUMMARY.md
@@ -137,7 +137,7 @@ Each JSONL line contains a complete Event object with the following structure:
 ```
 {run_id}_events.jsonl          # Per-step training events (JSONL format)
 {run_id}_metrics.csv           # Aggregated metrics (CSV format)
-{run_id}_metrics.json          # Aggregated metrics (JSON format)
+{run_id}_metrics.jsonl         # Per-step metrics (JSONL format)
 {run_id}_alerts.json           # Training alerts and warnings
 {run_id}_final_report.json     # Final training summary
 ```

--- a/examples/data_formats/README.md
+++ b/examples/data_formats/README.md
@@ -19,6 +19,10 @@ adapter = FlexibleDataAdapter("your_data.jsonl", field_map=field_map)
 df = adapter.load()
 ```
 
+> ℹ️ **Training logs**: Core replay and monitoring tools assume JSONL files with
+> one record per training step. Use `tools/json_to_jsonl.py` to convert legacy
+> aggregated JSON metrics before ingesting them with the flexible adapter.
+
 ## Supported Formats
 
 ### 1. Flexible Data Adapter (Recommended)

--- a/examples/hyperparameter_tuning.py
+++ b/examples/hyperparameter_tuning.py
@@ -793,9 +793,17 @@ def main():
     # 9. Save Detailed Results
     print("\n9. Saving detailed results...")
 
-    detailed_results = {
-        "grid_search_results": grid_results,
-        "random_search_results": random_results,
+    results_path = Path("./hyperparameter_tuning_results.jsonl")
+    records: List[Dict[str, Any]] = []
+
+    for result in grid_results:
+        records.append({"record_type": "grid_search_result", **result})
+
+    for result in random_results:
+        records.append({"record_type": "random_search_result", **result})
+
+    summary_record = {
+        "record_type": "summary",
         "best_grid_result": best_grid_result,
         "best_random_result": best_random_result,
         "best_overall_result": best_overall,
@@ -803,14 +811,17 @@ def main():
             "grid_search_time": grid_time,
             "random_search_time": random_time,
             "total_experiments": len(grid_results) + len(random_results),
-            "best_overall_reward": best_overall['avg_reward']
-        }
+            "best_overall_reward": best_overall['avg_reward'],
+        },
     }
 
-    with open("./hyperparameter_tuning_results.json", "w") as f:
-        json.dump(detailed_results, f, indent=2, default=str)
+    records.append(summary_record)
 
-    print("💾 Detailed results saved to ./hyperparameter_tuning_results.json")
+    with results_path.open("w") as f:
+        for record in records:
+            f.write(json.dumps(record, default=str) + "\n")
+
+    print(f"💾 Detailed results saved to {results_path}")
 
     # 10. Finish Experiment
     print("\n10. Finishing experiment...")
@@ -826,7 +837,7 @@ def main():
 
     print("\n📁 Files created:")
     print(f"   - {config.output_dir}/{summary['experiment_id']}/ - Experiment data")
-    print("   - ./hyperparameter_tuning_results.json - Detailed results")
+    print("   - ./hyperparameter_tuning_results.jsonl - Detailed results (JSONL)")
     print("   - ./hyperparameter_tuning_plots.png - Analysis plots")
 
     # 11. Summary

--- a/examples/trl_integration/advanced_monitoring.py
+++ b/examples/trl_integration/advanced_monitoring.py
@@ -235,9 +235,9 @@ class AdvancedPPOMonitor(PPOMonitor):
     def save_ppo_analysis(self):
         """Save advanced PPO analysis and call parent method."""
         # Save convergence analysis
-        convergence_path = self.output_dir / f"{self.run_id}_convergence_analysis.json"
+        convergence_path = self.output_dir / f"{self.run_id}_convergence_analysis.jsonl"
         with open(convergence_path, "w") as f:
-            json.dump(self.convergence_analysis, f, indent=2)
+            f.write(json.dumps(self.convergence_analysis) + "\n")
         print(f"📊 Convergence analysis saved to {convergence_path}")
 
         # Call parent method to save standard PPO analysis

--- a/examples/trl_integration/basic_ppo_integration.py
+++ b/examples/trl_integration/basic_ppo_integration.py
@@ -193,6 +193,7 @@ def test_basic_ppo_integration():
         # Verify files were created
         expected_files = [
             f"{output_dir}/test_ppo_run_metrics.csv",
+            f"{output_dir}/test_ppo_run_metrics.jsonl",
             f"{output_dir}/test_ppo_run_ppo_metrics.csv",
             f"{output_dir}/test_ppo_run_checkpoint_summary.csv",
         ]

--- a/src/rldk/integrations/trl/README.md
+++ b/src/rldk/integrations/trl/README.md
@@ -36,7 +36,7 @@ The integration creates several output files:
 
 - `{run_id}_events.jsonl` - Per-step training events (JSONL format)
 - `{run_id}_metrics.csv` - Aggregated metrics (CSV format)
-- `{run_id}_metrics.json` - Aggregated metrics (JSON format)
+- `{run_id}_metrics.jsonl` - Per-step metrics (JSONL format)
 - `{run_id}_alerts.json` - Training alerts and warnings
 - `{run_id}_final_report.json` - Final training summary
 

--- a/src/rldk/integrations/trl/callbacks.py
+++ b/src/rldk/integrations/trl/callbacks.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
+from ...io.unified_writer import UnifiedWriter
 from transformers import (
     TrainerCallback,
     TrainerControl,
@@ -616,15 +617,22 @@ class RLDKCallback(TrainerCallback):
         # Convert to DataFrame
         df = pd.DataFrame([m.to_dict() for m in self.metrics_history])
 
-        # Save as CSV and JSON (aggregates only)
+        # Save as CSV and JSONL (per-step records)
         csv_path = self.output_dir / f"{self.run_id}_metrics.csv"
-        json_path = self.output_dir / f"{self.run_id}_metrics.json"
+        jsonl_path = self.output_dir / f"{self.run_id}_metrics.jsonl"
 
         df.to_csv(csv_path, index=False)
-        df.to_json(json_path, orient='records', indent=2)
 
-        # Note: JSONL file is handled separately and should not be modified here
-        # The JSONL file contains per-step events and is written in real-time
+        writer = UnifiedWriter(self.output_dir)
+        records = df.to_dict(orient="records")
+
+        try:
+            writer.write_jsonl(records, jsonl_path.name)
+        except Exception as exc:
+            warnings.warn(
+                f"Failed to write metrics JSONL file {jsonl_path}: {exc}",
+                stacklevel=2,
+            )
 
     def _save_alerts(self):
         """Save alerts to file."""

--- a/src/rldk/integrations/trl/dashboard.py
+++ b/src/rldk/integrations/trl/dashboard.py
@@ -235,12 +235,12 @@ def load_metrics_data():
 
     # Find all metrics files
     if RUN_ID:
-        metrics_files = list(OUTPUT_DIR.glob(f"{{RUN_ID}}_metrics.json"))
+        metrics_files = list(OUTPUT_DIR.glob(f"{{RUN_ID}}_metrics.jsonl"))
         alerts_files = list(OUTPUT_DIR.glob(f"{{RUN_ID}}_alerts.json"))
         ppo_files = list(OUTPUT_DIR.glob(f"{{RUN_ID}}_ppo_metrics.csv"))
         checkpoint_files = list(OUTPUT_DIR.glob(f"{{RUN_ID}}_checkpoint_summary.csv"))
     else:
-        metrics_files = list(OUTPUT_DIR.glob("*_metrics.json"))
+        metrics_files = list(OUTPUT_DIR.glob("*_metrics.jsonl"))
         alerts_files = list(OUTPUT_DIR.glob("*_alerts.json"))
         ppo_files = list(OUTPUT_DIR.glob("*_ppo_metrics.csv"))
         checkpoint_files = list(OUTPUT_DIR.glob("*_checkpoint_summary.csv"))
@@ -249,11 +249,11 @@ def load_metrics_data():
     for file in metrics_files:
         try:
             with open(file, 'r') as f:
-                data = json.load(f)
-                if isinstance(data, list):
-                    metrics_data.extend(data)
-                else:
-                    metrics_data.append(data)
+                for line in f:
+                    record = line.strip()
+                    if not record:
+                        continue
+                    metrics_data.append(json.loads(record))
         except Exception as e:
             st.error(f"Error loading {{file}}: {{e}}")
 
@@ -542,12 +542,12 @@ with tab4:
         """Update dashboard data from files."""
         # Load metrics data
         if self.run_id:
-            metrics_files = list(self.output_dir.glob(f"{self.run_id}_metrics.json"))
+            metrics_files = list(self.output_dir.glob(f"{self.run_id}_metrics.jsonl"))
             alerts_files = list(self.output_dir.glob(f"{self.run_id}_alerts.json"))
             ppo_files = list(self.output_dir.glob(f"{self.run_id}_ppo_metrics.csv"))
             checkpoint_files = list(self.output_dir.glob(f"{self.run_id}_checkpoint_summary.csv"))
         else:
-            metrics_files = list(self.output_dir.glob("*_metrics.json"))
+            metrics_files = list(self.output_dir.glob("*_metrics.jsonl"))
             alerts_files = list(self.output_dir.glob("*_alerts.json"))
             ppo_files = list(self.output_dir.glob("*_ppo_metrics.csv"))
             checkpoint_files = list(self.output_dir.glob("*_checkpoint_summary.csv"))
@@ -557,11 +557,11 @@ with tab4:
         for file in metrics_files:
             try:
                 with open(file) as f:
-                    data = json.load(f)
-                    if isinstance(data, list):
-                        self.metrics_data.extend(data)
-                    else:
-                        self.metrics_data.append(data)
+                    for line in f:
+                        record = line.strip()
+                        if not record:
+                            continue
+                        self.metrics_data.append(json.loads(record))
             except Exception as e:
                 print(f"Error loading {file}: {e}")
 
@@ -617,22 +617,10 @@ with tab4:
 
         # Save to file immediately for persistence
         if self.run_id:
-            metrics_file = self.output_dir / f"{self.run_id}_metrics.json"
+            metrics_file = self.output_dir / f"{self.run_id}_metrics.jsonl"
             try:
-                # Load existing data
-                existing_data = []
-                if metrics_file.exists():
-                    with open(metrics_file) as f:
-                        existing_data = json.load(f)
-                        if not isinstance(existing_data, list):
-                            existing_data = [existing_data]
-
-                # Add new metrics
-                existing_data.append(metrics_dict)
-
-                # Save back to file
-                with open(metrics_file, 'w') as f:
-                    json.dump(existing_data, f, indent=2)
+                with open(metrics_file, 'a') as f:
+                    f.write(json.dumps(metrics_dict) + "\n")
 
                 print(f"📊 Added metrics for step {metrics.step} to dashboard")
             except Exception as e:

--- a/src/rldk/integrations/trl/monitors.py
+++ b/src/rldk/integrations/trl/monitors.py
@@ -2,12 +2,14 @@
 
 import json
 import time
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
+from ...io.unified_writer import UnifiedWriter
 from transformers import (
     TrainerCallback,
     TrainerControl,
@@ -896,10 +898,19 @@ class ComprehensivePPOMonitor(TrainerCallback):
         csv_path = self.output_dir / f"{self.run_id}_comprehensive_metrics.csv"
         df.to_csv(csv_path, index=False)
 
-        # Save as JSON
-        json_path = self.output_dir / f"{self.run_id}_comprehensive_metrics.json"
-        with open(json_path, "w") as f:
-            json.dump(self.comprehensive_metrics_history, f, indent=2)
+        # Save as JSONL for per-step compatibility
+        jsonl_path = self.output_dir / f"{self.run_id}_comprehensive_metrics.jsonl"
+
+        writer = UnifiedWriter(self.output_dir)
+        records = df.to_dict(orient="records")
+
+        try:
+            writer.write_jsonl(records, jsonl_path.name)
+        except Exception as exc:
+            warnings.warn(
+                f"Failed to write comprehensive metrics JSONL file {jsonl_path}: {exc}",
+                stacklevel=2,
+            )
 
         print(f"💾 Comprehensive metrics saved: {csv_path}")
 

--- a/tools/json_to_jsonl.py
+++ b/tools/json_to_jsonl.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Convert JSON training logs to JSONL format.
+
+This helper script converts aggregated JSON structures into line-delimited JSON
+records that are easier to stream. When converting dictionaries you can specify
+which key contains the list of records via ``--array-key``. If no key is
+provided the entire JSON object is emitted as a single record.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterator, Union
+
+JsonValue = Union[dict, list, str, int, float, bool, None]
+
+
+def iter_records(data: JsonValue, array_key: str | None = None) -> Iterator[JsonValue]:
+    """Yield JSON-serializable records from the loaded data."""
+    if array_key:
+        if not isinstance(data, dict):
+            raise ValueError("--array-key can only be used when the JSON document is an object")
+        if array_key not in data:
+            raise KeyError(f"Key '{array_key}' not found in JSON document")
+        candidate = data[array_key]
+        if not isinstance(candidate, list):
+            raise TypeError(f"Value for '{array_key}' is not a list")
+        data = candidate
+
+    if isinstance(data, list):
+        for item in data:
+            yield item
+    else:
+        # Emit the entire structure as a single record
+        yield data
+
+
+def convert_json_to_jsonl(source: Path, destination: Path, array_key: str | None = None) -> None:
+    """Convert ``source`` JSON file to JSONL format at ``destination``."""
+    with source.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    records = list(iter_records(data, array_key=array_key))
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with destination.open("w", encoding="utf-8") as f:
+        for record in records:
+            f.write(json.dumps(record) + "\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Convert JSON logs to JSONL format")
+    parser.add_argument("source", type=Path, help="Path to the input JSON file")
+    parser.add_argument(
+        "destination",
+        type=Path,
+        nargs="?",
+        help="Optional output path. Defaults to replacing .json with .jsonl",
+    )
+    parser.add_argument(
+        "--array-key",
+        dest="array_key",
+        help="Name of the key that contains an array of records to emit",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    source: Path = args.source
+    destination: Path
+
+    if args.destination is not None:
+        destination = args.destination
+    else:
+        if source.suffix.lower() == ".json":
+            destination = source.with_suffix(".jsonl")
+        else:
+            destination = source.parent / f"{source.name}.jsonl"
+
+    convert_json_to_jsonl(source, destination, array_key=args.array_key)
+    print(f"Converted {source} -> {destination}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- emit per-step metrics JSONL from the TRL callback and align monitors/dashboard with the new file format
- refresh example workflows to log metrics as JSONL, including updated TRL demos and hyperparameter tuning outputs
- add a json-to-jsonl conversion helper and document the JSONL expectation for training data ingestion
- ensure the TRL callback and monitor write metrics JSONL via the shared UnifiedWriter so extended fields no longer trip schema validation

## Testing
- pytest tests/unit/test_api_contract.py::TestPublicSymbols -q
- python tools/json_to_jsonl.py --help

------
https://chatgpt.com/codex/tasks/task_e_68c8e6c34748832f897bce8efa66126f