### PR TITLE
Add release acceptance monitor gate to CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,18 @@ jobs:
       run: |
         chmod +x scripts/release_check.sh
         source .venv/bin/activate && ./scripts/release_check.sh
-    
+
+    - name: Upload monitor acceptance artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: rldk-monitor-acceptance-${{ matrix.python-version }}
+        path: |
+          artifacts/release_acceptance_alerts.jsonl
+          artifacts/release_acceptance_report.json
+          artifacts/release_acceptance_replay_report.json
+        if-no-files-found: error
+        retention-days: 30
+
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/scripts/release_check.sh
+++ b/scripts/release_check.sh
@@ -95,19 +95,22 @@ monitor_pid=""
 
 sleep 2
 
-if ! rldk monitor \
+rldk monitor \
     --stream "${metrics_path}" \
     --rules "${project_root}/rules.yaml" \
     --pid "${loop_pid}" \
     --alerts "${alerts_path}" \
     --report "${report_path}" \
-    >"${monitor_log}" 2>&1 & then
+    >"${monitor_log}" 2>&1 &
+monitor_launch_status=$?
+monitor_pid=$!
+if [[ ${monitor_launch_status} -ne 0 ]]; then
+    monitor_pid=""
     echo "❌ Failed to launch streaming monitor. Logs:" >&2
     cat "${monitor_log}" >&2 || true
     cat "${loop_log}" >&2 || true
     exit 1
 fi
-monitor_pid=$!
 
 if ! wait "${loop_pid}" >/dev/null 2>&1; then
     echo "❌ Minimal streaming loop exited with an error. Logs:" >&2

--- a/scripts/release_check.sh
+++ b/scripts/release_check.sh
@@ -52,6 +52,120 @@ python3 -m ruff check || {
     echo "   These should be addressed in future releases."
 }
 
