### PR TITLE
Normalize reward health CLI inputs via shared training metrics

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -165,31 +165,39 @@ rldk reward reward-drift MODEL_A MODEL_B --prompts PROMPTS_FILE
 rldk reward reward-drift ./models/reward_v1 ./models/reward_v2 --prompts prompts.jsonl
 ```
 
-### `rldk reward reward-health run`
+### `rldk reward-health`
 
-Run reward health analysis on scores data.
+Normalize reward metrics and generate a health report.
 
 ```bash
-rldk reward reward-health run --scores SCORES_FILE --out OUTPUT_DIR [OPTIONS]
+rldk reward-health --run RUN_SOURCE [OPTIONS]
 ```
 
 **Options:**
-- `--scores`: Path to scores JSONL file (required)
-- `--config`: Path to health configuration YAML file
-- `--out`: Output directory for reports (required)
-- `--adapter`: Adapter type for data ingestion (`custom_jsonl`, `trl`, `openrlhf`, `wandb`)
+- `--run`, `-r`: Path to training run data (JSONL stream, metrics table, or logs directory) (required)
+- `--reference`, `-ref`: Optional reference run for drift comparison
+- `--output-dir`, `-o`: Output directory for reports (default: `reward_analysis`)
+- `--preset`: Field map preset for common trainer schemas
+- `--field-map`: JSON object mapping source columns to canonical training metrics
+- `--reward-col`: Column name for reward values (default: `reward_mean`)
+- `--step-col`: Column name for training steps (default: `step`)
+- `--threshold-drift`: P-value threshold for drift detection (default: `0.1`)
+- `--threshold-saturation`: Threshold for saturation detection (default: `0.8`)
+- `--threshold-calibration`: Threshold for calibration quality (default: `0.7`)
+- `--threshold-shortcut`: Threshold for shortcut signal detection (default: `0.6`)
+- `--threshold-leakage`: Threshold for label leakage risk (default: `0.3`)
 - `--gate`: Enable CI gate mode with exit codes (0=pass, 1=warn, 2=fail)
 
 **Examples:**
 ```bash
-# Basic reward health analysis
-rldk reward reward-health run --scores scores.jsonl --out ./reports
+# Analyze a JSONL event stream with custom field mappings
+rldk reward-health --run metrics.jsonl --field-map '{"reward": "reward_mean", "kl": "kl_mean"}'
 
-# With custom configuration
-rldk reward reward-health run --scores scores.jsonl --config custom_config.yaml --out ./reports
+# Use a CSV table that already contains normalized columns
+rldk reward-health --run ./reports/training_metrics.csv
 
