### PR TITLE
feat: add reward drift score file mode

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -151,18 +151,22 @@ Compare two reward models and detect drift.
 
 ```bash
 rldk reward reward-drift MODEL_A MODEL_B --prompts PROMPTS_FILE
+rldk reward reward-drift --scores-a scores_a.jsonl --scores-b scores_b.jsonl
 ```
 
 **Arguments:**
-- `MODEL_A`: Path to first reward model directory
-- `MODEL_B`: Path to second reward model directory
+- `MODEL_A`: Path to first reward model directory (required when using prompt mode)
+- `MODEL_B`: Path to second reward model directory (required when using prompt mode)
 
 **Options:**
-- `--prompts`, `-p`: Path to prompts JSONL file (required)
+- `--prompts`, `-p`: Path to prompts JSONL file (required when comparing model directories)
+- `--scores-a`: Path to the first JSONL score file (each record must contain `prompt` and `score`)
+- `--scores-b`: Path to the second JSONL score file
 
 **Examples:**
 ```bash
 rldk reward reward-drift ./models/reward_v1 ./models/reward_v2 --prompts prompts.jsonl
+rldk reward reward-drift --scores-a outputs/baseline_scores.jsonl --scores-b outputs/new_model_scores.jsonl
 ```
 
 ### `rldk reward-health`

--- a/src/rldk/cli.py
+++ b/src/rldk/cli.py
@@ -5,7 +5,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 import pandas as pd
@@ -67,7 +67,7 @@ from rldk.replay import replay
 from rldk.reward import health
 
 # Import reward modules
-from rldk.reward.drift import compare_models
+from rldk.reward.drift import compare_models, compare_score_lists
 from rldk.reward.health_analysis import health as reward_health_analysis
 from rldk.reward.health_config.config import get_legacy_thresholds, load_config
 from rldk.reward.health_config.exit_codes import raise_on_failure