+# Run acceptance gate using the minimal streaming loop
+echo "🛡️ Running monitor acceptance gate..."
+project_root="$(pwd)"
+acceptance_dir="$(mktemp -d "${project_root}/artifacts/release_acceptance.XXXXXX")"
+metrics_path="${acceptance_dir}/artifacts/run.jsonl"
+alerts_path="${acceptance_dir}/artifacts/alerts.jsonl"
+report_path="${acceptance_dir}/artifacts/report.json"
+replay_report_path="${acceptance_dir}/artifacts/report_replay.json"
+monitor_log="${acceptance_dir}/monitor.log"
+loop_log="${acceptance_dir}/loop.log"
+replay_log="${acceptance_dir}/replay.log"
+final_alerts_path="${project_root}/artifacts/release_acceptance_alerts.jsonl"
+final_report_path="${project_root}/artifacts/release_acceptance_report.json"
+final_replay_report_path="${project_root}/artifacts/release_acceptance_replay_report.json"
+rm -f "${final_alerts_path}" "${final_report_path}" "${final_replay_report_path}"
+
+cleanup_acceptance() {
+    if [[ -n "${loop_pid:-}" ]]; then
+        kill -TERM "${loop_pid}" >/dev/null 2>&1 || true
+        wait "${loop_pid}" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "${acceptance_dir:-}" && -d "${acceptance_dir}" ]]; then
+        rm -rf "${acceptance_dir}"
+    fi
+}
+trap cleanup_acceptance EXIT
+
+cd "${acceptance_dir}"
+
+RLDK_METRICS_PATH="${metrics_path}" \
+PYTHONPATH="${project_root}/src${PYTHONPATH:+:${PYTHONPATH}}" \
+python "${project_root}/examples/minimal_streaming_loop.py" \
+    >"${loop_log}" 2>&1 &
+loop_pid=$!
+
+sleep 2
+
+if ! timeout 120s rldk monitor \
+    --stream "${metrics_path}" \
+    --rules "${project_root}/rules.yaml" \
+    --pid "${loop_pid}" \
+    --alerts "${alerts_path}" \
+    --report "${report_path}" \
+    >"${monitor_log}" 2>&1; then
+    echo "❌ Streaming monitor run failed. Logs:" >&2
+    cat "${monitor_log}" >&2 || true
+    cat "${loop_log}" >&2 || true
+    exit 1
+fi
+
+wait "${loop_pid}" >/dev/null 2>&1 || true
+loop_pid=""
+
+for required_path in "${alerts_path}" "${report_path}"; do
+    if [[ ! -s "${required_path}" ]]; then
+        echo "❌ Expected artifact '${required_path}' was not created." >&2
+        cat "${monitor_log}" >&2 || true
+        cat "${loop_log}" >&2 || true
+        exit 1
+    fi
+done
+
+if ! timeout 60s rldk monitor \
+    --once "${metrics_path}" \
+    --rules "${project_root}/rules.yaml" \
+    --report "${replay_report_path}" \
+    >"${replay_log}" 2>&1; then
+    echo "❌ Replay monitor run failed. Logs:" >&2
+    cat "${replay_log}" >&2 || true
+    exit 1
+fi
+
+if [[ ! -s "${replay_report_path}" ]]; then
+    echo "❌ Replay report '${replay_report_path}' was not created." >&2
+    cat "${replay_log}" >&2 || true
+    exit 1
+fi
+
+python3 - "${report_path}" "${replay_report_path}" <<'PYTHON'
+import json
+import sys
+
+stream_report = json.load(open(sys.argv[1], encoding="utf-8"))
+replay_report = json.load(open(sys.argv[2], encoding="utf-8"))
+
+stream_counts = {
+    rule_id: data.get("activations")
+    for rule_id, data in stream_report.get("rules", {}).items()
+}
+replay_counts = {
+    rule_id: data.get("activations")
+    for rule_id, data in replay_report.get("rules", {}).items()
+}
+
+if stream_counts != replay_counts:
+    sys.stderr.write("Activation counts differed between streaming and replay runs.\n")
+    sys.stderr.write(f"Streaming: {stream_counts}\n")
+    sys.stderr.write(f"Replay: {replay_counts}\n")
+    sys.exit(1)
+PYTHON
+
+cp "${alerts_path}" "${final_alerts_path}"
+cp "${report_path}" "${final_report_path}"
+cp "${replay_report_path}" "${final_replay_report_path}"
+
+cd "${project_root}"
+
+cleanup_acceptance
+trap - EXIT
+unset acceptance_dir
+unset loop_pid
+
+echo "✅ Monitor acceptance gate passed. Artifacts copied to artifacts/release_acceptance_*."
+
 # Build documentation
 echo "📚 Building documentation..."
 mkdocs build

--- a/scripts/release_check.sh
+++ b/scripts/release_check.sh
@@ -102,11 +102,18 @@ rldk monitor \
     --alerts "${alerts_path}" \
     --report "${report_path}" \
     >"${monitor_log}" 2>&1 &
-monitor_launch_status=$?
 monitor_pid=$!
-if [[ ${monitor_launch_status} -ne 0 ]]; then
+sleep 1
+if ! kill -0 "${monitor_pid}" >/dev/null 2>&1; then
+    monitor_status=0
+    if ! wait "${monitor_pid}" >/dev/null 2>&1; then
+        monitor_status=$?
+    fi
     monitor_pid=""
     echo "❌ Failed to launch streaming monitor. Logs:" >&2
+    if [[ ${monitor_status} -ne 0 ]]; then
+        echo "   Exit status: ${monitor_status}" >&2
+    fi
     cat "${monitor_log}" >&2 || true
     cat "${loop_log}" >&2 || true
     exit 1