-# CI gate mode
-rldk reward reward-health run --scores scores.jsonl --out ./reports --gate
+# Run with a reference directory and CI gating
+rldk reward-health --run ./runs/current --reference ./runs/baseline --gate
 ```
 
 ### `rldk reward reward-health gate`
@@ -413,6 +421,8 @@ rldk reward-health --run RUN_PATH [OPTIONS]
 - `--run`, `-r`: Path to training run data (required)
 - `--reference`, `-ref`: Path to reference run data
 - `--output-dir`, `-o`: Output directory for reports (default: `reward_analysis`)
+- `--preset`: Field map preset for common trainer schemas
+- `--field-map`: JSON object mapping source columns to canonical training metrics
 - `--reward-col`: Column name for reward values (default: `reward_mean`)
 - `--step-col`: Column name for training steps (default: `step`)
 - `--threshold-drift`: P-value threshold for drift detection (default: `0.1`)

--- a/src/rldk/cli.py
+++ b/src/rldk/cli.py
@@ -32,7 +32,11 @@ from rldk.evals.suites import COMPREHENSIVE_SUITE, QUICK_SUITE, SAFETY_SUITE
 from rldk.forensics.ckpt_diff import diff_checkpoints
 from rldk.forensics.env_audit import audit_environment
 from rldk.forensics.log_scan import scan_logs
-from rldk.ingest import ingest_runs, ingest_runs_to_events
+from rldk.ingest import (
+    ingest_runs,
+    ingest_runs_to_events,
+    normalize_training_metrics_source,
+)
 from rldk.io import (
     CkptDiffReportV1,
     DeterminismCardV1,
@@ -2215,6 +2219,21 @@ def reward_health(
     output_dir: str = typer.Option(
         "reward_analysis", "--output-dir", "-o", help="Output directory for reports"
     ),
+    preset: Optional[str] = typer.Option(
+        None,
+        "--preset",
+        help=(
+            "Field map preset to normalize training metrics"
+            f" ({', '.join(sorted(FIELD_MAP_PRESETS))})"
+            if FIELD_MAP_PRESETS
+            else "Field map preset name (e.g. trl)."
+        ),
+    ),
+    field_map: Optional[str] = typer.Option(
+        None,
+        "--field-map",
+        help="JSON object mapping source columns to canonical training metrics.",
+    ),
     reward_col: str = typer.Option(
         "reward_mean", "--reward-col", help="Column name for reward values"
     ),
@@ -2241,18 +2260,65 @@ def reward_health(
     ),
 ):
     """Analyze reward model health and detect pathologies."""
+
+    def _ensure_column_present(df: pd.DataFrame, column: str, kind: str) -> None:
+        if column not in df.columns:
+            raise ValidationError(
+                f"{kind.capitalize()} column '{column}' not found after normalization",
+                suggestion=(
+                    "Use --preset or --field-map to map your metrics to canonical names, "
+                    "for example --field-map '{\"reward\": \"reward_mean\"}'"
+                ),
+                error_code=f"MISSING_{kind.upper()}_COLUMN",
+            )
+        if df[column].dropna().empty:
+            raise ValidationError(
+                f"Normalized {kind} column '{column}' is empty",
+                suggestion=(
+                    "Use --preset or --field-map to map the correct column or verify the source data"
+                ),
+                error_code=f"EMPTY_{kind.upper()}_COLUMN",
+            )
+
     try:
         typer.echo(f"Analyzing reward health for run: {run_path}")
 
-        # Ingest run data
-        typer.echo("Ingesting run data...")
-        run_data = ingest_runs(run_path)
+        try:
+            combined_map = _combine_field_maps(preset, field_map)
+        except ValueError as exc:
+            typer.echo(f"Invalid field map: {exc}", err=True)
+            raise typer.Exit(1)
 
-        # Ingest reference data if provided
+        mapping_dict = combined_map or None
+
+        # Normalize run data
+        typer.echo("Normalizing run data...")
+        run_data = normalize_training_metrics_source(run_path, field_map=mapping_dict)
+
+        if run_data.empty:
+            raise ValidationError(
+                "Normalized run data is empty",
+                suggestion="Ensure the source contains reward metrics",
+                error_code="EMPTY_RUN_DATA",
+            )
+
+        _ensure_column_present(run_data, step_col, "step")
+        _ensure_column_present(run_data, reward_col, "reward")
+
         reference_data = None
         if reference_path:
-            typer.echo("Ingesting reference data...")
-            reference_data = ingest_runs(reference_path)
+            typer.echo("Normalizing reference data...")
+            reference_data = normalize_training_metrics_source(
+                reference_path, field_map=mapping_dict
+            )
+            if reference_data.empty:
+                raise ValidationError(
+                    "Normalized reference data is empty",
+                    suggestion="Verify the reference source contains reward metrics",
+                    error_code="EMPTY_REFERENCE_DATA",
+                )
+            _ensure_column_present(reference_data, step_col, "step")
+            _ensure_column_present(reference_data, reward_col, "reward")
 
         # Run reward health analysis
         typer.echo("Running reward health analysis...")
@@ -2330,6 +2396,12 @@ def reward_health(
                 typer.echo("GATE: FAIL")
             raise typer.Exit(exit_code)
 
+    except (ValidationError, AdapterError) as exc:
+        typer.echo(format_error_message(exc), err=True)
+        if gate:
+            typer.echo("GATE: FAIL")
+            raise typer.Exit(2)
+        raise typer.Exit(1)
     except Exception as e:
         typer.echo(f"Error: {e}", err=True)
         if gate:

--- a/src/rldk/ingest/__init__.py
+++ b/src/rldk/ingest/__init__.py
@@ -2,5 +2,17 @@
 
 from .ingest import ingest_runs, ingest_runs_to_events
 from .stream_normalizer import stream_jsonl_to_dataframe
+from .training_metrics_normalizer import (
+    TRAINING_METRIC_COLUMNS,
+    normalize_training_metrics_source,
+    standardize_training_metrics,
+)
 
-__all__ = ["ingest_runs", "ingest_runs_to_events", "stream_jsonl_to_dataframe"]
+__all__ = [
+    "TRAINING_METRIC_COLUMNS",
+    "ingest_runs",
+    "ingest_runs_to_events",
+    "normalize_training_metrics_source",
+    "standardize_training_metrics",
+    "stream_jsonl_to_dataframe",
+]

--- a/src/rldk/ingest/ingest.py
+++ b/src/rldk/ingest/ingest.py
@@ -20,44 +20,10 @@ from ..utils.error_handling import (
     validate_file_path,
 )
 from ..utils.progress import spinner
+from .training_metrics_normalizer import standardize_training_metrics
 
 
 logger = logging.getLogger(__name__)
-
-
-_CANONICAL_COLUMNS = [
-    "step",
-    "phase",
-    "reward_mean",
-    "reward_std",
-    "kl_mean",
-    "entropy_mean",
-    "clip_frac",
-    "grad_norm",
-    "lr",
-    "loss",
-    "tokens_in",
-    "tokens_out",
-    "wall_time",
-    "seed",
-    "run_id",
-    "git_sha",
-]
-
-
-_NUMERIC_COLUMNS = {
-    "reward_mean",
-    "reward_std",
-    "kl_mean",
-    "entropy_mean",
-    "clip_frac",
-    "grad_norm",
-    "lr",
-    "loss",
-    "tokens_in",
-    "tokens_out",
-    "wall_time",
-}
 
 
 def ingest_runs(
@@ -217,7 +183,7 @@ def ingest_runs(
 
     # Validate and standardize schema
     try:
-        df = _standardize_schema(df)
+        df = standardize_training_metrics(df)
         logger.info(f"Schema standardized, {len(df)} records ready")
     except Exception as e:
         raise AdapterError(
@@ -227,49 +193,6 @@ def ingest_runs(
         ) from e
 
     return df
-
-
-def _standardize_schema(df: pd.DataFrame) -> pd.DataFrame:
-    """Standardize DataFrame schema to the TrainingMetrics format."""
-
-    if "step" not in df.columns:
-        raise ValidationError(
-            "DataFrame is missing required 'step' column",
-            suggestion="Ensure every record includes a numeric 'step' value",
-            error_code="MISSING_STEP_COLUMN",
-        )
-
-    standardized = df.copy()
-
-    standardized["step"] = pd.to_numeric(standardized["step"], errors="coerce")
-    invalid_steps = standardized["step"].isna()
-    invalid_count = int(invalid_steps.sum())
-    if invalid_count:
-        logger.warning(
-            "Dropped %d row%s with missing or non-numeric step during schema standardization",
-            invalid_count,
-            "" if invalid_count == 1 else "s",
-        )
-        standardized = standardized.loc[~invalid_steps].copy()
-
-    for column in _CANONICAL_COLUMNS:
-        if column not in standardized.columns:
-            standardized[column] = None
-
-    standardized["step"] = standardized["step"].astype("Int64")
-
-    for column in _NUMERIC_COLUMNS.intersection(standardized.columns):
-        standardized[column] = pd.to_numeric(standardized[column], errors="coerce")
-
-    standardized = standardized.sort_values("step").reset_index(drop=True)
-
-    canonical = [column for column in _CANONICAL_COLUMNS if column in standardized.columns]
-    extras = sorted(column for column in standardized.columns if column not in _CANONICAL_COLUMNS)
-    ordered_columns = canonical + extras
-
-    return standardized.loc[:, ordered_columns]
-
-
 def ingest_runs_to_events(
     source: Union[str, Path],
     adapter_hint: Optional[str] = None,

--- a/src/rldk/ingest/training_metrics_normalizer.py
+++ b/src/rldk/ingest/training_metrics_normalizer.py
@@ -1,0 +1,189 @@
+"""Helpers for normalizing user supplied training metrics."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Dict, Iterable, Optional, Union
+
+import pandas as pd
+
+from ..utils.error_handling import ValidationError, validate_file_path
+from .stream_normalizer import stream_jsonl_to_dataframe
+
+logger = logging.getLogger(__name__)
+
+
+TRAINING_METRIC_COLUMNS: list[str] = [
+    "step",
+    "phase",
+    "reward_mean",
+    "reward_std",
+    "kl_mean",
+    "entropy_mean",
+    "clip_frac",
+    "grad_norm",
+    "lr",
+    "loss",
+    "tokens_in",
+    "tokens_out",
+    "wall_time",
+    "seed",
+    "run_id",
+    "git_sha",
+]
+
+
+_NUMERIC_COLUMNS = {
+    "reward_mean",
+    "reward_std",
+    "kl_mean",
+    "entropy_mean",
+    "clip_frac",
+    "grad_norm",
+    "lr",
+    "loss",
+    "tokens_in",
+    "tokens_out",
+    "wall_time",
+}
+
+_STREAM_EXTENSIONS = {".jsonl", ".ndjson"}
+_TABLE_EXTENSIONS = {".csv", ".tsv", ".parquet"}
+
+
+def _stable_column_order(columns: Iterable[str]) -> list[str]:
+    ordered = [column for column in TRAINING_METRIC_COLUMNS if column in columns]
+    extras = sorted(column for column in columns if column not in ordered)
+    return ordered + extras
+
+
+def standardize_training_metrics(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a DataFrame that follows the canonical TrainingMetrics schema."""
+
+    if "step" not in df.columns:
+        raise ValidationError(
+            "DataFrame is missing required 'step' column",
+            suggestion="Use --preset or --field-map to map your step column to 'step'",
+            error_code="MISSING_STEP_COLUMN",
+        )
+
+    standardized = df.copy()
+    standardized["step"] = pd.to_numeric(standardized["step"], errors="coerce")
+
+    invalid_steps = standardized["step"].isna()
+    invalid_count = int(invalid_steps.sum())
+    if invalid_count:
+        logger.warning(
+            "Dropped %d row%s with missing or non-numeric step during normalization",
+            invalid_count,
+            "" if invalid_count == 1 else "s",
+        )
+        standardized = standardized.loc[~invalid_steps].copy()
+
+    for column in TRAINING_METRIC_COLUMNS:
+        if column not in standardized.columns:
+            standardized[column] = None
+
+    standardized["step"] = standardized["step"].astype("int64")
+
+    for column in _NUMERIC_COLUMNS.intersection(standardized.columns):
+        standardized[column] = pd.to_numeric(standardized[column], errors="coerce")
+
+    standardized = standardized.sort_values("step").reset_index(drop=True)
+    return standardized.loc[:, _stable_column_order(standardized.columns)]
+
+
+def _rename_with_field_map(
+    df: pd.DataFrame, field_map: Optional[Dict[str, str]]
+) -> pd.DataFrame:
+    if not field_map:
+        return df
+
+    rename_map = {
+        source: target
+        for source, target in field_map.items()
+        if isinstance(source, str) and isinstance(target, str)
+    }
+    if not rename_map:
+        return df
+
+    overlapping = set(rename_map).intersection(df.columns)
+    if not overlapping:
+        return df
+
+    return df.rename(columns=rename_map)
+
+
+def _load_table(path: Path) -> pd.DataFrame:
+    suffix = path.suffix.lower()
+    try:
+        if suffix == ".csv":
+            return pd.read_csv(path)
+        if suffix == ".tsv":
+            return pd.read_csv(path, sep="\t")
+        if suffix == ".parquet":
+            return pd.read_parquet(path)
+    except Exception as exc:
+        raise ValidationError(
+            f"Failed to read metrics table from {path}",
+            suggestion="Ensure the file contains valid tabular data",
+            error_code="TABLE_READ_FAILED",
+        ) from exc
+
+    raise ValidationError(
+        f"Unsupported table format: {suffix}",
+        suggestion="Use .csv, .tsv, or .parquet files",
+        error_code="UNSUPPORTED_TABLE_FORMAT",
+    )
+
+
+def normalize_training_metrics_source(
+    source: Union[str, Path], field_map: Optional[Dict[str, str]] = None
+) -> pd.DataFrame:
+    """Normalize an arbitrary run input into the TrainingMetrics schema."""
+
+    field_map = field_map or None
+
+    try:
+        path_obj = validate_file_path(source, must_exist=True)
+    except ValidationError:
+        raise
+    except Exception as exc:
+        raise ValidationError(
+            f"Failed to resolve path: {source}",
+            suggestion="Provide a valid file or directory path",
+            error_code="INVALID_RUN_PATH",
+        ) from exc
+
+    if path_obj.is_dir():
+        from .ingest import ingest_runs
+
+        raw_df = ingest_runs(path_obj)
+    elif path_obj.is_file():
+        suffix = path_obj.suffix.lower()
+        if suffix in _STREAM_EXTENSIONS:
+            raw_df = stream_jsonl_to_dataframe(path_obj, field_map=field_map)
+        elif suffix in _TABLE_EXTENSIONS:
+            raw_df = _load_table(path_obj)
+        else:
+            from .ingest import ingest_runs
+
+            raw_df = ingest_runs(path_obj)
+    else:
+        raise ValidationError(
+            f"Unsupported run path: {source}",
+            suggestion="Provide a JSONL file, metrics table, or directory of logs",
+            error_code="UNSUPPORTED_RUN_SOURCE",
+        )
+
+    renamed = _rename_with_field_map(raw_df, field_map)
+    return standardize_training_metrics(renamed)
+
+
+__all__ = [
+    "TRAINING_METRIC_COLUMNS",
+    "normalize_training_metrics_source",
+    "standardize_training_metrics",
+]
+

--- a/tests/test_reward_health_cli.py
+++ b/tests/test_reward_health_cli.py
@@ -1,0 +1,74 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from typer.testing import CliRunner
+
+from rldk.cli import app
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _write_reward_jsonl(path: Path) -> None:
+    records = [
+        {"time": 1.0, "step": 1, "name": "reward", "value": 0.5},
+        {"time": 1.0, "step": 1, "name": "kl", "value": 0.1},
+        {"time": 2.0, "step": 2, "name": "reward", "value": 0.6},
+        {"time": 2.0, "step": 2, "name": "kl", "value": 0.12},
+    ]
+    with path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record) + "\n")
+
+
+def test_reward_health_cli_normalizes_jsonl(tmp_path: Path, runner: CliRunner) -> None:
+    jsonl_path = tmp_path / "metrics.jsonl"
+    _write_reward_jsonl(jsonl_path)
+
+    output_dir = tmp_path / "outputs"
+    mapping = json.dumps({"reward": "reward_mean", "kl": "kl_mean"})
+    result = runner.invoke(
+        app,
+        [
+            "reward-health",
+            "--run",
+            str(jsonl_path),
+            "--output-dir",
+            str(output_dir),
+            "--field-map",
+            mapping,
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+
+    summary_path = output_dir / "reward_health_summary.json"
+    assert summary_path.exists()
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert "calibration_score" in summary
+
+
+def test_reward_health_cli_missing_reward(tmp_path: Path, runner: CliRunner) -> None:
+    csv_path = tmp_path / "metrics.csv"
+    pd.DataFrame({"step": [1, 2], "kl_mean": [0.1, 0.2]}).to_csv(csv_path, index=False)
+
+    output_dir = tmp_path / "outputs"
+    result = runner.invoke(
+        app,
+        [
+            "reward-health",
+            "--run",
+            str(csv_path),
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    assert result.exit_code != 0
+    error_output = result.stderr or result.stdout
+    assert "Use --preset or --field-map" in error_output

--- a/tests/test_standardize_schema.py
+++ b/tests/test_standardize_schema.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pandas.testing as pdt
 import pytest
 
-from rldk.ingest.ingest import _standardize_schema
+from rldk.ingest import standardize_training_metrics
 
 
 def test_standardize_schema_coerces_numeric_columns() -> None:
@@ -19,7 +19,7 @@ def test_standardize_schema_coerces_numeric_columns() -> None:
         }
     )
 
-    standardized = _standardize_schema(raw)
+    standardized = standardize_training_metrics(raw)
 
     assert list(standardized["step"]) == [1, 2]
     assert standardized["reward_mean"].dtype.kind in {"f", "c"}
@@ -38,7 +38,7 @@ def test_standardize_schema_drops_rows_with_invalid_step(caplog: pytest.LogCaptu
     )
 
     caplog.set_level(logging.WARNING)
-    standardized = _standardize_schema(raw)
+    standardized = standardize_training_metrics(raw)
 
     assert list(standardized["step"]) == [1]
     assert any("Dropped 2 row" in message for message in caplog.messages)
@@ -54,7 +54,7 @@ def test_standardize_schema_column_order_and_idempotent() -> None:
         }
     )
 
-    standardized = _standardize_schema(raw)
+    standardized = standardize_training_metrics(raw)
 
     expected_prefix = [
         "step",
@@ -77,5 +77,5 @@ def test_standardize_schema_column_order_and_idempotent() -> None:
     assert standardized.columns[: len(expected_prefix)].tolist() == expected_prefix
     assert standardized.columns.tolist() == expected_prefix + ["custom_metric"]
 
-    round_trip = _standardize_schema(standardized)
+    round_trip = standardize_training_metrics(standardized)
     pdt.assert_frame_equal(standardized, round_trip)


### PR DESCRIPTION
## Summary
- add a shared training metrics normalizer for JSONL streams, tables, and directories and reuse it inside ingest
- update the reward-health CLI to call the normalizer, expose --preset/--field-map, and surface friendly validation errors
- refresh CLI documentation and add tests that cover successful JSONL normalization and missing reward failures

## Testing
- pytest tests/test_reward_health_cli.py tests/test_standardize_schema.py tests/test_stream_jsonl_normalizer.py


------
https://chatgpt.com/codex/tasks/task_e_68cb0baaffb0832fbce3e1b04a3f1c54