### PR TITLE
Add event/DataFrame conversion utilities

### DIFF
--- a/src/rldk/io/event_schema.py
+++ b/src/rldk/io/event_schema.py
@@ -1,8 +1,97 @@
 """Normalized event schema for RL training runs."""
 
+from __future__ import annotations
+
 import json
+import logging
+import math
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+import pandas as pd
+
+from ..utils.error_handling import ValidationError
+
+logger = logging.getLogger(__name__)
+
+_TRAINING_METRIC_COLUMNS = [
+    "step",
+    "phase",
+    "reward_mean",
+    "reward_std",
+    "kl_mean",
+    "entropy_mean",
+    "clip_frac",
+    "grad_norm",
+    "lr",
+    "loss",
+    "tokens_in",
+    "tokens_out",
+    "wall_time",
+    "seed",
+    "run_id",
+]
+
+_NUMERIC_COLUMNS = {
+    "reward_mean",
+    "reward_std",
+    "kl_mean",
+    "entropy_mean",
+    "clip_frac",
+    "grad_norm",
+    "lr",
+    "loss",
+    "tokens_in",
+    "tokens_out",
+    "wall_time",
+}
+
+
+def _is_missing(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, float) and (math.isnan(value) or math.isinf(value)):
+        return True
+    try:
+        return bool(pd.isna(value))  # type: ignore[arg-type]
+    except Exception:
+        return False
+
+
+def _coerce_numeric(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        value_float = float(value)
+        return value_float if math.isfinite(value_float) else None
+    if isinstance(value, str):
+        value = value.strip()
+        if not value:
+            return None
+        try:
+            value_float = float(value)
+        except ValueError:
+            return None
+        return value_float if math.isfinite(value_float) else None
+    return None
+
+
+def _coerce_wall_time(value: Any) -> Optional[float]:
+    numeric_value = _coerce_numeric(value)
+    if numeric_value is not None:
+        return numeric_value
+    if hasattr(value, "timestamp"):
+        try:
+            return float(value.timestamp())
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _stable_column_order(columns: Iterable[str]) -> List[str]:
+    ordered = [column for column in _TRAINING_METRIC_COLUMNS if column in columns]
+    extras = sorted(column for column in columns if column not in ordered)
+    return ordered + extras
 
 
 @dataclass
@@ -56,19 +145,9 @@ class Event:
 def create_event_from_row(
     row: Dict[str, Any], run_id: str, git_sha: Optional[str] = None
 ) -> Event:
-    """
-    Create an Event object from a training data row.
+    """Create an Event object from a training data row."""
 
-    Args:
-        row: Dictionary containing training step data
-        run_id: Unique identifier for the training run
-        git_sha: Git commit SHA if available
-
-    Returns:
-        Event object with normalized data
-    """
-    # Extract metrics from the row
-    metrics = {}
+    metrics: Dict[str, float] = {}
     metric_fields = [
         "reward_mean",
         "reward_std",
@@ -78,28 +157,14 @@ def create_event_from_row(
         "grad_norm",
         "lr",
         "loss",
-        # Network metrics
-        "network_bandwidth",
-        "network_latency",
-        "bandwidth_mbps",
-        "latency_ms",
-        "bandwidth_upload_mbps",
-        "bandwidth_download_mbps",
-        "total_bandwidth_mbps",
-        "allreduce_bandwidth",
-        "broadcast_bandwidth",
-        "gather_bandwidth",
-        "scatter_bandwidth",
-        "packet_loss_percent",
-        "network_errors",
-        "dns_resolution_ms",
     ]
 
     for field in metric_fields:
         if field in row and row[field] is not None:
-            metrics[field] = float(row[field])
+            numeric_value = _coerce_numeric(row[field])
+            if numeric_value is not None:
+                metrics[field] = numeric_value
 
-    # Extract RNG information
     rng = {
         "seed": row.get("seed"),
         "python_hash_seed": row.get("python_hash_seed"),
@@ -108,7 +173,6 @@ def create_event_from_row(
         "random_seed": row.get("random_seed"),
     }
 
-    # Extract data slice information
     data_slice = {
         "tokens_in": row.get("tokens_in"),
         "tokens_out": row.get("tokens_out"),
@@ -116,29 +180,32 @@ def create_event_from_row(
         "sequence_length": row.get("sequence_length"),
     }
 
-    # Extract model information
     model_info = {
         "run_id": run_id,
         "git_sha": git_sha,
-        "phase": row.get("phase", "train"),
+        "phase": row.get("phase") or "train",
         "model_name": row.get("model_name"),
         "model_size": row.get("model_size"),
         "optimizer": row.get("optimizer"),
         "scheduler": row.get("scheduler"),
     }
 
-    # Generate notes based on data quality
-    notes = []
-    if row.get("clip_frac", 0) > 0.2:
+    notes: List[str] = []
+    clip_frac = _coerce_numeric(row.get("clip_frac"))
+    if clip_frac is not None and clip_frac > 0.2:
         notes.append("High clipping fraction detected")
-    if row.get("grad_norm", 0) > 10.0:
+    grad_norm = _coerce_numeric(row.get("grad_norm"))
+    if grad_norm is not None and grad_norm > 10.0:
         notes.append("Large gradient norm detected")
-    if row.get("kl_mean", 0) > 0.2:
+    kl_mean = _coerce_numeric(row.get("kl_mean"))
+    if kl_mean is not None and kl_mean > 0.2:
         notes.append("High KL divergence detected")
+
+    wall_time = _coerce_wall_time(row.get("wall_time")) or 0.0
 
     return Event(
         step=int(row["step"]),
-        wall_time=float(row.get("wall_time", 0)),
+        wall_time=wall_time,
         metrics=metrics,
         rng=rng,
         data_slice=data_slice,
@@ -147,58 +214,139 @@ def create_event_from_row(
     )
 
 
-def events_to_dataframe(events: List[Event]) -> "pd.DataFrame":
-    """
-    Convert a list of events to a pandas DataFrame.
+def events_to_dataframe(events: Sequence[Event | Dict[str, Any]]) -> pd.DataFrame:
+    """Convert normalized events into a TrainingMetrics-style DataFrame."""
 
-    Args:
-        events: List of Event objects
+    rows: List[Dict[str, Any]] = []
+    skipped = 0
 
-    Returns:
-        DataFrame with flattened event data
-    """
-    import pandas as pd
-
-    rows = []
     for event in events:
-        row = {
-            "step": event.step,
-            "wall_time": event.wall_time,
-            "run_id": event.model_info["run_id"],
-            "git_sha": event.model_info.get("git_sha"),
-            "phase": event.model_info.get("phase", "train"),
-            "tokens_in": event.data_slice.get("tokens_in"),
-            "tokens_out": event.data_slice.get("tokens_out"),
-            "seed": event.rng.get("seed"),
-            "notes": "; ".join(event.notes) if event.notes else None,
-        }
+        if isinstance(event, Event):
+            event_dict = {
+                "step": event.step,
+                "wall_time": event.wall_time,
+                "metrics": event.metrics,
+                "rng": event.rng,
+                "data_slice": event.data_slice,
+                "model_info": event.model_info,
+            }
+        elif isinstance(event, dict):
+            event_dict = event
+        else:
+            skipped += 1
+            continue
 
-        # Add metrics
-        for key, value in event.metrics.items():
-            row[key] = value
+        step_value = event_dict.get("step")
+        try:
+            step_numeric = int(step_value)
+        except (TypeError, ValueError):
+            skipped += 1
+            continue
+
+        row: Dict[str, Any] = {"step": step_numeric}
+
+        wall_time = _coerce_wall_time(event_dict.get("wall_time"))
+        if wall_time is not None:
+            row["wall_time"] = wall_time
+
+        model_info = event_dict.get("model_info") or {}
+        run_id = model_info.get("run_id")
+        if run_id is not None and not _is_missing(run_id):
+            row["run_id"] = str(run_id)
+        phase = model_info.get("phase")
+        if phase is not None and not _is_missing(phase):
+            row["phase"] = phase
+        git_sha = model_info.get("git_sha")
+        if git_sha is not None and not _is_missing(git_sha):
+            row["git_sha"] = git_sha
+
+        rng = event_dict.get("rng") or {}
+        seed = rng.get("seed")
+        if seed is not None and not _is_missing(seed):
+            row["seed"] = seed
+
+        data_slice = event_dict.get("data_slice") or {}
+        for key, value in data_slice.items():
+            if _is_missing(value):
+                continue
+            numeric_value = _coerce_numeric(value)
+            row[key] = numeric_value if numeric_value is not None else value
+
+        metrics = event_dict.get("metrics") or {}
+        for key, value in metrics.items():
+            if _is_missing(value):
+                continue
+            numeric_value = _coerce_numeric(value)
+            row[key] = numeric_value if numeric_value is not None else value
 
         rows.append(row)
 
-    return pd.DataFrame(rows)
+    if skipped:
+        logger.warning(
+            "Skipped %d malformed event%s while converting to DataFrame",
+            skipped,
+            "" if skipped == 1 else "s",
+        )
+
+    if not rows:
+        return pd.DataFrame(columns=_TRAINING_METRIC_COLUMNS)
+
+    df = pd.DataFrame(rows)
+
+    df["step"] = pd.to_numeric(df["step"], errors="coerce").astype("Int64")
+
+    for column in _NUMERIC_COLUMNS.intersection(df.columns):
+        df[column] = pd.to_numeric(df[column], errors="coerce")
+
+    df = df.sort_values("step").reset_index(drop=True)
+    return df.reindex(columns=_stable_column_order(df.columns))
 
 
 def dataframe_to_events(
-    df: "pd.DataFrame", run_id: str, git_sha: Optional[str] = None
+    df: pd.DataFrame, run_id: Optional[str] = None, git_sha: Optional[str] = None
 ) -> List[Event]:
-    """
-    Convert a pandas DataFrame to a list of Event objects.
+    """Convert a TrainingMetrics-style DataFrame into normalized events."""
 
-    Args:
-        df: DataFrame with training data
-        run_id: Unique identifier for the training run
-        git_sha: Git commit SHA if available
+    if "step" not in df.columns:
+        raise ValidationError(
+            "DataFrame is missing required 'step' column",
+            suggestion="Ensure every row includes a numeric 'step' value",
+            error_code="MISSING_STEP_COLUMN",
+        )
 
-    Returns:
-        List of Event objects
-    """
-    events = []
-    for _, row in df.iterrows():
-        event = create_event_from_row(row.to_dict(), run_id, git_sha)
+    standardized = df.copy()
+    standardized["step"] = pd.to_numeric(standardized["step"], errors="coerce")
+    invalid_steps = standardized["step"].isna()
+    dropped = int(invalid_steps.sum())
+    if dropped:
+        logger.warning(
+            "Dropped %d row%s without a valid step while converting DataFrame to events",
+            dropped,
+            "" if dropped == 1 else "s",
+        )
+        standardized = standardized.loc[~invalid_steps].copy()
+
+    events: List[Event] = []
+    for _, row in standardized.iterrows():
+        row_dict: Dict[str, Any] = {}
+        for column, value in row.items():
+            row_dict[column] = None if _is_missing(value) else value
+
+        wall_time = _coerce_wall_time(row_dict.get("wall_time"))
+        row_dict["wall_time"] = wall_time if wall_time is not None else 0.0
+
+        row_run_id = row_dict.get("run_id") or run_id or "unknown"
+        row_git_sha = row_dict.get("git_sha") or git_sha
+
+        try:
+            event = create_event_from_row(row_dict, str(row_run_id), row_git_sha)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            logger.warning(
+                "Skipping row at step %s due to error constructing event: %s",
+                row_dict.get("step"),
+                exc,
+            )
+            continue
         events.append(event)
 
     return events

--- a/src/rldk/io/event_schema.py
+++ b/src/rldk/io/event_schema.py
@@ -32,6 +32,34 @@ _TRAINING_METRIC_COLUMNS = [
     "run_id",
 ]
 
+_CORE_METRIC_FIELDS = [
+    "reward_mean",
+    "reward_std",
+    "kl_mean",
+    "entropy_mean",
+    "clip_frac",
+    "grad_norm",
+    "lr",
+    "loss",
+]
+
+_NETWORK_METRIC_FIELDS = [
+    "network_bandwidth",
+    "network_latency",
+    "bandwidth_mbps",
+    "latency_ms",
+    "bandwidth_upload_mbps",
+    "bandwidth_download_mbps",
+    "total_bandwidth_mbps",
+    "allreduce_bandwidth",
+    "broadcast_bandwidth",
+    "gather_bandwidth",
+    "scatter_bandwidth",
+    "packet_loss_percent",
+    "network_errors",
+    "dns_resolution_ms",
+]
+
 _NUMERIC_COLUMNS = {
     "reward_mean",
     "reward_std",
@@ -148,18 +176,7 @@ def create_event_from_row(
     """Create an Event object from a training data row."""
 
     metrics: Dict[str, float] = {}
-    metric_fields = [
-        "reward_mean",
-        "reward_std",
-        "kl_mean",
-        "entropy_mean",
-        "clip_frac",
-        "grad_norm",
-        "lr",
-        "loss",
-    ]
-
-    for field in metric_fields:
+    for field in [*_CORE_METRIC_FIELDS, *_NETWORK_METRIC_FIELDS]:
         if field in row and row[field] is not None:
             numeric_value = _coerce_numeric(row[field])
             if numeric_value is not None:

--- a/tests/test_dataframe_event_converters.py
+++ b/tests/test_dataframe_event_converters.py
@@ -1,0 +1,84 @@
+"""Tests for converting between TrainingMetrics DataFrames and normalized events."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from rldk.io.event_schema import dataframe_to_events, events_to_dataframe
+
+
+def test_dataframe_event_round_trip_preserves_metrics() -> None:
+    df = pd.DataFrame(
+        {
+            "step": [0, 1],
+            "reward_mean": [1.0, 1.5],
+            "reward_std": [0.1, 0.2],
+            "kl_mean": [0.01, 0.015],
+            "entropy_mean": [2.0, 1.9],
+            "clip_frac": [0.1, 0.12],
+            "grad_norm": [0.9, 1.1],
+            "lr": [3e-4, 2.5e-4],
+            "loss": [0.5, 0.45],
+            "tokens_in": [128, 128],
+            "tokens_out": [120, 130],
+            "wall_time": [1_690_000_000.0, 1_690_000_100.0],
+            "run_id": ["run-123", "run-123"],
+            "seed": [42, 42],
+            "phase": ["train", "train"],
+        }
+    )
+
+    events = dataframe_to_events(df)
+    assert len(events) == len(df)
+
+    round_trip = events_to_dataframe(events)
+
+    numeric_columns = [
+        "reward_mean",
+        "reward_std",
+        "kl_mean",
+        "entropy_mean",
+        "clip_frac",
+        "grad_norm",
+        "lr",
+        "loss",
+        "tokens_in",
+        "tokens_out",
+        "wall_time",
+    ]
+
+    for column in numeric_columns:
+        np.testing.assert_allclose(
+            round_trip[column].to_numpy(dtype=float),
+            df[column].to_numpy(dtype=float),
+            rtol=1e-6,
+            atol=1e-8,
+            equal_nan=True,
+        )
+
+    np.testing.assert_array_equal(round_trip["step"].to_numpy(), df["step"].to_numpy())
+    assert list(round_trip["run_id"].fillna("")) == list(df["run_id"].fillna(""))
+    assert list(round_trip["seed"].fillna(pd.NA)) == list(df["seed"].fillna(pd.NA))
+    assert list(round_trip["phase"].fillna("")) == list(df["phase"].fillna(""))
+
+
+def test_events_to_dataframe_handles_non_numeric_metrics() -> None:
+    bad_event = {
+        "step": 3,
+        "wall_time": 100.0,
+        "metrics": {"reward_mean": "not-a-number", "kl_mean": "0.2"},
+        "rng": {"seed": 11},
+        "data_slice": {},
+        "model_info": {"run_id": "run-456", "phase": "eval"},
+    }
+
+    df = events_to_dataframe([bad_event])
+    assert math.isnan(df.loc[0, "reward_mean"])
+    assert df.loc[0, "kl_mean"] == pytest.approx(0.2)
+    assert df.loc[0, "run_id"] == "run-456"
+    assert df.loc[0, "phase"] == "eval"
+    assert df.loc[0, "seed"] == 11

--- a/tests/test_dataframe_event_converters.py
+++ b/tests/test_dataframe_event_converters.py
@@ -82,3 +82,23 @@ def test_events_to_dataframe_handles_non_numeric_metrics() -> None:
     assert df.loc[0, "run_id"] == "run-456"
     assert df.loc[0, "phase"] == "eval"
     assert df.loc[0, "seed"] == 11
+
+
+def test_dataframe_to_events_preserves_network_metrics() -> None:
+    df = pd.DataFrame(
+        {
+            "step": [5],
+            "network_bandwidth": [250.0],
+            "latency_ms": [12.5],
+        }
+    )
+
+    events = dataframe_to_events(df, run_id="net-run")
+    assert len(events) == 1
+    event_metrics = events[0].metrics
+    assert event_metrics["network_bandwidth"] == pytest.approx(250.0)
+    assert event_metrics["latency_ms"] == pytest.approx(12.5)
+
+    restored = events_to_dataframe(events)
+    assert restored.loc[0, "network_bandwidth"] == pytest.approx(250.0)
+    assert restored.loc[0, "latency_ms"] == pytest.approx(12.5)


### PR DESCRIPTION
## Summary
- add converters to normalize between TrainingMetrics DataFrames and normalized events with numeric coercion
- preserve key metadata like run_id, phase, and seeds while skipping malformed records safely
- add tests covering round-trip fidelity and robust handling of non-numeric metrics

## Testing
- pytest tests/test_dataframe_event_converters.py tests/integration/test_phase_b_cards.py


------
https://chatgpt.com/codex/tasks/task_e_68caebc35f9c832f8d581308ccc716b3