--- a/scripts/release_check.sh
+++ b/scripts/release_check.sh
@@ -55,6 +55,7 @@ python3 -m ruff check || {
 # Run acceptance gate using the minimal streaming loop
 echo "🛡️ Running monitor acceptance gate..."
 project_root="$(pwd)"
+mkdir -p "${project_root}/artifacts"
 acceptance_dir="$(mktemp -d "${project_root}/artifacts/release_acceptance.XXXXXX")"
 metrics_path="${acceptance_dir}/artifacts/run.jsonl"
 alerts_path="${acceptance_dir}/artifacts/alerts.jsonl"
@@ -69,6 +70,10 @@ final_replay_report_path="${project_root}/artifacts/release_acceptance_replay_re
 rm -f "${final_alerts_path}" "${final_report_path}" "${final_replay_report_path}"
 
 cleanup_acceptance() {
+    if [[ -n "${monitor_pid:-}" ]]; then
+        kill -TERM "${monitor_pid}" >/dev/null 2>&1 || true
+        wait "${monitor_pid}" >/dev/null 2>&1 || true
+    fi
     if [[ -n "${loop_pid:-}" ]]; then
         kill -TERM "${loop_pid}" >/dev/null 2>&1 || true
         wait "${loop_pid}" >/dev/null 2>&1 || true
@@ -86,24 +91,49 @@ PYTHONPATH="${project_root}/src${PYTHONPATH:+:${PYTHONPATH}}" \
 python "${project_root}/examples/minimal_streaming_loop.py" \
     >"${loop_log}" 2>&1 &
 loop_pid=$!
+monitor_pid=""
 
 sleep 2
 
-if ! timeout 120s rldk monitor \
+if ! rldk monitor \
     --stream "${metrics_path}" \
     --rules "${project_root}/rules.yaml" \
     --pid "${loop_pid}" \
     --alerts "${alerts_path}" \
     --report "${report_path}" \
-    >"${monitor_log}" 2>&1; then
-    echo "❌ Streaming monitor run failed. Logs:" >&2
+    >"${monitor_log}" 2>&1 & then
+    echo "❌ Failed to launch streaming monitor. Logs:" >&2
     cat "${monitor_log}" >&2 || true
     cat "${loop_log}" >&2 || true
     exit 1
 fi
+monitor_pid=$!
 
-wait "${loop_pid}" >/dev/null 2>&1 || true
+if ! wait "${loop_pid}" >/dev/null 2>&1; then
+    echo "❌ Minimal streaming loop exited with an error. Logs:" >&2
+    cat "${loop_log}" >&2 || true
+    kill -TERM "${monitor_pid}" >/dev/null 2>&1 || true
+    wait "${monitor_pid}" >/dev/null 2>&1 || true
+    exit 1
+fi
 loop_pid=""
+
+sleep 2
+
+if kill -0 "${monitor_pid}" >/dev/null 2>&1; then
+    kill -INT "${monitor_pid}" >/dev/null 2>&1 || kill -TERM "${monitor_pid}" >/dev/null 2>&1 || true
+fi
+
+if ! wait "${monitor_pid}" >/dev/null 2>&1; then
+    monitor_status=$?
+    if [[ ${monitor_status} -ne 130 && ${monitor_status} -ne 143 ]]; then
+        echo "❌ Streaming monitor run failed. Logs:" >&2
+        cat "${monitor_log}" >&2 || true
+        cat "${loop_log}" >&2 || true
+        exit 1
+    fi
+fi
+monitor_pid=""
 
 for required_path in "${alerts_path}" "${report_path}"; do
     if [[ ! -s "${required_path}" ]]; then
@@ -163,6 +193,7 @@ cleanup_acceptance
 trap - EXIT
 unset acceptance_dir
 unset loop_pid
+unset monitor_pid
 
 echo "✅ Monitor acceptance gate passed. Artifacts copied to artifacts/release_acceptance_*."
 


### PR DESCRIPTION
## Summary
- extend the release check script to run the minimal streaming loop acceptance gate and compare streaming vs replay activations
- copy the generated monitor artifacts into deterministic paths while cleaning temporary data
- publish the monitor acceptance outputs from the release workflow for auditability

## Testing
- bash -n scripts/release_check.sh

------
https://chatgpt.com/codex/tasks/task_e_68ca4ada51a0832f8fedd235d6d1b412