### PR TITLE
feat: Add core streaming engine and minimal CLI for framework-agnostic monitoring

### DIFF
--- a/examples/minimal_streaming_loop.py
+++ b/examples/minimal_streaming_loop.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Minimal streaming loop that emits JSONL events with rising KL values."""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from rldk.emit import EventWriter
+
+
+def main():
+    """Run minimal streaming loop that demonstrates auto-stop behavior."""
+    print(f"PID: {os.getpid()}")
+    
+    output_path = Path("artifacts/run.jsonl")
+    output_path.parent.mkdir(exist_ok=True)
+    
+    with EventWriter(output_path, run_id="minimal-demo") as writer:
+        for step in range(1, 101):
+            if step < 20:
+                kl = 0.1 + (step * 0.01)  # Gradual increase
+            elif step < 40:
+                kl = 0.3 + ((step - 20) * 0.005)  # Slower increase
+            else:
+                kl = 0.4 + ((step - 40) * 0.01)  # Faster increase to trigger rule
+            
+            writer.log(step=step, name="kl", value=kl)
+            
+            reward = -0.5 + (step * 0.01)  # Improving reward
+            writer.log(step=step, name="reward", value=reward)
+            
+            grad_norm = 1.0 + (step * 0.02)  # Rising gradient norm
+            writer.log(step=step, name="grad_norm", value=grad_norm)
+            
+            print(f"Step {step}: kl={kl:.3f}, reward={reward:.3f}, grad_norm={grad_norm:.3f}")
+            
+            time.sleep(0.1)
+    
+    print("Training loop completed")
+
+
+if __name__ == "__main__":
+    main()

--- a/rules.yaml
+++ b/rules.yaml
@@ -1,0 +1,33 @@
+rules:
+  - id: stop_on_high_kl
+    where: name == "kl"
+    condition: value > 0.35
+    window:
+      size: 5
+      kind: consecutive
+    cooldown_steps: 5
+    actions:
+      - warn:
+          msg: "KL {value:.3f} exceeded at step {step}"
+
+  - id: warn_on_high_grad_norm
+    where: name == "grad_norm"
+    condition: value > 2.0
+    window:
+      size: 3
+      kind: consecutive
+    cooldown_steps: 10
+    actions:
+      - warn:
+          msg: "High gradient norm {value:.3f} at step {step}"
+
+  - id: rolling_kl_check
+    where: name == "kl"
+    condition: mean(value) > 0.25
+    window:
+      size: 10
+      kind: rolling
+    cooldown_steps: 0
+    actions:
+      - warn:
+          msg: "Rolling KL mean {value:.3f} exceeded threshold at step {step}"

--- a/src/rldk/cli.py
+++ b/src/rldk/cli.py
@@ -72,6 +72,9 @@ from rldk.utils.error_handling import (
 from rldk.utils.progress import print_operation_status, timed_operation_context
 from rldk.utils.runtime import with_timeout
 
+from rldk.monitor.engine import MonitorEngine, load_rules_from_yaml
+from rldk.monitor.events import EventWriter
+
 
 def ensure_config_initialized():
     """Ensure configuration is initialized for CLI operations."""
@@ -95,9 +98,11 @@ app = typer.Typer(
 forensics_app = typer.Typer(name="forensics", help="Forensics commands for RL training analysis")
 reward_app = typer.Typer(name="reward", help="Reward model analysis commands")
 evals_app = typer.Typer(name="evals", help="Evaluation suite commands")
+monitor_app = typer.Typer(name="monitor", help="Framework-agnostic monitoring commands")
 
 # Add sub-apps to main app
 app.add_typer(forensics_app, name="forensics")
+app.add_typer(monitor_app, name="monitor")
 app.add_typer(reward_app, name="reward")
 app.add_typer(evals_app, name="evals")
 
@@ -2527,6 +2532,128 @@ def seed_cmd(
             else:
                 typer.echo("  Non-deterministic behavior enabled")
 
+    except Exception as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
+
+
+@monitor_app.command("stream")
+def monitor_stream(
+    path: str = typer.Argument(..., help="Path to JSONL file or '-' for stdin"),
+    rules: str = typer.Option(..., "--rules", help="Path to YAML rules file"),
+    pid: Optional[int] = typer.Option(None, "--pid", help="Process ID to monitor (not used in PR1)"),
+    field_map: Optional[str] = typer.Option(None, "--field-map", help="JSON field mapping for non-canonical schemas"),
+    alerts: str = typer.Option("artifacts/alerts.jsonl", "--alerts", help="Path to write alerts.jsonl"),
+    report: Optional[str] = typer.Option(None, "--report", help="Path to write report.json"),
+    cooldown_steps: int = typer.Option(0, "--cooldown-steps", help="Global cooldown steps override"),
+    grace_steps: int = typer.Option(0, "--grace-steps", help="Global grace steps override"),
+    kill_timeout_sec: int = typer.Option(5, "--kill-timeout-sec", help="Timeout for process termination (not used in PR1)"),
+    http_timeout_sec: int = typer.Option(30, "--http-timeout-sec", help="HTTP action timeout (not used in PR1)"),
+    retries: int = typer.Option(3, "--retries", help="Action retry count (not used in PR1)"),
+):
+    """Monitor JSONL events in streaming mode with live rule evaluation."""
+    ensure_config_initialized()
+    
+    try:
+        # Parse field mapping if provided
+        field_mapping = None
+        if field_map:
+            field_mapping = json.loads(field_map)
+        
+        rules = load_rules_from_yaml(rules)
+        
+        for rule in rules:
+            if cooldown_steps > 0:
+                rule.cooldown_steps = cooldown_steps
+            if grace_steps > 0:
+                rule.grace_steps = grace_steps
+        
+        engine = MonitorEngine(rules, alerts, report)
+        
+        stream_path = None if path == "-" else path
+        engine.process_stream(stream_path, field_mapping, follow=True)
+        
+    except FileNotFoundError as e:
+        typer.echo(f"Error: File not found - {e}", err=True)
+        raise typer.Exit(1)
+    except json.JSONDecodeError as e:
+        typer.echo(f"Error: Invalid JSON in field-map - {e}", err=True)
+        raise typer.Exit(1)
+    except Exception as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
+
+
+@monitor_app.command("once")
+def monitor_once(
+    path: str = typer.Argument(..., help="Path to JSONL file"),
+    rules: str = typer.Option(..., "--rules", help="Path to YAML rules file"),
+    report: Optional[str] = typer.Option(None, "--report", help="Path to write report.json"),
+    field_map: Optional[str] = typer.Option(None, "--field-map", help="JSON field mapping for non-canonical schemas"),
+    alerts: str = typer.Option("artifacts/alerts.jsonl", "--alerts", help="Path to write alerts.jsonl"),
+):
+    """Monitor JSONL events in batch mode for deterministic analysis."""
+    ensure_config_initialized()
+    
+    try:
+        # Parse field mapping if provided
+        field_mapping = None
+        if field_map:
+            field_mapping = json.loads(field_map)
+        
+        rules = load_rules_from_yaml(rules)
+        
+        engine = MonitorEngine(rules, alerts, report)
+        
+        engine.process_stream(path, field_mapping, follow=False)
+        
+        typer.echo(f"Batch monitoring complete. Alerts written to {alerts}")
+        if report:
+            typer.echo(f"Report written to {report}")
+        
+    except FileNotFoundError as e:
+        typer.echo(f"Error: File not found - {e}", err=True)
+        raise typer.Exit(1)
+    except json.JSONDecodeError as e:
+        typer.echo(f"Error: Invalid JSON in field-map - {e}", err=True)
+        raise typer.Exit(1)
+    except Exception as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
+
+
+@app.command()
+def emit(
+    to: str = typer.Option(..., "--to", help="Path to JSONL file to write to"),
+    name: str = typer.Option(..., "--name", help="Metric name"),
+    value: float = typer.Option(..., "--value", help="Metric value"),
+    step: int = typer.Option(..., "--step", help="Training step number"),
+    time: Optional[str] = typer.Option(None, "--time", help="ISO8601 timestamp (defaults to current time)"),
+    run_id: Optional[str] = typer.Option(None, "--run-id", help="Run identifier"),
+    tags: Optional[str] = typer.Option(None, "--tags", help="JSON tags object"),
+    meta: Optional[str] = typer.Option(None, "--meta", help="JSON metadata object"),
+):
+    """Emit a single event to JSONL file."""
+    ensure_config_initialized()
+    
+    try:
+        # Parse JSON fields if provided
+        tags_dict = None
+        if tags:
+            tags_dict = json.loads(tags)
+            
+        meta_dict = None
+        if meta:
+            meta_dict = json.loads(meta)
+        
+        with EventWriter(to, run_id) as writer:
+            writer.log(step, name, value, time, tags_dict, meta_dict)
+        
+        typer.echo(f"Event emitted to {to}")
+        
+    except json.JSONDecodeError as e:
+        typer.echo(f"Error: Invalid JSON in tags or meta - {e}", err=True)
+        raise typer.Exit(1)
     except Exception as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)

--- a/src/rldk/emit.py
+++ b/src/rldk/emit.py
@@ -1,0 +1,5 @@
+"""Event emission utilities for framework-agnostic logging."""
+
+from .monitor.events import EventWriter
+
+__all__ = ["EventWriter"]

--- a/src/rldk/monitor/__init__.py
+++ b/src/rldk/monitor/__init__.py
@@ -1,0 +1,15 @@
+"""Framework-agnostic monitoring engine for RLDK."""
+
+from .engine import MonitorEngine, read_stream
+from .events import CanonicalEvent, EventWriter
+from .rules import Rule, RuleEngine, Window
+
+__all__ = [
+    "MonitorEngine",
+    "read_stream",
+    "CanonicalEvent",
+    "EventWriter",
+    "Rule",
+    "RuleEngine",
+    "Window",
+]

--- a/src/rldk/monitor/engine.py
+++ b/src/rldk/monitor/engine.py
@@ -1,0 +1,335 @@
+"""Core monitoring engine for streaming JSONL events."""
+
+import gzip
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, Generator, List, Optional, TextIO, Union
+
+import yaml
+
+from .rules import Rule, RuleEngine
+
+
+def read_stream(
+    path_or_stdin: Union[str, Path, None],
+    field_map: Optional[Dict[str, str]] = None,
+    follow: bool = False
+) -> Generator[Dict[str, Any], None, None]:
+    """Read and canonicalize events from JSONL stream.
+
+    Args:
+        path_or_stdin: Path to file, "-" for stdin, or None for stdin
+        field_map: Optional mapping from source fields to canonical schema
+        follow: Whether to follow file like tail -F (streaming mode)
+
+    Yields:
+        Canonicalized event dictionaries
+    """
+    if path_or_stdin is None or path_or_stdin == "-":
+        yield from _read_file_stream(sys.stdin, field_map)
+    else:
+        path = Path(path_or_stdin)
+
+        if path.suffix == ".gz":
+            if follow:
+                raise ValueError("Cannot follow gzip files in streaming mode")
+            with gzip.open(path, "rt", encoding="utf-8") as f:
+                yield from _read_file_stream(f, field_map)
+        else:
+            if follow:
+                yield from _follow_file(path, field_map)
+            else:
+                with open(path, encoding="utf-8") as f:
+                    yield from _read_file_stream(f, field_map)
+
+
+def _read_file_stream(
+    file_handle: TextIO,
+    field_map: Optional[Dict[str, str]] = None
+) -> Generator[Dict[str, Any], None, None]:
+    """Read events from file handle."""
+    partial_line = ""
+
+    for line in file_handle:
+        line = partial_line + line
+
+        if not line.endswith("\n"):
+            partial_line = line
+            continue
+        else:
+            partial_line = ""
+
+        line = line.strip()
+        if not line:
+            continue
+
+        try:
+            raw_event = json.loads(line)
+            canonical_event = _canonicalize_event(raw_event, field_map)
+            if canonical_event:
+                yield canonical_event
+        except json.JSONDecodeError:
+            continue
+
+
+def _follow_file(
+    path: Path,
+    field_map: Optional[Dict[str, str]] = None
+) -> Generator[Dict[str, Any], None, None]:
+    """Follow file like tail -F with rotation and truncation handling."""
+    last_size = 0
+    last_inode = None
+
+    while True:
+        try:
+            if not path.exists():
+                time.sleep(0.1)
+                continue
+
+            stat = path.stat()
+            current_inode = stat.st_ino
+            current_size = stat.st_size
+
+            if last_inode is not None and current_inode != last_inode:
+                last_size = 0
+
+            if current_size < last_size:
+                last_size = 0
+
+            if current_size > last_size:
+                with open(path, encoding="utf-8") as f:
+                    f.seek(last_size)
+                    yield from _read_file_stream(f, field_map)
+                    last_size = f.tell()
+
+            last_inode = current_inode
+            time.sleep(0.1)
+
+        except OSError:
+            time.sleep(0.1)
+            continue
+
+
+def _canonicalize_event(
+    raw_event: Dict[str, Any],
+    field_map: Optional[Dict[str, str]] = None
+) -> Optional[Dict[str, Any]]:
+    """Convert raw event to canonical schema.
+
+    Args:
+        raw_event: Raw event dictionary
+        field_map: Optional field mapping {"source_field": "canonical_field"}
+
+    Returns:
+        Canonicalized event dictionary or None if invalid
+    """
+    if field_map is None:
+        field_map = {}
+
+    default_map = {
+        "time": "time",
+        "step": "step",
+        "name": "name",
+        "value": "value",
+        "run_id": "run_id",
+        "tags": "tags",
+        "meta": "meta",
+    }
+
+    effective_map = {**default_map, **field_map}
+
+    canonical = {}
+
+    for canonical_field, source_field in effective_map.items():
+        if source_field in raw_event:
+            canonical[canonical_field] = raw_event[source_field]
+
+    required_fields = ["time", "step", "name", "value"]
+    for field in required_fields:
+        if field not in canonical:
+            return None
+
+    try:
+        canonical["step"] = int(canonical["step"])
+        canonical["value"] = float(canonical["value"])
+        canonical["name"] = str(canonical["name"])
+        canonical["time"] = str(canonical["time"])
+    except (ValueError, TypeError):
+        return None
+
+    return canonical
+
+
+class MonitorEngine:
+    """Main monitoring engine for processing JSONL events."""
+
+    def __init__(
+        self,
+        rules: List[Rule],
+        alerts_path: Optional[Union[str, Path]] = None,
+        report_path: Optional[Union[str, Path]] = None
+    ):
+        """Initialize monitoring engine.
+
+        Args:
+            rules: List of rules to evaluate
+            alerts_path: Path to write alerts.jsonl (default: artifacts/alerts.jsonl)
+            report_path: Path to write report.json (optional)
+        """
+        self.rule_engine = RuleEngine(rules)
+
+        if alerts_path is None:
+            alerts_path = Path("artifacts/alerts.jsonl")
+        self.alerts_path = Path(alerts_path)
+        self.alerts_path.parent.mkdir(parents=True, exist_ok=True)
+
+        self.report_path = Path(report_path) if report_path else None
+
+        self.alerts: List[Dict[str, Any]] = []
+        self.last_seen_metrics: Dict[str, Any] = {}
+        self.rule_activation_counts: Dict[str, int] = {}
+        self.first_activations: Dict[str, Dict[str, Any]] = {}
+        self.last_activations: Dict[str, Dict[str, Any]] = {}
+
+    def process_stream(
+        self,
+        path_or_stdin: Union[str, Path, None],
+        field_map: Optional[Dict[str, str]] = None,
+        follow: bool = False
+    ) -> None:
+        """Process event stream and generate alerts.
+
+        Args:
+            path_or_stdin: Path to JSONL file, "-" for stdin, or None for stdin
+            field_map: Optional field mapping for non-canonical schemas
+            follow: Whether to follow file in streaming mode
+        """
+        for event in read_stream(path_or_stdin, field_map, follow):
+            self._process_event(event)
+
+        if self.report_path:
+            self._write_report()
+
+    def _process_event(self, event: Dict[str, Any]) -> None:
+        """Process a single event."""
+        metric_key = event["name"]
+        if event.get("tags"):
+            tag_str = "&".join(f"{k}={v}" for k, v in sorted(event["tags"].items()))
+            metric_key = f"{metric_key}#{tag_str}"
+        self.last_seen_metrics[metric_key] = event
+
+        alerts = self.rule_engine.evaluate_event(event)
+
+        for alert in alerts:
+            self._handle_alert(alert)
+
+    def _handle_alert(self, alert: Dict[str, Any]) -> None:
+        """Handle a triggered alert."""
+        rule_id = alert["rule_id"]
+
+        self.rule_activation_counts[rule_id] = self.rule_activation_counts.get(rule_id, 0) + 1
+
+        if rule_id not in self.first_activations:
+            self.first_activations[rule_id] = {
+                "step": alert["step"],
+                "timestamp": alert["ts"]
+            }
+        self.last_activations[rule_id] = {
+            "step": alert["step"],
+            "timestamp": alert["ts"]
+        }
+
+        for rule in self.rule_engine.rules:
+            if rule.id == rule_id:
+                self._execute_actions(alert, rule.actions)
+                break
+
+        self.alerts.append(alert)
+
+        self._write_alert(alert)
+
+    def _execute_actions(self, alert: Dict[str, Any], actions: List[Dict[str, Any]]) -> None:
+        """Execute actions for an alert."""
+        for action in actions:
+            if "warn" in action:
+                self._execute_warn_action(alert, action["warn"])
+
+    def _execute_warn_action(self, alert: Dict[str, Any], warn_config: Dict[str, Any]) -> None:
+        """Execute warn action."""
+        message = warn_config.get("msg", "Alert triggered")
+        templated_message = self._template_message(message, alert)
+
+        print(f"WARNING: {templated_message}", file=sys.stderr)
+
+        alert["action"] = "warn"
+        alert["message"] = templated_message
+
+    def _template_message(self, template: str, alert: Dict[str, Any]) -> str:
+        """Template a message with alert data."""
+        try:
+            context = {
+                "name": alert["metric"],
+                "value": alert["value"],
+                "step": alert["step"],
+                "rule_id": alert["rule_id"],
+                "ts": alert["ts"],
+                "metric": alert["metric"],
+            }
+            if alert.get("run_id"):
+                context["run_id"] = alert["run_id"]
+            if alert.get("tags"):
+                context["tags"] = alert["tags"]
+            if alert.get("meta"):
+                context["meta"] = alert["meta"]
+
+            return template.format(**context)
+        except (KeyError, ValueError):
+            return template
+
+    def _write_alert(self, alert: Dict[str, Any]) -> None:
+        """Write alert to alerts.jsonl file."""
+        with open(self.alerts_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(alert) + "\n")
+            f.flush()
+
+    def _write_report(self) -> None:
+        """Write summary report to JSON file."""
+        if not self.report_path:
+            return
+
+        report = {
+            "rules_summary": {
+                "total_rules": len(self.rule_engine.rules),
+                "activated_rules": len(self.rule_activation_counts),
+                "activation_counts": self.rule_activation_counts,
+                "first_activations": self.first_activations,
+                "last_activations": self.last_activations,
+            },
+            "last_seen_metrics": self.last_seen_metrics,
+            "total_alerts": len(self.alerts),
+        }
+
+        self.report_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.report_path, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2)
+
+
+def load_rules_from_yaml(yaml_path: Union[str, Path]) -> List[Rule]:
+    """Load rules from YAML file.
+
+    Args:
+        yaml_path: Path to YAML rules file
+
+    Returns:
+        List of Rule objects
+    """
+    with open(yaml_path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    rules = []
+    for rule_data in data.get("rules", []):
+        rules.append(Rule.from_dict(rule_data))
+
+    return rules

--- a/src/rldk/monitor/events.py
+++ b/src/rldk/monitor/events.py
@@ -1,0 +1,135 @@
+"""Canonical event schema and writer for framework-agnostic monitoring."""
+
+import json
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+
+@dataclass
+class CanonicalEvent:
+    """Canonical event schema for framework-agnostic monitoring.
+
+    Required fields:
+    - time: ISO8601 timestamp
+    - step: integer step number
+    - name: metric name string
+    - value: numeric value
+
+    Optional fields:
+    - run_id: unique run identifier
+    - tags: arbitrary key-value metadata
+    - meta: additional metadata
+    """
+    time: str
+    step: int
+    name: str
+    value: float
+    run_id: Optional[str] = None
+    tags: Optional[Dict[str, Any]] = None
+    meta: Optional[Dict[str, Any]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        result = {
+            "time": self.time,
+            "step": self.step,
+            "name": self.name,
+            "value": self.value,
+        }
+        if self.run_id is not None:
+            result["run_id"] = self.run_id
+        if self.tags is not None:
+            result["tags"] = self.tags
+        if self.meta is not None:
+            result["meta"] = self.meta
+        return result
+
+    def to_json(self) -> str:
+        """Convert to JSON string."""
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "CanonicalEvent":
+        """Create event from dictionary."""
+        return cls(
+            time=data["time"],
+            step=int(data["step"]),
+            name=str(data["name"]),
+            value=float(data["value"]),
+            run_id=data.get("run_id"),
+            tags=data.get("tags"),
+            meta=data.get("meta"),
+        )
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "CanonicalEvent":
+        """Create event from JSON string."""
+        data = json.loads(json_str)
+        return cls.from_dict(data)
+
+
+class EventWriter:
+    """Simple JSONL event writer for framework-agnostic logging."""
+
+    def __init__(self, path: Union[str, Path], run_id: Optional[str] = None):
+        """Initialize event writer.
+
+        Args:
+            path: Path to JSONL file to write to
+            run_id: Optional run ID to include in all events
+        """
+        self.path = Path(path)
+        self.run_id = run_id or f"run-{int(time.time())}"
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+        self._file = open(self.path, "a", buffering=1, encoding="utf-8")
+
+    def log(
+        self,
+        step: int,
+        name: str,
+        value: float,
+        time_iso: Optional[str] = None,
+        tags: Optional[Dict[str, Any]] = None,
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Log a single event.
+
+        Args:
+            step: Training step number
+            name: Metric name
+            value: Metric value
+            time_iso: ISO8601 timestamp (defaults to current time)
+            tags: Optional tags dictionary
+            meta: Optional metadata dictionary
+        """
+        if time_iso is None:
+            time_iso = datetime.utcnow().isoformat() + "Z"
+
+        event = CanonicalEvent(
+            time=time_iso,
+            step=step,
+            name=name,
+            value=value,
+            run_id=self.run_id,
+            tags=tags,
+            meta=meta,
+        )
+
+        self._file.write(event.to_json() + "\n")
+        self._file.flush()
+
+    def close(self) -> None:
+        """Close the file handle."""
+        if hasattr(self, "_file") and not self._file.closed:
+            self._file.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()

