### PR TITLE
feat: add wandb/mlflow bridges and regex parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ rldk monitor --stream artifacts --rules ppo_strict --preset accelerate --pid <tr
 
 # Batch analysis of a finished run with a custom rules file
 rldk monitor --once artifacts/run.jsonl --rules my_rules.yaml --report artifacts/report.json
+
+# Stream hosted runs without touching trainer code
+rldk monitor --from-wandb my-entity/my-project/my-run --rules ppo_safe --alerts artifacts/wandb_alerts.jsonl
+rldk monitor --from-mlflow 0123456789abcdef --rules dpo_basic --alerts artifacts/mlflow_alerts.jsonl
+
+# Parse TRL stdout directly with regex sniffing
+python train_trl.py | rldk monitor --rules ppo_safe --regex trl --alerts artifacts/stdout_alerts.jsonl
 ```
 
 Key conveniences:
@@ -147,6 +154,8 @@ Key conveniences:
 - **Directory tailing** – Passing a directory to `--stream` automatically follows the newest `*.jsonl` file and handles rotation.
 - **Environment hook** – Set `RLDK_METRICS_PATH` to auto-tail a metrics file without specifying `--stream`; piping JSONL to stdin also just works.
 - **Ready-made emitter** – `examples/minimal_streaming_loop.py` shows how to emit canonical events and responds to monitor stop actions out of the box.
+- **Hosted run bridges** – `--from-wandb` and `--from-mlflow` follow remote projects with clear error messages and retry guards.
+- **Regex sniffing** – `--regex` (for example `--regex trl`) extracts metrics from stdout/stderr without changing your training loop.
 
 ### **Reward Model Health Analysis**
 Comprehensive reward model analysis and drift detection:

--- a/src/rldk/cli.py
+++ b/src/rldk/cli.py
@@ -54,6 +54,8 @@ from rldk.monitor import (
     load_rules,
     read_events_once,
     read_stream,
+    stream_from_mlflow,
+    stream_from_wandb,
 )
 from rldk.monitor.presets import FIELD_MAP_PRESETS, RULE_PRESETS, get_field_map_preset
 from rldk.emit import EventWriter
@@ -180,6 +182,16 @@ def monitor(
         readable=True,
         help="Analyze an existing JSONL metrics file once and exit.",
     ),
+    from_wandb: Optional[str] = typer.Option(
+        None,
+        "--from-wandb",
+        help="Stream metrics directly from a W&B run path (entity/project[/run_id]).",
+    ),
+    from_mlflow: Optional[str] = typer.Option(
+        None,
+        "--from-mlflow",
+        help="Stream metrics from an MLflow run ID using the active tracking URI.",
+    ),
     rules: str = typer.Option(
         ...,
         "--rules",
@@ -209,6 +221,11 @@ def monitor(
         None,
         "--field-map",
         help="JSON object mapping input keys to canonical event fields.",
+    ),
+    regex: Optional[str] = typer.Option(
+        None,
+        "--regex",
+        help="Regex preset or pattern to parse text logs (e.g. 'trl').",
     ),
     pid: Optional[int] = typer.Option(
         None,
@@ -247,15 +264,28 @@ def monitor(
     ensure_config_initialized()
     stream_source = stream
     once_source = once
+    wandb_source = from_wandb
+    mlflow_source = from_mlflow
     env_stream = os.environ.get("RLDK_METRICS_PATH")
-    if stream_source is None and once_source is None:
+    if (
+        stream_source is None
+        and once_source is None
+        and wandb_source is None
+        and mlflow_source is None
+    ):
         if env_stream:
             stream_source = env_stream
         elif not sys.stdin.isatty():
             stream_source = "-"
-    if (stream_source is None) == (once_source is None):
+    selections = [
+        stream_source is not None,
+        once_source is not None,
+        wandb_source is not None,
+        mlflow_source is not None,
+    ]
+    if sum(1 for selected in selections if selected) != 1:
         typer.echo(
-            "Provide exactly one of --stream or --once, or pipe metrics via stdin.",
+            "Provide exactly one source via --stream, --once, --from-wandb, or --from-mlflow (stdin also supported).",
             err=True,
         )
         raise typer.Exit(1)
@@ -288,13 +318,29 @@ def monitor(
             else:
                 typer.echo(message)
 
+    mode: str
+    if once_source is not None:
+        mode = "once"
+    elif wandb_source is not None:
+        mode = "wandb"
+    elif mlflow_source is not None:
+        mode = "mlflow"
+    else:
+        mode = "stream"
+
     try:
-        if stream_source is not None:
-            for event in read_stream(stream_source, field_map=mapping):
+        if mode == "stream":
+            for event in read_stream(stream_source, field_map=mapping, regex=regex):
                 emit_alerts(engine.process_event(event))
-        else:
-            events = read_events_once(once_source, field_map=mapping)
+        elif mode == "once":
+            events = read_events_once(once_source, field_map=mapping, regex=regex)
             for event in events:
+                emit_alerts(engine.process_event(event))
+        elif mode == "wandb":
+            for event in stream_from_wandb(wandb_source):
+                emit_alerts(engine.process_event(event))
+        elif mode == "mlflow":
+            for event in stream_from_mlflow(mlflow_source):
                 emit_alerts(engine.process_event(event))
     except KeyboardInterrupt:
         typer.echo("Monitoring interrupted by user", err=True)
@@ -302,6 +348,13 @@ def monitor(
         pass
     except typer.Exit:
         raise
+    except ValueError as exc:
+        typer.echo(f"Failed to parse metrics: {exc}", err=True)
+        raise typer.Exit(1)
+    except RuntimeError as exc:
+        message = str(exc) or exc.__class__.__name__
+        typer.echo(f"Monitoring failed: {message}", err=True)
+        raise typer.Exit(1)
     except Exception as exc:
         message = str(exc) or exc.__class__.__name__
         typer.echo(f"Monitoring failed: {message}", err=True)
@@ -316,7 +369,7 @@ def monitor(
         except Exception as exc:
             typer.echo(f"Failed to write report: {exc}", err=True)
             raise typer.Exit(1)
-    elif once is not None:
+    elif once_source is not None:
         typer.echo(json.dumps(report_payload, indent=2, sort_keys=True))
 
 

--- a/src/rldk/monitor/__init__.py
+++ b/src/rldk/monitor/__init__.py
@@ -1,5 +1,6 @@
 """Monitoring utilities for processing JSONL training events."""
 
+from .bridges import stream_from_mlflow, stream_from_wandb
 from .engine import (
     ActionConfig,
     ActionDispatcher,
@@ -28,4 +29,6 @@ __all__ = [
     "load_rules",
     "read_events_once",
     "read_stream",
+    "stream_from_mlflow",
+    "stream_from_wandb",
 ]

--- a/src/rldk/monitor/bridges.py
+++ b/src/rldk/monitor/bridges.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import logging
+import math
+import time
+from datetime import datetime, timezone
+from numbers import Number
+from typing import Any, Dict, Iterable, Iterator, Optional, Sequence, Tuple
+
+from .engine import Event, _now_iso, canonicalize_event
+
+logger = logging.getLogger(__name__)
+
+_WANDB_TRANSIENT_TOKENS = ("rate limit", "temporarily unavailable", "timeout", "timed out", "connection", "429", "502", "503")
+_MLFLOW_TRANSIENT_TOKENS = ("temporarily unavailable", "timeout", "connection", "429", "502", "503")
+_WANDB_SKIP_KEYS = {
+    "_step",
+    "_timestamp",
+    "_runtime",
+    "_session_id",
+    "_wandb",
+    "_runtime_seconds",
+    "global_step",
+    "epoch",
+    "_metric_system",
+    "_metric_variant",
+    "_runtime_ms",
+    "_runtime_min",
+    "_runtime_epoch",
+    "_runtime_hr",
+    "_runtime_day",
+    "_timestamp_seconds",
+    "_timestamp_ms",
+    "_timestamp_min",
+    "_timestamp_hour",
+    "_timestamp_day",
+    "_index",
+    "_batch",
+    "_runtime_total",
+    "_runtime_iter",
+    "_runtime_step",
+}
+
+
+def _timestamp_to_iso(timestamp: Any) -> str:
+    if timestamp is None:
+        return _now_iso()
+    try:
+        value = float(timestamp)
+    except (TypeError, ValueError):
+        return _now_iso()
+    if value > 1e12:
+        value /= 1000.0
+    try:
+        parsed = datetime.fromtimestamp(value, tz=timezone.utc)
+    except (OSError, OverflowError):
+        return _now_iso()
+    return parsed.isoformat().replace("+00:00", "Z")
+
+
+def _sanitize_tags(tags: Dict[str, Any]) -> Dict[str, Any]:
+    return {key: value for key, value in tags.items() if value not in (None, "")}
+
+
+def _is_numeric(value: Any) -> bool:
+    if not isinstance(value, Number):
+        return False
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return False
+    return math.isfinite(numeric)
+
+
+def _should_retry(message: str, tokens: Sequence[str]) -> bool:
+    lowered = message.lower()
+    return any(token in lowered for token in tokens)
+
+
+def _parse_wandb_target(target: str) -> Tuple[str, str, Optional[str]]:
+    raw = target.strip()
+    if raw.startswith("wandb://"):
+        raw = raw[len("wandb://") :]
+    parts = [part for part in raw.split("/") if part]
+    if len(parts) == 3:
+        return parts[0], parts[1], parts[2]
+    if len(parts) == 2:
+        return parts[0], parts[1], None
+    raise ValueError(
+        "W&B target must be formatted as 'entity/project/run_id' or 'entity/project'"
+    )
+
+
+def stream_from_wandb(
+    target: str,
+    poll_interval: float = 5.0,
+    idle_sleep: float = 5.0,
+) -> Iterator[Event]:
+    """Stream metrics from a W&B run or project."""
+
+    try:
+        import wandb  # type: ignore
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError(
+            "wandb package is required for --from-wandb. Install with 'pip install wandb'."
+        ) from exc
+
+    try:
+        entity, project, run_id = _parse_wandb_target(target)
+    except ValueError as exc:
+        raise RuntimeError(str(exc)) from exc
+
+    api = wandb.Api()
+    run = None
+    resolved_target = None
+    try:
+        if run_id:
+            resolved_target = f"{entity}/{project}/{run_id}"
+            run = api.run(resolved_target)
+        else:
+            candidates = list(
+                api.runs(f"{entity}/{project}", order="-updated_at", per_page=1)
+            )
+            if not candidates:
+                raise RuntimeError(
+                    f"No runs found for W&B project '{entity}/{project}'."
+                )
+            run = candidates[0]
+            resolved_target = f"{entity}/{project}/{run.id}"
+    except Exception as exc:  # pragma: no cover - network interaction
+        raise RuntimeError(f"Failed to resolve W&B run '{target}': {exc}") from exc
+
+    logger.info(
+        "Streaming metrics from W&B run %s (%s/%s)",
+        getattr(run, "id", resolved_target),
+        getattr(run, "entity", entity),
+        getattr(run, "project", project),
+    )
+
+    seen: set[Tuple[str, int, Optional[float], Optional[float]]] = set()
+    last_step = -1
+    backoff = poll_interval
+    while True:
+        try:
+            run.reload()
+            history: Iterable[Dict[str, Any]] = run.scan_history(
+                page_size=500, min_step=max(last_step + 1, 0)
+            )
+        except Exception as exc:  # pragma: no cover - network interaction
+            wait = min(max(backoff, poll_interval), 60.0)
+            message = str(exc) or exc.__class__.__name__
+            if _should_retry(message, _WANDB_TRANSIENT_TOKENS):
+                logger.warning("W&B API unavailable (%s). Retrying in %.1fs", message, wait)
+                time.sleep(wait)
+                backoff = min(wait * 2, 60.0)
+                continue
+            raise RuntimeError(f"W&B streaming failed: {message}") from exc
+        emitted = False
+        backoff = poll_interval
+        for row in history:
+            step_raw = row.get("_step") or row.get("step") or row.get("global_step")
+            try:
+                step = int(step_raw) if step_raw is not None else None
+            except (TypeError, ValueError):
+                step = None
+            if step is None:
+                continue
+            last_step = max(last_step, step)
+            timestamp = _timestamp_to_iso(row.get("_timestamp"))
+            tags = _sanitize_tags(
+                {
+                    "source": "wandb",
+                    "wandb_entity": getattr(run, "entity", entity),
+                    "wandb_project": getattr(run, "project", project),
+                    "wandb_run": getattr(run, "id", None),
+                }
+            )
+            meta: Dict[str, Any] = {}
+            if getattr(run, "url", None):
+                meta["wandb_url"] = run.url
+            for key, value in row.items():
+                if key in _WANDB_SKIP_KEYS or key.startswith("_"):
+                    continue
+                if not _is_numeric(value):
+                    continue
+                signature = (key, step, row.get("_timestamp"), row.get("_runtime"))
+                if signature in seen:
+                    continue
+                seen.add(signature)
+                payload = {
+                    "time": timestamp,
+                    "step": step,
+                    "name": key,
+                    "value": float(value),
+                    "run_id": getattr(run, "id", resolved_target),
+                    "tags": tags,
+                }
+                if meta:
+                    payload["meta"] = meta
+                try:
+                    event = canonicalize_event(payload, None)
+                except ValueError as exc:
+                    logger.debug(
+                        "Skipping W&B metric %s at step %s: %s", key, step, exc
+                    )
+                    continue
+                emitted = True
+                yield event
+        if not emitted:
+            time.sleep(idle_sleep)
+
+
+def stream_from_mlflow(
+    run_id: str,
+    poll_interval: float = 5.0,
+) -> Iterator[Event]:
+    """Stream metrics from an MLflow run."""
+
+    try:
+        from mlflow.tracking import MlflowClient  # type: ignore
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError(
+            "mlflow package is required for --from-mlflow. Install with 'pip install mlflow'."
+        ) from exc
+
+    client = MlflowClient()
+    try:
+        run = client.get_run(run_id)
+    except Exception as exc:  # pragma: no cover - network interaction
+        raise RuntimeError(f"Failed to load MLflow run '{run_id}': {exc}") from exc
+
+    known_metrics = set(run.data.metrics.keys())
+    metric_offsets: Dict[str, int] = {name: 0 for name in known_metrics}
+    backoff = poll_interval
+
+    while True:
+        try:
+            run = client.get_run(run_id)
+        except Exception as exc:  # pragma: no cover - network interaction
+            wait = min(max(backoff, poll_interval), 60.0)
+            message = str(exc) or exc.__class__.__name__
+            if _should_retry(message, _MLFLOW_TRANSIENT_TOKENS):
+                logger.warning(
+                    "MLflow tracking API unavailable (%s). Retrying in %.1fs", message, wait
+                )
+                time.sleep(wait)
+                backoff = min(wait * 2, 60.0)
+                continue
+            raise RuntimeError(f"MLflow streaming failed: {message}") from exc
+
+        backoff = poll_interval
+        tags = dict(run.data.tags)
+        experiment_id = getattr(run.info, "experiment_id", None)
+        run_name = getattr(run.info, "run_name", None)
+        source_tags = _sanitize_tags(
+            {
+                "source": "mlflow",
+                "mlflow_experiment_id": experiment_id,
+                "mlflow_run_name": run_name,
+            }
+        )
+        metric_names = set(run.data.metrics.keys()) | known_metrics
+        known_metrics = metric_names
+        emitted = False
+        for name in sorted(metric_names):
+            try:
+                history = client.get_metric_history(run_id, name)
+            except Exception as exc:  # pragma: no cover - network interaction
+                message = str(exc) or exc.__class__.__name__
+                if _should_retry(message, _MLFLOW_TRANSIENT_TOKENS):
+                    wait = min(max(backoff, poll_interval), 60.0)
+                    logger.warning(
+                        "MLflow metric fetch failed for %s (%s). Retrying in %.1fs",
+                        name,
+                        message,
+                        wait,
+                    )
+                    time.sleep(wait)
+                    backoff = min(wait * 2, 60.0)
+                    continue
+                logger.error("Failed to fetch MLflow history for %s: %s", name, message)
+                continue
+            offset = metric_offsets.get(name, 0)
+            if offset >= len(history):
+                continue
+            for metric in history[offset:]:
+                if not _is_numeric(metric.value):
+                    continue
+                value = float(metric.value)
+                timestamp_value = getattr(metric, "timestamp", None)
+                timestamp = _timestamp_to_iso(
+                    (timestamp_value / 1000.0) if timestamp_value is not None else None
+                )
+                payload = {
+                    "time": timestamp,
+                    "step": int(metric.step),
+                    "name": name,
+                    "value": value,
+                    "run_id": run_id,
+                    "tags": source_tags,
+                }
+                if tags:
+                    payload["meta"] = {"mlflow_tags": dict(tags)}
+                try:
+                    event = canonicalize_event(payload, None)
+                except ValueError as exc:
+                    logger.debug(
+                        "Skipping MLflow metric %s at step %s: %s", name, metric.step, exc
+                    )
+                    continue
+                emitted = True
+                yield event
+            metric_offsets[name] = len(history)
+        if not emitted:
+            time.sleep(poll_interval)
+
+
+__all__ = ["stream_from_mlflow", "stream_from_wandb"]

--- a/src/rldk/monitor/engine.py
+++ b/src/rldk/monitor/engine.py
@@ -31,6 +31,7 @@ from typing import (
 import yaml
 
 from .presets import RULE_PRESETS, get_rule_preset
+from .regexes import create_line_parser
 
 logger = logging.getLogger(__name__)
 
@@ -447,7 +448,11 @@ def canonicalize_event(payload: Dict[str, Any], field_map: Optional[Dict[str, st
     )
 
 
-def read_events_once(path: str | os.PathLike[str], field_map: Optional[Dict[str, str]] = None) -> List[Event]:
+def read_events_once(
+    path: str | os.PathLike[str],
+    field_map: Optional[Dict[str, str]] = None,
+    regex: Optional[str] = None,
+) -> List[Event]:
     path_obj = Path(path)
     if not path_obj.exists():
         raise FileNotFoundError(f"Event log '{path}' does not exist")
@@ -468,29 +473,94 @@ def read_events_once(path: str | os.PathLike[str], field_map: Optional[Dict[str,
                     yield line
 
         opener = _open_text
+    parser = create_line_parser(regex) if regex else None
     events: List[Event] = []
+    auto_step = 0
+
+    def _next_auto_step() -> int:
+        nonlocal auto_step
+        auto_step += 1
+        return auto_step
+
     for line in opener(path_obj):
         line = line.strip()
         if not line:
             continue
-        try:
-            payload = json.loads(line)
-        except json.JSONDecodeError as exc:
-            logger.warning("Failed to parse JSON event: %s", exc)
-            continue
-        try:
-            events.append(canonicalize_event(payload, field_map))
-        except ValueError as exc:
-            logger.warning("Skipping invalid event: %s", exc)
+        if parser is None:
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError as exc:
+                logger.warning("Failed to parse JSON event: %s", exc)
+                continue
+            try:
+                events.append(canonicalize_event(payload, field_map))
+            except ValueError as exc:
+                logger.warning("Skipping invalid event: %s", exc)
+        else:
+            try:
+                parsed_events = list(parser.parse(line))
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("Regex parser failed for line: %s", exc)
+                continue
+            for payload in parsed_events:
+                data = dict(payload)
+                data.setdefault("time", _now_iso())
+                data.setdefault("step", _next_auto_step())
+                try:
+                    events.append(canonicalize_event(data, field_map))
+                except ValueError as exc:
+                    logger.warning("Skipping invalid parsed event: %s", exc)
     return events
 
 
 def read_stream(
     path_or_stdin: str | os.PathLike[str],
     field_map: Optional[Dict[str, str]] = None,
+    regex: Optional[str] = None,
     poll_interval: float = 0.5,
 ) -> Iterator[Event]:
     """Yield canonical events from a stream, following file rotations."""
+
+    parser = create_line_parser(regex) if regex else None
+    auto_step = 0
+
+    def _next_auto_step() -> int:
+        nonlocal auto_step
+        auto_step += 1
+        return auto_step
+
+    def _line_events(line: str) -> Iterable[Event]:
+        nonlocal auto_step
+        if parser is None:
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError as exc:
+                logger.warning("Failed to parse JSON event: %s", exc)
+                return []
+            try:
+                event = canonicalize_event(payload, field_map)
+                auto_step = max(auto_step, event.step)
+                return [event]
+            except ValueError as exc:
+                logger.warning("Skipping invalid event: %s", exc)
+                return []
+        try:
+            parsed_payloads = list(parser.parse(line)) if parser else []
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Regex parser failed for line: %s", exc)
+            return []
+        events: List[Event] = []
+        for payload in parsed_payloads:
+            data = dict(payload)
+            data.setdefault("time", _now_iso())
+            data.setdefault("step", _next_auto_step())
+            try:
+                event = canonicalize_event(data, field_map)
+                auto_step = max(auto_step, event.step)
+                events.append(event)
+            except ValueError as exc:
+                logger.warning("Skipping invalid parsed event: %s", exc)
+        return events
 
     if str(path_or_stdin) == "-":
         import sys
@@ -499,13 +569,8 @@ def read_stream(
             line = line.strip()
             if not line:
                 continue
-            try:
-                payload = json.loads(line)
-                yield canonicalize_event(payload, field_map)
-            except json.JSONDecodeError as exc:
-                logger.warning("Failed to parse JSON event from stdin: %s", exc)
-            except ValueError as exc:
-                logger.warning("Skipping invalid stdin event: %s", exc)
+            for event in _line_events(line):
+                yield event
         return
 
     raw_target = str(path_or_stdin)
@@ -593,13 +658,8 @@ def read_stream(
                     line = line.strip()
                     if not line:
                         continue
-                    try:
-                        payload = json.loads(line)
-                        yield canonicalize_event(payload, field_map)
-                    except json.JSONDecodeError as exc:
-                        logger.warning("Failed to parse JSON event: %s", exc)
-                    except ValueError as exc:
-                        logger.warning("Skipping invalid event: %s", exc)
+                    for event in _line_events(line):
+                        yield event
             else:
                 if active_path is None:
                     time.sleep(poll_interval)

--- a/src/rldk/monitor/regexes.py
+++ b/src/rldk/monitor/regexes.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+_NAME_ALIASES: Sequence[str] = (
+    "name",
+    "metric",
+    "metric_name",
+    "key",
+)
+_VALUE_ALIASES: Sequence[str] = (
+    "value",
+    "v",
+    "scalar",
+    "metric_value",
+)
+_STEP_ALIASES: Sequence[str] = (
+    "step",
+    "steps",
+    "global_step",
+    "s",
+    "iteration",
+    "iter",
+    "t",
+)
+_TIME_ALIASES: Sequence[str] = (
+    "time",
+    "timestamp",
+    "wall_time",
+    "walltime",
+    "ts",
+)
+_RUN_ALIASES: Sequence[str] = (
+    "run_id",
+    "run",
+    "runid",
+)
+
+
+class LineParser:
+    """Parse raw log lines into canonical event payloads."""
+
+    def __init__(self) -> None:
+        self._auto_step = 0
+
+    def parse(self, line: str) -> Iterable[Dict[str, Any]]:
+        raise NotImplementedError
+
+    def _next_step(self) -> int:
+        self._auto_step += 1
+        return self._auto_step
+
+    def _coerce_step(self, raw: Optional[str]) -> int:
+        if raw is None:
+            return self._next_step()
+        value = raw.strip()
+        if not value:
+            return self._next_step()
+        try:
+            step = int(float(value))
+        except (TypeError, ValueError):
+            return self._next_step()
+        if step > self._auto_step:
+            self._auto_step = step
+        return step
+
+    def _coerce_time(self, raw: Optional[str]) -> str:
+        if raw is None:
+            return _now_iso()
+        value = raw.strip()
+        if not value:
+            return _now_iso()
+        try:
+            timestamp = float(value)
+        except (TypeError, ValueError):
+            try:
+                parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError:
+                return _now_iso()
+            return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+        if timestamp > 1e12:
+            timestamp = timestamp / 1000.0
+        try:
+            parsed = datetime.fromtimestamp(timestamp, tz=timezone.utc)
+        except (OSError, OverflowError):
+            return _now_iso()
+        return parsed.isoformat().replace("+00:00", "Z")
+
+
+def _first(groups: Dict[str, Any], aliases: Sequence[str]) -> Optional[str]:
+    for key in aliases:
+        value = groups.get(key)
+        if value not in (None, ""):
+            return str(value)
+    return None
+
+
+class RegexLineParser(LineParser):
+    """Parse metrics using a user-provided regular expression."""
+
+    def __init__(self, pattern: re.Pattern[str]) -> None:
+        super().__init__()
+        self._pattern = pattern
+
+    def parse(self, line: str) -> Iterable[Dict[str, Any]]:
+        events: List[Dict[str, Any]] = []
+        current_step: Optional[int] = None
+        current_time: Optional[str] = None
+        current_run: Optional[str] = None
+        for match in self._pattern.finditer(line):
+            groups = {key: value for key, value in match.groupdict().items() if value is not None}
+            if not groups:
+                continue
+            name_value = _first(groups, _NAME_ALIASES)
+            value_value = _first(groups, _VALUE_ALIASES)
+            if name_value is None or value_value is None:
+                continue
+            step_token = _first(groups, _STEP_ALIASES)
+            if step_token is not None:
+                step_value = self._coerce_step(step_token)
+                current_step = step_value
+            elif current_step is not None:
+                step_value = current_step
+            else:
+                step_value = self._next_step()
+                current_step = step_value
+            time_token = _first(groups, _TIME_ALIASES)
+            if time_token is not None:
+                time_value = self._coerce_time(time_token)
+                current_time = time_value
+            else:
+                time_value = current_time or _now_iso()
+                current_time = time_value
+            run_token = _first(groups, _RUN_ALIASES)
+            if run_token is not None:
+                current_run = run_token.strip()
+            event: Dict[str, Any] = {
+                "name": name_value.strip(),
+                "value": value_value.strip(),
+                "step": step_value,
+                "time": time_value,
+            }
+            if current_run:
+                event["run_id"] = current_run
+            events.append(event)
+        return events
+
+
+class TRLLineParser(LineParser):
+    """Parse TRL-style key/value metrics from stdout/stderr."""
+
+    _PAIR = re.compile(
+        r"(?P<key>[A-Za-z0-9_./-]+)\s*(?:=|:)\s*(?P<value>[-+]?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?)(?=[\s,;]|$)"
+    )
+    _STEP_KEYS = {"step", "steps", "global_step", "iteration", "iter"}
+    _TIME_KEYS = {"time", "timestamp", "wall_time", "walltime"}
+    _RUN_KEYS = {"run", "run_id"}
+
+    def parse(self, line: str) -> Iterable[Dict[str, Any]]:
+        matches = list(self._PAIR.finditer(line))
+        if not matches:
+            return []
+        metrics: List[Dict[str, Any]] = []
+        step_value: Optional[int] = None
+        time_value: Optional[str] = None
+        run_value: Optional[str] = None
+        for match in matches:
+            key = match.group("key")
+            raw_value = match.group("value")
+            if key is None or raw_value is None:
+                continue
+            normalized_key = key.strip()
+            lower = normalized_key.lower()
+            if lower in self._STEP_KEYS:
+                step_value = self._coerce_step(raw_value)
+                continue
+            if lower in self._TIME_KEYS:
+                time_value = self._coerce_time(raw_value)
+                continue
+            if lower in self._RUN_KEYS:
+                run_value = raw_value.strip()
+                continue
+            metrics.append({"name": normalized_key, "value": raw_value})
+        if not metrics:
+            return []
+        if step_value is None:
+            step_value = self._next_step()
+        time_iso = time_value or _now_iso()
+        events: List[Dict[str, Any]] = []
+        for metric in metrics:
+            event = {
+                "name": metric["name"],
+                "value": metric["value"],
+                "step": step_value,
+                "time": time_iso,
+            }
+            if run_value:
+                event["run_id"] = run_value
+            events.append(event)
+        return events
+
+
+def create_line_parser(spec: str) -> LineParser:
+    """Create a line parser from a preset name or regular expression."""
+
+    if spec is None:
+        raise ValueError("Regex specification must not be None")
+    pattern = spec.strip()
+    if not pattern:
+        raise ValueError("Regex specification must be a non-empty string")
+    preset = pattern.lower()
+    if preset == "trl":
+        return TRLLineParser()
+    try:
+        compiled = re.compile(pattern)
+    except re.error as exc:
+        raise ValueError(f"Invalid regex pattern '{spec}': {exc}") from exc
+    return RegexLineParser(compiled)
+
+
+__all__ = ["LineParser", "create_line_parser"]

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -16,7 +16,15 @@ from typer.testing import CliRunner
 
 from rldk.cli import app
 from rldk.emit import EventWriter
-from rldk.monitor import ActionDispatcher, Alert, Event, MonitorEngine, load_rules, read_stream
+from rldk.monitor import (
+    ActionDispatcher,
+    Alert,
+    Event,
+    MonitorEngine,
+    load_rules,
+    read_events_once,
+    read_stream,
+)
 
 
 @pytest.fixture
@@ -104,6 +112,49 @@ def test_read_stream_handles_rotation(tmp_path: Path) -> None:
         assert event2.step == 2
     finally:
         gen.close()
+
+
+def test_read_events_once_regex_trl(tmp_path: Path) -> None:
+    log_path = tmp_path / "stdout.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "step=1 kl=0.31 reward=-0.10",
+                "step=2 kl=0.62 reward=-0.05",
+            ]
+        )
+        + "\n"
+    )
+
+    events = read_events_once(log_path, regex="trl")
+    sequence = [(event.step, event.name) for event in events]
+    assert sequence == [(1, "kl"), (1, "reward"), (2, "kl"), (2, "reward")]
+    kl_values = [event.value for event in events if event.name == "kl"]
+    assert kl_values == pytest.approx([0.31, 0.62])
+
+
+def test_read_stream_regex_pattern(tmp_path: Path) -> None:
+    path = tmp_path / "metrics.log"
+    pattern = r"step=(?P<step>\d+)\s+metric=(?P<name>\w+)\s+value=(?P<value>[-+0-9.]+)"
+
+    def writer() -> None:
+        with path.open("w", encoding="utf-8") as handle:
+            for step, value in enumerate([0.2, 0.4, 0.6], start=1):
+                handle.write(f"step={step} metric=kl value={value}\n")
+                handle.flush()
+                time.sleep(0.01)
+
+    thread = threading.Thread(target=writer)
+    thread.start()
+    gen = read_stream(path, regex=pattern, poll_interval=0.01)
+    try:
+        events = [next(gen), next(gen), next(gen)]
+    finally:
+        gen.close()
+    thread.join()
+
+    assert [event.step for event in events] == [1, 2, 3]
+    assert [event.value for event in events] == pytest.approx([0.2, 0.4, 0.6])
 
 
 def test_monitor_engine_warn_action(tmp_path: Path) -> None:
@@ -488,6 +539,137 @@ def test_monitor_cli_field_map_preset(tmp_path: Path, runner: CliRunner) -> None
     assert report["rules"]["ppo_high_kl_guard"]["activations"] >= 1
     assert any(alert["rule_id"] == "ppo_high_kl_guard" for alert in report["alerts"])
 
+
+def test_monitor_cli_regex_preset(tmp_path: Path, runner: CliRunner) -> None:
+    log_path = tmp_path / "stdout.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "step=1 kl=0.30 reward=0.10",
+                "step=2 kl=0.60 reward=0.15",
+            ]
+        )
+        + "\n"
+    )
+    rules_path = tmp_path / "rules.yaml"
+    rules_path.write_text(
+        """
+rules:
+  - id: regex_kl_stop
+    where: name == "kl"
+    condition: value > 0.5
+    actions:
+      - warn: {}
+"""
+    )
+    report_path = tmp_path / "report.json"
+    alerts_path = tmp_path / "alerts.jsonl"
+
+    result = runner.invoke(
+        app,
+        [
+            "monitor",
+            "--once",
+            str(log_path),
+            "--rules",
+            str(rules_path),
+            "--regex",
+            "trl",
+            "--report",
+            str(report_path),
+            "--alerts",
+            str(alerts_path),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    alerts = [json.loads(line) for line in alerts_path.read_text().splitlines()]
+    assert len(alerts) == 1
+    assert alerts[0]["rule_id"] == "regex_kl_stop"
+
+
+def test_monitor_cli_from_wandb(monkeypatch, tmp_path: Path, runner: CliRunner) -> None:
+    rules_path = tmp_path / "rules.yaml"
+    rules_path.write_text(
+        """
+rules:
+  - id: kl_gate
+    where: name == "kl"
+    condition: value > 0.5
+    actions:
+      - warn: {}
+"""
+    )
+    events = [
+        Event(time=_now_iso(), step=1, name="kl", value=0.4),
+        Event(time=_now_iso(), step=2, name="kl", value=0.7),
+    ]
+
+    def fake_stream(target: str):
+        for event in events:
+            yield event
+
+    monkeypatch.setattr("rldk.cli.stream_from_wandb", fake_stream)
+
+    alerts_path = tmp_path / "alerts.jsonl"
+    report_path = tmp_path / "report.json"
+    result = runner.invoke(
+        app,
+        [
+            "monitor",
+            "--from-wandb",
+            "entity/project/run",
+            "--rules",
+            str(rules_path),
+            "--alerts",
+            str(alerts_path),
+            "--report",
+            str(report_path),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    payloads = [json.loads(line) for line in alerts_path.read_text().splitlines()]
+    assert any(alert["step"] == 2 for alert in payloads)
+
+
+def test_monitor_cli_from_mlflow(monkeypatch, tmp_path: Path, runner: CliRunner) -> None:
+    rules_path = tmp_path / "rules.yaml"
+    rules_path.write_text(
+        """
+rules:
+  - id: reward_warn
+    where: name == "reward"
+    condition: value < 0.0
+    actions:
+      - warn: {}
+"""
+    )
+    events = [
+        Event(time=_now_iso(), step=1, name="reward", value=0.2),
+        Event(time=_now_iso(), step=2, name="reward", value=-0.3),
+    ]
+
+    def fake_mlflow(run_id: str):
+        for event in events:
+            yield event
+
+    monkeypatch.setattr("rldk.cli.stream_from_mlflow", fake_mlflow)
+
+    alerts_path = tmp_path / "alerts.jsonl"
+    result = runner.invoke(
+        app,
+        [
+            "monitor",
+            "--from-mlflow",
+            "fake-run-id",
+            "--rules",
+            str(rules_path),
+            "--alerts",
+            str(alerts_path),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    alerts = [json.loads(line) for line in alerts_path.read_text().splitlines()]
+    assert any(alert["step"] == 2 and alert["name"] == "reward" for alert in alerts)
 
 def test_monitor_cli_defaults_to_stdin(tmp_path: Path, runner: CliRunner) -> None:
     events = []


### PR DESCRIPTION
## Summary
- add streaming bridges for W&B and MLflow runs with retry-aware error handling
- extend monitor readers with regex parsing support and wire new CLI options
- cover hosted bridges and regex flows with CLI/unit tests and update docs

## Testing
- pytest tests/test_monitor_core.py

------
https://chatgpt.com/codex/tasks/task_e_68c9e97e19c8832f8328ebcc30a9aa48