@@ -1017,32 +1017,156 @@ def forensics_doctor(
 # REWARD COMMANDS
 # ============================================================================
 
+def _load_score_file(path: str, label: str) -> Tuple[List[str], List[float]]:
+    """Load prompts and scores from a JSONL score file."""
+
+    prompts: List[str] = []
+    scores: List[float] = []
+
+    for line_number, record in enumerate(read_jsonl(path), start=1):
+        if not isinstance(record, dict):
+            raise ValueError(
+                f"{label} score file contains a non-object record on line {line_number}."
+            )
+
+        if "score" not in record:
+            raise ValueError(
+                f"Missing 'score' field in {label} score file on line {line_number}."
+            )
+
+        score_value = record.get("score")
+        if score_value is None:
+            raise ValueError(
+                f"Score value is missing for line {line_number} in {label} score file."
+            )
+
+        try:
+            score_float = float(score_value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Score value on line {line_number} in {label} score file is not numeric: {score_value!r}."
+            ) from exc
+
+        prompt_value = record.get("prompt") or record.get("text") or ""
+        prompts.append(str(prompt_value))
+        scores.append(score_float)
+
+    if not scores:
+        raise ValueError(f"No scores found in {label} score file at {path}.")
+
+    return prompts, scores
+
+
+def _has_prompt_text(prompts: Sequence[str]) -> bool:
+    return any(str(prompt).strip() for prompt in prompts)
+
+
+def _validate_score_alignment(prompts_a: Sequence[str], prompts_b: Sequence[str]) -> None:
+    if len(prompts_a) != len(prompts_b):
+        raise ValueError(
+            "Score files must have the same number of records for drift comparison."
+        )
+
+    if _has_prompt_text(prompts_a) and _has_prompt_text(prompts_b):
+        mismatched_rows = [
+            str(index + 1)
+            for index, (prompt_a, prompt_b) in enumerate(zip(prompts_a, prompts_b))
+            if str(prompt_a) != str(prompt_b)
+        ]
+        if mismatched_rows:
+            joined_rows = ", ".join(mismatched_rows[:5])
+            suffix = "" if len(mismatched_rows) <= 5 else ", ..."
+            raise ValueError(
+                "Score files contain mismatched prompts at rows: "
+                f"{joined_rows}{suffix}."
+            )
+
+
+def _select_prompts(prompts_a: Sequence[str], prompts_b: Sequence[str]) -> List[str]:
+    if _has_prompt_text(prompts_a):
+        return [str(prompt) for prompt in prompts_a]
+    if _has_prompt_text(prompts_b):
+        return [str(prompt) for prompt in prompts_b]
+    return [""] * len(prompts_a)
+
+
 @reward_app.command(name="reward-drift")
 def reward_drift(
-    model_a: str = typer.Argument(..., help="Path to first reward model directory"),
-    model_b: str = typer.Argument(..., help="Path to second reward model directory"),
-    prompts: str = typer.Option(
-        ..., "--prompts", "-p", help="Path to prompts JSONL file"
+    model_a: Optional[str] = typer.Argument(
+        None, help="Path to first reward model directory"
+    ),
+    model_b: Optional[str] = typer.Argument(
+        None, help="Path to second reward model directory"
+    ),
+    prompts: Optional[str] = typer.Option(
+        None, "--prompts", "-p", help="Path to prompts JSONL file"
+    ),
+    scores_a: Optional[str] = typer.Option(
+        None, "--scores-a", help="Path to JSONL score file for the first model"
+    ),
+    scores_b: Optional[str] = typer.Option(
+        None, "--scores-b", help="Path to JSONL score file for the second model"
     ),
 ):
     """Compare two reward models and detect drift."""
     try:
-        typer.echo("Comparing reward models:")
-        typer.echo(f"  Model A: {model_a}")
-        typer.echo(f"  Model B: {model_b}")
-        typer.echo(f"  Prompts: {prompts}")
+        using_score_files = scores_a is not None or scores_b is not None
+        using_model_dirs = model_a is not None or model_b is not None
 
-        # Read prompts
-        prompt_list = list(read_jsonl(prompts))
-        prompt_texts = [p.get("text", p.get("prompt", "")) for p in prompt_list]
+        if using_score_files and using_model_dirs:
+            raise ValueError(
+                "Provide either model directories with --prompts or two score files, not both."
+            )
 
-        if not prompt_texts:
-            raise ValueError("No valid prompts found in file")
+        if using_score_files:
+            if scores_a is None or scores_b is None:
+                raise ValueError(
+                    "Both --scores-a and --scores-b must be provided when comparing score files."
+                )
 
-        typer.echo(f"Loaded {len(prompt_texts)} prompts")
+            typer.echo("Comparing reward scores from files:")
+            typer.echo(f"  Scores A: {scores_a}")
+            typer.echo(f"  Scores B: {scores_b}")
 
-        # Compare models
-        report = compare_models(model_a, model_b, prompt_texts)
+            prompts_a, scores_list_a = _load_score_file(scores_a, "First")
+            prompts_b, scores_list_b = _load_score_file(scores_b, "Second")
+            _validate_score_alignment(prompts_a, prompts_b)
+            prompt_texts = _select_prompts(prompts_a, prompts_b)
+
+            report = compare_score_lists(prompt_texts, scores_list_a, scores_list_b)
+            scores_a_values = scores_list_a
+            scores_b_values = scores_list_b
+        else:
+            if model_a is None or model_b is None:
+                raise ValueError(
+                    "Model directory paths are required when score files are not provided."
+                )
+            if prompts is None:
+                raise ValueError(
+                    "--prompts is required when comparing model directories."
+                )
+
+            typer.echo("Comparing reward models:")
+            typer.echo(f"  Model A: {model_a}")
+            typer.echo(f"  Model B: {model_b}")
+            typer.echo(f"  Prompts: {prompts}")
+
+            # Read prompts
+            prompt_list = list(read_jsonl(prompts))
+            prompt_texts = [p.get("text", p.get("prompt", "")) for p in prompt_list]
+
+            if not prompt_texts:
+                raise ValueError("No valid prompts found in file")
+
+            typer.echo(f"Loaded {len(prompt_texts)} prompts")
+
+            model_a_fn = read_reward_head(model_a)
+            model_b_fn = read_reward_head(model_b)
+
+            scores_a_values = model_a_fn(prompt_texts)
+            scores_b_values = model_b_fn(prompt_texts)
+
+            report = compare_score_lists(prompt_texts, scores_a_values, scores_b_values)
 
         # Validate report
         validate(RewardDriftReportV1, report)
@@ -1054,19 +1178,12 @@ def reward_drift(
         # Create scatter plot
         import matplotlib.pyplot as plt
 
-        # Load model outputs for plotting
-        model_a_fn = read_reward_head(model_a)
-        model_b_fn = read_reward_head(model_b)
-
-        scores_a = model_a_fn(prompt_texts)
-        scores_b = model_b_fn(prompt_texts)
-
         fig, ax = plt.subplots(figsize=(8, 8))
-        ax.scatter(scores_a, scores_b, alpha=0.6)
+        ax.scatter(scores_a_values, scores_b_values, alpha=0.6)
 
         # Add diagonal line
-        min_val = min(min(scores_a), min(scores_b))
-        max_val = max(max(scores_a), max(scores_b))
+        min_val = min(min(scores_a_values), min(scores_b_values))
+        max_val = max(max(scores_a_values), max(scores_b_values))
         ax.plot([min_val, max_val], [min_val, max_val], "r--", alpha=0.5)
 
         ax.set_xlabel("Model A Scores")
@@ -1097,6 +1214,9 @@ def reward_drift(
         typer.echo(f"  MAE (z-scored): {report['mae_z']:.4f}")
         typer.echo(f"  L2 distance (z-scored): {report['l2_z']:.4f}")
         typer.echo(f"  Sign flip rate: {report['sign_flip_rate']:.4f}")
+        typer.echo(f"  Drift magnitude: {report['drift_magnitude']:.4f}")
+        typer.echo(f"  Effect size (Cohen's d): {report['effect_size']:.4f}")
+        typer.echo(f"  Confidence: {report['confidence_summary']}")
 
         if report["slice_deltas"]:
             typer.echo("\nSlice analysis:")

--- a/src/rldk/io/consolidated_schemas.py
+++ b/src/rldk/io/consolidated_schemas.py
@@ -421,6 +421,9 @@ RewardDriftReportV1 = {
         "mae_z",
         "l2_z",
         "sign_flip_rate",
+        "drift_magnitude",
+        "effect_size",
+        "confidence_summary",
         "slice_deltas",
     ],
     "properties": {
@@ -430,6 +433,9 @@ RewardDriftReportV1 = {
         "mae_z": {"type": "number"},
         "l2_z": {"type": "number"},
         "sign_flip_rate": {"type": "number"},
+        "drift_magnitude": {"type": "number"},
+        "effect_size": {"type": "number"},
+        "confidence_summary": {"type": "string"},
         "slice_deltas": {
             "type": "object",
             "additionalProperties": {

--- a/src/rldk/io/schemas.py
+++ b/src/rldk/io/schemas.py
@@ -128,6 +128,9 @@ RewardDriftReportV1 = {
         "mae_z",
         "l2_z",
         "sign_flip_rate",
+        "drift_magnitude",
+        "effect_size",
+        "confidence_summary",
         "slice_deltas",
     ],
     "properties": {
@@ -137,6 +140,9 @@ RewardDriftReportV1 = {
         "mae_z": {"type": "number"},
         "l2_z": {"type": "number"},
         "sign_flip_rate": {"type": "number"},
+        "drift_magnitude": {"type": "number"},
+        "effect_size": {"type": "number"},
+        "confidence_summary": {"type": "string"},
         "slice_deltas": {
             "type": "object",
             "additionalProperties": {

--- a/src/rldk/reward/drift.py
+++ b/src/rldk/reward/drift.py
@@ -1,27 +1,75 @@
 """Reward model drift detection."""
 
+from __future__ import annotations
+
+import math
 import re
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, Iterable, List, Sequence, Tuple
 
 import numpy as np
 import pandas as pd
-from scipy.stats import ks_2samp, pearsonr, spearmanr
+from scipy.stats import ks_2samp, pearsonr, spearmanr, t
 
 from rldk.io.readers import read_reward_head
 
 
 def compare_models(
-    model_a_dir: str, model_b_dir: str, prompts: List[str]
+    model_a_dir: str, model_b_dir: str, prompts: Sequence[str]
 ) -> Dict[str, Any]:
     """Compare two reward models and detect drift."""
+
+    prompts_list = list(prompts)
+    if len(prompts_list) < 2:
+        raise ValueError(
+            "Reward drift comparison requires at least two prompts to compute statistics."
+        )
 
     # Load reward models
     model_a_fn = read_reward_head(model_a_dir)
     model_b_fn = read_reward_head(model_b_dir)
 
     # Get scores
-    scores_a = model_a_fn(prompts)
-    scores_b = model_b_fn(prompts)
+    scores_a = model_a_fn(prompts_list)
+    scores_b = model_b_fn(prompts_list)
+
+    return compare_score_lists(prompts_list, scores_a, scores_b)
+
+
+def compare_score_lists(
+    prompts: Sequence[str],
+    scores_a: Iterable[float],
+    scores_b: Iterable[float],
+) -> Dict[str, Any]:
+    """Compare two sets of scores that correspond to the same prompts."""
+
+    scores_a_arr = np.asarray(list(scores_a), dtype=float)
+    scores_b_arr = np.asarray(list(scores_b), dtype=float)
+
+    if scores_a_arr.shape != scores_b_arr.shape:
+        raise ValueError(
+            "Score sequences must have the same length for drift comparison."
+        )
+    if scores_a_arr.size < 2:
+        raise ValueError(
+            "Reward drift comparison requires at least two scores on each side."
+        )
+
+    prompts_list = list(prompts)
+    if prompts_list:
+        if len(prompts_list) != scores_a_arr.size:
+            raise ValueError(
+                "Number of prompts must match the number of scores for drift comparison."
+            )
+    else:
+        prompts_list = [""] * scores_a_arr.size
+
+    return _compute_drift_report(prompts_list, scores_a_arr, scores_b_arr)
+
+
+def _compute_drift_report(
+    prompts: List[str], scores_a: np.ndarray, scores_b: np.ndarray
+) -> Dict[str, Any]:
+    """Compute the reward drift report for two aligned score arrays."""
 
     # Compute correlation metrics
     pearson_corr, _ = pearsonr(scores_a, scores_b)
@@ -40,6 +88,9 @@ def compare_models(
     # Compute slice deltas
     slice_deltas = compute_slice_deltas(prompts, scores_a, scores_b)
 
+    mean_diff, confidence_summary = _compute_confidence_summary(scores_a, scores_b)
+    effect_size = _compute_effect_size(scores_a, scores_b)
+
     return {
         "version": "1",
         "pearson": float(pearson_corr),
@@ -47,11 +98,14 @@ def compare_models(
         "mae_z": float(mae_z),
         "l2_z": float(l2_z),
         "sign_flip_rate": float(sign_flip_rate),
+        "drift_magnitude": float(abs(mean_diff)),
+        "effect_size": float(effect_size),
+        "confidence_summary": confidence_summary,
         "slice_deltas": slice_deltas,
     }
 
 
-def z_score(values: List[float]) -> np.ndarray:
+def z_score(values: Sequence[float]) -> np.ndarray:
     """Compute z-scores for a list of values."""
     values = np.array(values)
     mean = np.mean(values)
@@ -62,7 +116,7 @@ def z_score(values: List[float]) -> np.ndarray:
 
 
 def compute_slice_deltas(
-    prompts: List[str], scores_a: List[float], scores_b: List[float]
+    prompts: Sequence[str], scores_a: Sequence[float], scores_b: Sequence[float]
 ) -> Dict[str, Dict[str, Any]]:
     """Compute deltas for different prompt slices."""
     slice_deltas = {}
@@ -143,3 +197,56 @@ def detect_reward_drift(
     )
 
     return drift_detected, drift_metrics
+
+
+def _compute_effect_size(scores_a: np.ndarray, scores_b: np.ndarray) -> float:
+    """Compute Cohen's d effect size for two score distributions."""
+
+    n_a = scores_a.size
+    n_b = scores_b.size
+    if n_a < 2 or n_b < 2:
+        return 0.0
+
+    var_a = np.var(scores_a, ddof=1)
+    var_b = np.var(scores_b, ddof=1)
+    pooled_denom = ((n_a - 1) * var_a + (n_b - 1) * var_b)
+    if pooled_denom <= 0:
+        return 0.0
+
+    pooled_std = math.sqrt(pooled_denom / (n_a + n_b - 2))
+    if pooled_std == 0 or not math.isfinite(pooled_std):
+        return 0.0
+
+    return float((np.mean(scores_b) - np.mean(scores_a)) / pooled_std)
+
+
+def _compute_confidence_summary(
+    scores_a: np.ndarray, scores_b: np.ndarray
+) -> Tuple[float, str]:
+    """Compute mean difference and a 95% confidence interval summary string."""
+
+    mean_diff = float(np.mean(scores_b) - np.mean(scores_a))
+
+    n_a = scores_a.size
+    n_b = scores_b.size
+    if n_a < 2 or n_b < 2:
+        return mean_diff, "Not enough data to compute confidence interval."
+
+    var_a = np.var(scores_a, ddof=1)
+    var_b = np.var(scores_b, ddof=1)
+    se_diff = math.sqrt(var_a / n_a + var_b / n_b)
+    if se_diff == 0 or not math.isfinite(se_diff):
+        return mean_diff, "Not enough variance to compute confidence interval."
+
+    df = min(n_a, n_b) - 1
+    if df <= 0:
+        return mean_diff, "Not enough data to compute confidence interval."
+
+    t_value = t.ppf(0.975, df)
+    if not math.isfinite(t_value):
+        return mean_diff, "Not enough data to compute confidence interval."
+
+    lower = mean_diff - t_value * se_diff
+    upper = mean_diff + t_value * se_diff
+    summary = f"Mean difference {mean_diff:.4f} (95% CI [{lower:.4f}, {upper:.4f}])"
+    return mean_diff, summary

--- a/tests/integration/test_reward_drift.py
+++ b/tests/integration/test_reward_drift.py
@@ -1,11 +1,14 @@
 """Test reward drift functionality."""
 
+import json
 import tempfile
 from pathlib import Path
 
 import torch
 import torch.nn as nn
+from typer.testing import CliRunner
 
+from rldk.cli import app
 from rldk.io.schemas import RewardDriftReportV1, validate
 from rldk.reward.drift import compare_models
 
@@ -119,3 +122,85 @@ def test_reward_drift_slice_analysis():
             assert "delta_mean" in slice_data
             assert "n" in slice_data
             assert slice_data["n"] > 0
+
+
+def test_reward_drift_score_files_cli() -> None:
+    """Score file mode should compute drift without model directories."""
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        scores_a_path = Path("scores_a.jsonl")
+        scores_b_path = Path("scores_b.jsonl")
+
+        scores_a = [
+            {"prompt": "Prompt 1", "score": 0.1},
+            {"prompt": "Prompt 2", "score": 0.2},
+            {"prompt": "Prompt 3", "score": 0.3},
+        ]
+        scores_b = [
+            {"prompt": "Prompt 1", "score": 0.2},
+            {"prompt": "Prompt 2", "score": 0.4},
+            {"prompt": "Prompt 3", "score": 0.6},
+        ]
+
+        scores_a_path.write_text("\n".join(json.dumps(item) for item in scores_a))
+        scores_b_path.write_text("\n".join(json.dumps(item) for item in scores_b))
+
+        result = runner.invoke(
+            app,
+            [
+                "reward",
+                "reward-drift",
+                "--scores-a",
+                str(scores_a_path),
+                "--scores-b",
+                str(scores_b_path),
+            ],
+        )
+
+        assert result.exit_code == 0, result.stdout
+
+        report_path = Path("rldk_reports/reward_drift.json")
+        assert report_path.exists()
+
+        report_data = json.loads(report_path.read_text())
+        assert report_data["drift_magnitude"] > 0.0
+        assert abs(report_data["effect_size"]) > 0.0
+        assert isinstance(report_data["confidence_summary"], str)
+
+
+def test_reward_drift_score_file_length_mismatch() -> None:
+    """Score files with mismatched rows should raise a friendly error."""
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        scores_a_path = Path("scores_a.jsonl")
+        scores_b_path = Path("scores_b.jsonl")
+
+        scores_a_path.write_text(
+            "\n".join(
+                json.dumps(item)
+                for item in (
+                    {"prompt": "Prompt 1", "score": 0.1},
+                    {"prompt": "Prompt 2", "score": 0.2},
+                )
+            )
+        )
+
+        scores_b_path.write_text(json.dumps({"prompt": "Prompt 1", "score": 0.1}))
+
+        result = runner.invoke(
+            app,
+            [
+                "reward",
+                "reward-drift",
+                "--scores-a",
+                str(scores_a_path),
+                "--scores-b",
+                str(scores_b_path),
+            ],
+        )
+
+        assert result.exit_code != 0
+        error_output = (result.stderr or result.stdout).lower()
+        assert "same number of records" in error_output


### PR DESCRIPTION
## Summary
- allow the reward drift CLI to operate on pairs of JSONL score files without requiring model directories
- extend the drift report schema and implementation to compute drift magnitude, effect size, and a confidence summary
- document the new usage and cover score file behaviour with integration tests

## Testing
- pytest tests/integration/test_reward_drift.py

------
https://chatgpt.com/codex/tasks/task_e_68cb2053f554832f90d123dd501a3f38