### PR TITLE
Run release validation against built wheel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
       run: python -m venv .venv
       
     - name: Run release check script
+      env:
+        PYTHONPATH: ""
       run: |
         chmod +x scripts/release_check.sh
         source .venv/bin/activate && ./scripts/release_check.sh

--- a/scripts/release_check.sh
+++ b/scripts/release_check.sh
@@ -16,6 +16,10 @@ fi
 echo "⬆️ Installing build dependencies..."
 pip install -U pip build mkdocs mkdocs-material mkdocstrings[python] mkdocs-git-revision-date-localized-plugin mkdocs-minify-plugin
 
+# Clean any previous build artifacts to avoid ambiguous wheel detection
+echo "🧹 Cleaning previous build artifacts..."
+rm -rf build dist
+
 # Build package first
 echo "🏗️ Building package..."
 python3 -m build
@@ -26,17 +30,51 @@ if [ ! -f dist/*.whl ]; then
     exit 1
 fi
 
+# Resolve built wheel path (expect exactly one)
+shopt -s nullglob
+wheel_candidates=(dist/*.whl)
+shopt -u nullglob
+
+if [ ${#wheel_candidates[@]} -eq 0 ]; then
+    echo "❌ No wheel file found in dist/ after globbing"
+    exit 1
+fi
+
+if [ ${#wheel_candidates[@]} -gt 1 ]; then
+    echo "❌ Multiple wheels found: ${wheel_candidates[*]}"
+    echo "Please clean the dist/ directory before running the release check."
+    exit 1
+fi
+
+wheel_path="${wheel_candidates[0]}"
+
 # Test installation from built wheel in clean environment
 echo "📥 Testing installation from built wheel..."
-pip install dist/*.whl
+pip install "${wheel_path}[dev]"
+
+# Ensure PYTHONPATH doesn't point at the local source tree so imports resolve to the wheel
+if [[ -n "${PYTHONPATH:-}" ]]; then
+    echo "🧹 Clearing PYTHONPATH to ensure wheel-based imports..."
+    unset PYTHONPATH
+fi
+
+# Ensure we're exercising the installed distribution instead of the local source tree
+echo "🔎 Verifying installed package location..."
+python3 - <<'PY'
+import pathlib
+import rldk
+
+package_path = pathlib.Path(rldk.__file__).resolve()
+if "site-packages" not in str(package_path):
+    raise SystemExit(
+        f"❌ Expected rldk to be imported from an installed wheel, but got: {package_path}"
+    )
+print(f"✅ rldk imported from {package_path}")
+PY
 
 # Test CLI works after installation
 echo "🧪 Testing CLI functionality..."
 rldk --help >/dev/null
-
-# Install dev dependencies for testing
-echo "📦 Installing development dependencies..."
-pip install -e .[dev]
 
 # Run actual tests - handle import issues gracefully
 echo "🧪 Running test suite..."


### PR DESCRIPTION
## Summary
- rebuild the release validation script to clean prior artifacts, install the freshly built wheel with its dev extras, and assert that imports resolve from site-packages
- clear PYTHONPATH before running pytest, ruff, and mkdocs so checks run against the installed distribution
- update the release workflow to enforce an empty PYTHONPATH when invoking the release validation script

## Testing
- ⚠️ `./scripts/release_check.sh` *(partially executed; cancelled after large dependency downloads to keep runtime reasonable)*

------
https://chatgpt.com/codex/tasks/task_e_68ca4ae7fbc8832f9d5651aaaa8364a1