--- a/src/rldk/monitor/rules.py
+++ b/src/rldk/monitor/rules.py
@@ -1,0 +1,236 @@
+"""Rule engine for monitoring JSONL events."""
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, List
+
+
+class WindowKind(Enum):
+    """Window types for rule evaluation."""
+    CONSECUTIVE = "consecutive"
+    ROLLING = "rolling"
+
+
+@dataclass
+class Window:
+    """Window configuration for rule evaluation."""
+    size: int
+    kind: WindowKind = WindowKind.CONSECUTIVE
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Window":
+        """Create window from dictionary."""
+        return cls(
+            size=data["size"],
+            kind=WindowKind(data.get("kind", "consecutive"))
+        )
+
+
+@dataclass
+class Rule:
+    """Rule definition for monitoring events."""
+    id: str
+    where: str  # Python-like boolean filter
+    condition: str  # Expression on event window
+    window: Window
+    cooldown_steps: int = 0
+    grace_steps: int = 0
+    actions: List[Dict[str, Any]] = None
+
+    def __post_init__(self):
+        if self.actions is None:
+            self.actions = []
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Rule":
+        """Create rule from dictionary."""
+        window_data = data.get("window", {"size": 1, "kind": "consecutive"})
+        return cls(
+            id=data["id"],
+            where=data["where"],
+            condition=data["condition"],
+            window=Window.from_dict(window_data),
+            cooldown_steps=data.get("cooldown_steps", 0),
+            grace_steps=data.get("grace_steps", 0),
+            actions=data.get("actions", [])
+        )
+
+
+class RuleEngine:
+    """Engine for evaluating rules against event streams."""
+
+    def __init__(self, rules: List[Rule]):
+        """Initialize rule engine.
+
+        Args:
+            rules: List of rules to evaluate
+        """
+        self.rules = rules
+        self._metric_windows: Dict[str, List[Any]] = {}
+        self._rule_cooldowns: Dict[str, int] = {}
+        self._rule_grace_counters: Dict[str, int] = {}
+
+    def evaluate_event(self, event: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Evaluate a single event against all rules.
+
+        Args:
+            event: Event dictionary with canonical schema
+
+        Returns:
+            List of alert dictionaries for triggered rules
+        """
+        alerts = []
+
+        for rule in self.rules:
+            if not self._matches_where_clause(event, rule.where):
+                continue
+
+            metric_key = self._get_metric_key(event, rule)
+
+            self._update_window(metric_key, event, rule.window)
+
+            if not self._check_grace_period(rule, metric_key):
+                continue
+
+            if self._is_in_cooldown(rule, event["step"]):
+                continue
+
+            if self._evaluate_condition(metric_key, rule):
+                alert = self._create_alert(event, rule, metric_key)
+                alerts.append(alert)
+
+                self._rule_cooldowns[rule.id] = event["step"] + rule.cooldown_steps
+
+        return alerts
+
+    def _matches_where_clause(self, event: Dict[str, Any], where_clause: str) -> bool:
+        """Check if event matches the where clause."""
+        try:
+            expr = where_clause
+
+            expr = expr.replace('name', f'"{event.get("name", "")}"')
+            expr = expr.replace('step', str(event.get("step", 0)))
+            expr = expr.replace('value', str(event.get("value", 0)))
+
+            if "tags." in expr and event.get("tags"):
+                for key, value in event["tags"].items():
+                    tag_ref = f"tags.{key}"
+                    if isinstance(value, str):
+                        expr = expr.replace(tag_ref, f'"{value}"')
+                    else:
+                        expr = expr.replace(tag_ref, str(value))
+
+            return eval(expr)
+        except Exception:
+            return False
+
+    def _get_metric_key(self, event: Dict[str, Any], rule: Rule) -> str:
+        """Get unique key for metric windowing."""
+        key = event["name"]
+        if event.get("tags"):
+            tag_str = "&".join(f"{k}={v}" for k, v in sorted(event["tags"].items()))
+            key = f"{key}#{tag_str}"
+        return key
+
+    def _update_window(self, metric_key: str, event: Dict[str, Any], window: Window) -> None:
+        """Update the window for a metric."""
+        if metric_key not in self._metric_windows:
+            self._metric_windows[metric_key] = []
+
+        window_data = self._metric_windows[metric_key]
+        window_data.append(event)
+
+        if len(window_data) > window.size:
+            if window.kind == WindowKind.CONSECUTIVE:
+                self._metric_windows[metric_key] = window_data[-window.size:]
+            elif window.kind == WindowKind.ROLLING:
+                pass
+
+    def _check_grace_period(self, rule: Rule, metric_key: str) -> bool:
+        """Check if grace period has been satisfied."""
+        if rule.grace_steps == 0:
+            return True
+
+        if metric_key not in self._rule_grace_counters:
+            self._rule_grace_counters[metric_key] = 0
+
+        self._rule_grace_counters[metric_key] += 1
+        return self._rule_grace_counters[metric_key] >= rule.grace_steps
+
+    def _is_in_cooldown(self, rule: Rule, current_step: int) -> bool:
+        """Check if rule is in cooldown period."""
+        if rule.id not in self._rule_cooldowns:
+            return False
+        return current_step <= self._rule_cooldowns[rule.id]
+
+    def _evaluate_condition(self, metric_key: str, rule: Rule) -> bool:
+        """Evaluate the condition on the current window."""
+        if metric_key not in self._metric_windows:
+            return False
+
+        window_data = self._metric_windows[metric_key]
+        if not window_data:
+            return False
+
+        if rule.window.kind == WindowKind.CONSECUTIVE:
+            eval_window = window_data
+        else:  # rolling
+            eval_window = window_data[-rule.window.size:] if len(window_data) >= rule.window.size else window_data
+
+        if len(eval_window) < rule.window.size:
+            return False
+
+        try:
+            values = [event["value"] for event in eval_window]
+
+            condition = rule.condition
+
+            if eval_window:
+                condition = condition.replace("value", str(eval_window[-1]["value"]))
+
+            condition = condition.replace("mean(value)", str(sum(values) / len(values)))
+            condition = condition.replace("max(value)", str(max(values)))
+            condition = condition.replace("min(value)", str(min(values)))
+
+            any_pattern = r"any\(value\s*([><=!]+)\s*([\d.]+)\)"
+            match = re.search(any_pattern, condition)
+            if match:
+                op, threshold = match.groups()
+                threshold = float(threshold)
+                if op == ">":
+                    result = any(v > threshold for v in values)
+                elif op == ">=":
+                    result = any(v >= threshold for v in values)
+                elif op == "<":
+                    result = any(v < threshold for v in values)
+                elif op == "<=":
+                    result = any(v <= threshold for v in values)
+                elif op == "==":
+                    result = any(v == threshold for v in values)
+                elif op == "!=":
+                    result = any(v != threshold for v in values)
+                else:
+                    result = False
+                condition = condition.replace(match.group(0), str(result))
+
+            return eval(condition)
+        except Exception:
+            return False
+
+    def _create_alert(self, event: Dict[str, Any], rule: Rule, metric_key: str) -> Dict[str, Any]:
+        """Create alert dictionary for triggered rule."""
+        return {
+            "ts": event["time"],
+            "step": event["step"],
+            "rule_id": rule.id,
+            "metric": event["name"],
+            "value": event["value"],
+            "window": {
+                "size": rule.window.size,
+                "kind": rule.window.kind.value
+            },
+            "run_id": event.get("run_id"),
+            "tags": event.get("tags"),
+            "meta": event.get("meta"),
+        }


### PR DESCRIPTION
# feat: Add core streaming engine and minimal CLI for framework-agnostic monitoring

## Summary
This PR implements the first phase of framework-agnostic monitoring for RLDK, adding a core streaming engine and minimal CLI that can monitor any JSONL event stream without requiring TRL or other framework dependencies.

**Key Components Added:**
- **Canonical JSONL Schema**: Standardized event format with required fields (time, step, name, value) and optional fields (run_id, tags, meta)
- **Streaming Engine**: Robust JSONL reader supporting stdin, file following with rotation/truncation handling, and field mapping for non-canonical schemas
- **YAML Rule Engine**: Configurable rules with `where` filters, `condition` expressions, window evaluation (consecutive/rolling), grace periods, and cooldown
- **Warn-Only Actions**: Alerts written to `alerts.jsonl` and stderr/stdout (process stopping and other actions deferred to future PRs)
- **CLI Integration**: New `rldk monitor stream/once` and `rldk emit` commands integrated into existing CLI
- **EventWriter**: Simple framework-agnostic event emitter for any training loop

**Example Usage:**
```bash
# Stream monitoring with live alerts
rldk monitor stream artifacts/run.jsonl --rules rules.yaml

# Batch analysis with deterministic report
rldk monitor once artifacts/run.jsonl --rules rules.yaml --report report.json

# Emit events from any framework
rldk emit --to artifacts/run.jsonl --step 42 --name kl --value 0.35
```

The implementation includes a complete example (`examples/minimal_streaming_loop.py`) and test rules (`rules.yaml`) that demonstrate monitoring KL divergence with consecutive windows and rolling averages.

## Review & Testing Checklist for Human

**Critical Issues to Verify (4 items):**
- [ ] **Security Review**: The rule evaluation uses `eval()` for condition parsing - verify this doesn't introduce code injection risks with untrusted YAML rules
- [ ] **Streaming Robustness**: Test file rotation/truncation during streaming monitoring to ensure no events are lost or duplicated
- [ ] **CLI Integration**: Verify new monitor commands don't break existing CLI functionality and imports work correctly
- [ ] **Field Mapping Edge Cases**: Test field mapping with malformed events, missing fields, and type conversion edge cases

**Recommended Test Plan:**
1. Run the acceptance test: `python examples/minimal_streaming_loop.py &` then `rldk monitor stream artifacts/run.jsonl --rules rules.yaml` 
2. Compare streaming vs batch results: `rldk monitor once artifacts/run.jsonl --rules rules.yaml --report report.json`
3. Test field mapping: Create events with different schema and use `--field-map '{"s":"step","metric":"name","v":"value"}'`
4. Test stdin streaming: `python examples/minimal_streaming_loop.py | rldk monitor stream - --rules rules.yaml`

### Notes
- Process stopping and HTTP/shell actions are intentionally out of scope for this PR (warn-only implementation)
- Built on existing RLDK JSONL infrastructure but completely framework-agnostic - no TRL dependencies required
- All linting issues resolved with ruff/black formatting

**Session Details:**
- Link to Devin run: https://app.devin.ai/sessions/c884dcb72d324078a7150d0dafe1589f
- Requested by: @adityachallapally (avasanthc@gmail.com)