### PR TITLE
Refactor TRL adapter to use shared normalizer

### DIFF
--- a/docs/TRL_INTEGRATION_GUIDE.md
+++ b/docs/TRL_INTEGRATION_GUIDE.md
@@ -216,6 +216,12 @@ adapter = TRLAdapter("malformed_events.jsonl")
 df = adapter.load()  # Only loads valid lines
 ```
 
+### Unknown Schemas
+
+Logs that use custom field names now fall back to the flexible adapter with a helpful
+message suggesting ``--field-map``. This keeps ingestion resilient while guiding you to
+map bespoke metrics into the shared TrainingMetrics schema.
+
 ### Missing Dependencies
 
 If TRL is not available, RLDK will raise a clear error:

--- a/src/rldk/adapters/trl.py
+++ b/src/rldk/adapters/trl.py
@@ -1,389 +1,241 @@
 """Adapter for TRL (Transformer Reinforcement Learning) logs."""
 
+from __future__ import annotations
+
 import json
-import re
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Dict, Iterable, List, Tuple
 
 import pandas as pd
 
-from ..utils.error_handling import AdapterError
+from ..utils.error_handling import AdapterError, ValidationError
 from .base import BaseAdapter
+from .flexible import FlexibleDataAdapter
 
 
 class TRLAdapter(BaseAdapter):
-    """Adapter for TRL training logs."""
+    """Adapter that normalizes TRL logs using the shared TrainingMetrics schema."""
+
+    PRESET = "trl"
+    _SUPPORTED_EXTENSIONS = {".jsonl", ".ndjson"}
+    _COLUMN_ALIASES: Dict[str, str] = {
+        "reward": "reward_mean",
+        "kl": "kl_mean",
+        "entropy": "entropy_mean",
+        "clipfrac": "clip_frac",
+        "learning_rate": "lr",
+        "gradient_norm": "grad_norm",
+        "total_loss": "loss",
+        "policy_loss": "loss",
+        "input_tokens": "tokens_in",
+        "output_tokens": "tokens_out",
+        "experiment_id": "run_id",
+        "commit_hash": "git_sha",
+    }
 
     def can_handle(self) -> bool:
-        """Check if source contains TRL logs."""
-        try:
-            if not self.source.exists():
-                return False
+        """Return ``True`` if the source looks like a TRL metrics export."""
 
-            # Look for TRL-specific files or patterns
-            if self.source.is_file():
-                return self._is_trl_file(self.source)
-            elif self.source.is_dir():
-                # Check for common TRL log files including new RLDK JSONL events
-                trl_files = (list(self.source.glob("*.log")) +
-                            list(self.source.glob("trainer_log.jsonl")) +
-                            list(self.source.glob("*_events.jsonl")) +
-                            list(self.source.glob("*.jsonl")))  # Be more permissive
-                return len(trl_files) > 0
-
-            return False
-        except Exception as e:
-            self.logger.warning(f"Error checking if source can be handled: {e}")
+        if not self.source.exists():
             return False
 
-    def _is_trl_file(self, file_path: Path) -> bool:
-        """Check if a file contains TRL logs."""
-        try:
-            self._handle_file_error(file_path, "read")
+        if self.source.is_file():
+            return self.source.suffix.lower() in self._SUPPORTED_EXTENSIONS
 
-            if file_path.suffix == ".jsonl":
-                with open(file_path) as f:
-                    first_line = f.readline().strip()
-                    if first_line:
-                        data = json.loads(first_line)
-                        # Check for TRL-specific keywords or our test fixture format
-                        # First check if data is a dict and has the required keys
-                        if isinstance(data, dict):
-                            # Check for new Event schema format
-                            if "metrics" in data and "model_info" in data:
-                                return True
-                            # Check for old format - be more flexible
-                            has_required_fields = all(
-                                key in data
-                                for key in ["step", "phase", "reward_mean", "kl_mean"]
-                            )
-                            has_trl_keywords = (
-                                "trl" in str(data).lower()
-                                or "trainer" in str(data).lower()
-                            )
-                            # Accept if it has required fields OR TRL keywords
-                            return has_required_fields or has_trl_keywords
-                        else:
-                            # For non-dict data, only check string content
-                            return (
-                                "trl" in str(data).lower()
-                                or "trainer" in str(data).lower()
-                            )
-            elif file_path.suffix == ".log":
-                with open(file_path) as f:
-                    content = f.read()
-                    return "trl" in content.lower() or "trainer" in content.lower()
-        except (OSError, UnicodeDecodeError, TypeError) as e:
-            # Log the specific error for debugging but don't fail the check
-            self.logger.warning(f"Error checking if file {file_path} is TRL format: {e}")
-            return False
-        except json.JSONDecodeError as e:
-            # Log JSON decode error but don't fail the check
-            self.logger.warning(f"JSON decode error in {file_path}: {e}")
-            return False
-        except AdapterError:
-            # Re-raise adapter errors
-            raise
-        except Exception as e:
-            self.logger.warning(f"Unexpected error checking TRL file {file_path}: {e}")
-            return False
+        if self.source.is_dir():
+            return any(
+                path.suffix.lower() in self._SUPPORTED_EXTENSIONS
+                for path in self._iter_candidate_files(self.source)
+            )
+
         return False
 
     def load(self) -> pd.DataFrame:
-        """Load TRL logs and convert to standard format."""
+        """Load TRL logs and normalize them into the TrainingMetrics table."""
+
         if not self.can_handle():
             raise AdapterError(
                 f"Cannot handle source: {self.source}",
-                suggestion="Check that the source contains TRL training logs",
-                error_code="CANNOT_HANDLE_SOURCE"
+                suggestion=(
+                    "Provide a TRL JSONL/NDJSON file or directory containing TRL events"
+                ),
+                error_code="CANNOT_HANDLE_SOURCE",
             )
 
-        self._log_operation("Loading TRL data", {"source": str(self.source)})
+        frames: List[pd.DataFrame] = []
 
-        metrics = []
-
-        try:
-            if self.source.is_file():
-                metrics = self._parse_file(self.source)
-            elif self.source.is_dir():
-                # Find and parse all TRL log files
-                log_files = list(self.source.glob("*.log")) + list(
-                    self.source.glob("*.jsonl")
+        for path in self._iter_candidate_files(self.source):
+            try:
+                frame = self._load_jsonl_file(path)
+            except ValidationError as exc:
+                self.logger.warning(
+                    "TRL adapter could not normalize %s directly (%s); falling back to the flexible adapter. "
+                    "Provide --field-map if your metrics use custom names.",
+                    path,
+                    exc,
                 )
-                if not log_files:
-                    raise AdapterError(
-                        f"No log files found in directory: {self.source}",
-                        suggestion="Ensure the directory contains .log or .jsonl files",
-                        error_code="NO_LOG_FILES_FOUND"
-                    )
+                frame = self._fallback_with_flexible(path)
+            frames.append(self._apply_legacy_aliases(frame))
 
-                for log_file in log_files:
-                    try:
-                        file_metrics = self._parse_file(log_file)
-                        metrics.extend(file_metrics)
-                    except Exception as e:
-                        self.logger.warning(f"Failed to parse {log_file}: {e}")
-                        continue
-
-            if not metrics:
-                # Try fallback parsing with more lenient requirements
-                metrics = self._fallback_parse()
-                if not metrics:
-                    raise AdapterError(
-                        f"No valid TRL metrics found in {self.source}",
-                        suggestion="Check that the source contains valid TRL training data. Required fields: step, phase, reward_mean, kl_mean",
-                        error_code="NO_VALID_METRICS_FOUND"
-                    )
-
-            # Convert to DataFrame
-            df = pd.DataFrame(metrics)
-            df = self._validate_dataframe(df)
-
-            # Ensure required columns exist
-            required_cols = [
-                "step",
-                "phase",
-                "reward_mean",
-                "reward_std",
-                "kl_mean",
-                "entropy_mean",
-                "clip_frac",
-                "grad_norm",
-                "lr",
-                "loss",
-                "tokens_in",
-                "tokens_out",
-                "wall_time",
-                "seed",
-                "run_id",
-                "git_sha",
-            ]
-
-            for col in required_cols:
-                if col not in df.columns:
-                    df[col] = None
-
-            self._log_operation("TRL data loaded successfully", {"records": len(df)})
-            return df[required_cols]
-
-        except AdapterError:
-            raise
-        except Exception as e:
+        if not frames:
             raise AdapterError(
-                f"Failed to load TRL data: {e}",
-                suggestion="Check that the source contains valid TRL training logs",
-                error_code="LOAD_FAILED",
-                details={"source": str(self.source)}
-            ) from e
+                f"No TRL metrics found in {self.source}",
+                suggestion="Ensure the path contains TRL JSONL event files",
+                error_code="NO_VALID_METRICS_FOUND",
+            )
 
-    def _parse_file(self, file_path: Path) -> List[Dict[str, Any]]:
-        """Parse a single TRL log file."""
-        metrics = []
+        combined = pd.concat(frames, ignore_index=True) if len(frames) > 1 else frames[0]
 
         try:
-            if file_path.suffix == ".jsonl":
-                with open(file_path) as f:
-                    for line_num, line in enumerate(f, 1):  # Start line numbering from 1
-                        line = line.strip()
-                        if not line:
-                            continue
-                        try:
-                            data = json.loads(line)
-                            metric = self._extract_trl_metric(data, line_num)
-                            if metric:
-                                metrics.append(metric)
-                        except json.JSONDecodeError as e:
-                            print(f"Warning: JSON decode error in {file_path} at line {line_num}: {e}")
-                            continue
+            from ..ingest.training_metrics_normalizer import standardize_training_metrics
 
-            elif file_path.suffix == ".log":
-                with open(file_path) as f:
-                    for line_num, line in enumerate(f, 1):  # Start line numbering from 1
-                        metric = self._parse_log_line(line, line_num)
-                        if metric:
-                            metrics.append(metric)
+            return standardize_training_metrics(combined)
+        except ValidationError as exc:
+            raise AdapterError(
+                f"Failed to standardize TRL metrics from {self.source}: {exc}",
+                suggestion="Provide --field-map or use the flexible adapter for custom schemas",
+                error_code="SCHEMA_STANDARDIZATION_FAILED",
+            ) from exc
 
-        except (OSError, UnicodeDecodeError) as e:
-            print(f"Warning: Error parsing {file_path}: {e}")
-            # Re-raise the exception with context
-            raise RuntimeError(f"Failed to parse TRL file {file_path}: {e}") from e
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
 
-        return metrics
+    def _iter_candidate_files(self, source: Path) -> Iterable[Path]:
+        if source.is_file():
+            yield source
+            return
 
-    def _extract_trl_metric(
-        self, data: Dict[str, Any], line_num: int
-    ) -> Dict[str, Any]:
-        """Extract metric from TRL JSON data."""
-        # Handle both old format and new Event schema format
-        if "metrics" in data and "model_info" in data:
-            # New Event schema format
-            metrics = data.get("metrics", {})
-            model_info = data.get("model_info", {})
-            rng = data.get("rng", {})
-            data_slice = data.get("data_slice", {})
+        for pattern in ("*.jsonl", "*.ndjson"):
+            for path in sorted(source.glob(pattern)):
+                yield path
 
-            metric = {
-                "step": data.get("step", line_num),
-                "phase": model_info.get("phase", "train"),
-                "reward_mean": metrics.get("reward_mean"),
-                "reward_std": metrics.get("reward_std"),
-                "kl_mean": metrics.get("kl_mean"),
-                "entropy_mean": metrics.get("entropy_mean"),
-                "clip_frac": metrics.get("clip_frac"),
-                "grad_norm": metrics.get("grad_norm"),
-                "lr": metrics.get("lr"),
-                "loss": metrics.get("loss"),
-                "tokens_in": data_slice.get("tokens_in"),
-                "tokens_out": data_slice.get("tokens_out"),
-                "wall_time": data.get("wall_time"),
-                "seed": rng.get("seed"),
-                "run_id": model_info.get("run_id"),
-                "git_sha": model_info.get("git_sha"),
-            }
-        else:
-            # Old format (backward compatibility)
-            metric = {
-                "step": data.get("step", line_num),
-                "phase": data.get("phase", "train"),
-                "reward_mean": data.get("reward_mean")
-                or data.get("reward", {}).get("mean"),
-                "reward_std": data.get("reward_std") or data.get("reward", {}).get("std"),
-                "kl_mean": data.get("kl_mean") or data.get("kl_div", {}).get("mean"),
-                "entropy_mean": data.get("entropy_mean")
-                or data.get("entropy", {}).get("mean"),
-                "clip_frac": data.get("clip_frac") or data.get("clipped_ratio"),
-                "grad_norm": data.get("grad_norm") or data.get("gradient_norm"),
-                "lr": data.get("lr") or data.get("learning_rate"),
-                "loss": data.get("loss") or data.get("total_loss"),
-                "tokens_in": data.get("tokens_in") or data.get("input_tokens"),
-                "tokens_out": data.get("tokens_out") or data.get("output_tokens"),
-                "wall_time": data.get("wall_time")
-                or (
-                    data.get("wall_time_ms", 0) / 1000.0
-                    if data.get("wall_time_ms") is not None
-                    else None
-                ),
-                "seed": data.get("seed"),
-                "run_id": data.get("run_id") or data.get("experiment_id"),
-                "git_sha": data.get("git_sha") or data.get("commit_hash"),
-            }
+    def _load_jsonl_file(self, path: Path) -> pd.DataFrame:
+        format_hint, first_record = self._detect_jsonl_format(path)
 
-        return metric
+        if format_hint == "event_stream":
+            from ..ingest.stream_normalizer import stream_jsonl_to_dataframe
 
-    def _parse_log_line(self, line: str, line_num: int) -> Dict[str, Any]:
-        """Parse a single log line for metrics."""
-        # Simple regex patterns for common TRL log formats
-        patterns = {
-            "step": r"step[:\s]+(\d+)",
-            "reward": r"reward[:\s]+([\d.-]+)",
-            "kl": r"kl[:\s]+([\d.-]+)",
-            "entropy": r"entropy[:\s]+([\d.-]+)",
-            "loss": r"loss[:\s]+([\d.-]+)",
-            "lr": r"lr[:\s]+([\d.-]+)",
-        }
+            return stream_jsonl_to_dataframe(path, preset=self.PRESET)
 
-        metric = {"step": line_num, "phase": "train"}
+        if format_hint == "event_dict":
+            from ..io.event_schema import events_to_dataframe
 
-        for key, pattern in patterns.items():
-            match = re.search(pattern, line, re.IGNORECASE)
-            if match:
-                try:
-                    value = float(match.group(1))
-                    if key == "reward":
-                        metric["reward_mean"] = value
-                    elif key == "kl":
-                        metric["kl_mean"] = value
-                    elif key == "entropy":
-                        metric["entropy_mean"] = value
-                    elif key == "loss":
-                        metric["loss"] = value
-                    elif key == "lr":
-                        metric["lr"] = value
-                except ValueError:
-                    continue
+            records = self._read_jsonl_records(path)
+            return events_to_dataframe(records)
 
-        # Only return if we found some meaningful metrics
-        if len(metric) > 2:  # More than just step and phase
-            return metric
+        if format_hint == "flat_table":
+            records = self._read_jsonl_records(path)
+            if not records:
+                raise ValidationError(
+                    f"No valid TRL records found in {path}",
+                    suggestion="Ensure the file contains JSON objects",
+                    error_code="NO_VALID_EVENTS",
+                )
+            return pd.DataFrame(records)
 
-        return None
+        raise ValidationError(
+            f"Unrecognized TRL log structure in {path}",
+            suggestion="Use --field-map with the flexible adapter to describe custom layouts",
+            error_code="UNKNOWN_TRL_FORMAT",
+            details={"first_record": first_record},
+        )
 
-    def _fallback_parse(self) -> List[Dict[str, Any]]:
-        """Fallback parsing with more lenient requirements."""
-        metrics = []
-
+    def _detect_jsonl_format(self, path: Path) -> Tuple[str | None, Dict[str, object] | None]:
         try:
-            if self.source.is_file():
-                metrics = self._fallback_parse_file(self.source)
-            elif self.source.is_dir():
-                # Try all JSONL files with fallback parsing
-                jsonl_files = list(self.source.glob("*.jsonl"))
-                for jsonl_file in jsonl_files:
-                    try:
-                        file_metrics = self._fallback_parse_file(jsonl_file)
-                        metrics.extend(file_metrics)
-                    except Exception as e:
-                        self.logger.warning(f"Fallback parsing failed for {jsonl_file}: {e}")
-                        continue
-        except Exception as e:
-            self.logger.warning(f"Fallback parsing failed: {e}")
-
-        return metrics
-
-    def _fallback_parse_file(self, file_path: Path) -> List[Dict[str, Any]]:
-        """Fallback parsing for a single file with lenient requirements."""
-        metrics = []
-
-        if file_path.suffix != ".jsonl":
-            return metrics
-
-        try:
-            with open(file_path) as f:
-                for line_num, line in enumerate(f, 1):  # Start line numbering from 1
-                    line = line.strip()
+            with path.open("r", encoding="utf-8") as handle:
+                for raw_line in handle:
+                    line = raw_line.strip()
                     if not line:
                         continue
-
-                    try:
-                        data = json.loads(line)
-                        if isinstance(data, dict):
-                            # More lenient metric extraction
-                            metric = self._extract_metric_lenient(data, line_num)
-                            if metric:
-                                metrics.append(metric)
-                    except json.JSONDecodeError as e:
-                        self.logger.warning(f"JSON decode error in {file_path} at line {line_num}: {e}")
+                    record = json.loads(line)
+                    if not isinstance(record, dict):
                         continue
-        except Exception as e:
-            self.logger.warning(f"Error in fallback parsing {file_path}: {e}")
+                    metrics = record.get("metrics")
+                    if isinstance(metrics, dict):
+                        return "event_dict", record
+                    if metrics is not None and not isinstance(metrics, dict):
+                        return None, record
+                    if any(key in record for key in ("metric", "metric_name", "name")):
+                        return "event_stream", record
+                    return "flat_table", record
+        except json.JSONDecodeError as exc:
+            raise ValidationError(
+                f"Invalid JSON in {path}: {exc}",
+                suggestion="Ensure each line is a valid JSON object",
+                error_code="INVALID_JSONL",
+            ) from exc
 
-        return metrics
+        return None, None
 
-    def _extract_metric_lenient(self, data: Dict[str, Any], line_num: int) -> Dict[str, Any]:
-        """Extract metric with lenient requirements - only need step and some metrics."""
-        # Check if we have at least a step and some meaningful data
-        if "step" not in data:
-            return None
+    def _read_jsonl_records(self, path: Path) -> List[Dict[str, object]]:
+        records: List[Dict[str, object]] = []
+        skipped = 0
 
-        # Try to extract any available metrics
-        metric = {
-            "step": data.get("step", line_num),
-            "phase": data.get("phase", "train"),
-        }
+        with path.open("r", encoding="utf-8") as handle:
+            for raw_line in handle:
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    skipped += 1
+                    continue
+                if isinstance(payload, dict):
+                    records.append(payload)
+                else:
+                    skipped += 1
 
-        # Add any available metrics
-        metric_fields = [
-            "reward_mean", "reward_std", "kl_mean", "entropy_mean",
-            "clip_frac", "grad_norm", "lr", "loss", "tokens_in",
-            "tokens_out", "wall_time", "seed", "run_id", "git_sha"
-        ]
+        if skipped:
+            self.logger.warning(
+                "Skipped %d invalid JSONL line%s while reading %s",
+                skipped,
+                "" if skipped == 1 else "s",
+                path,
+            )
 
-        for field in metric_fields:
-            if field in data:
-                metric[field] = data[field]
+        return records
 
-        # Only return if we have at least step and one other metric
-        if len(metric) > 2:
-            return metric
+    def _fallback_with_flexible(self, path: Path) -> pd.DataFrame:
+        adapter = FlexibleDataAdapter(
+            path,
+            validation_mode="flexible",
+            required_fields=["step"],
+        )
 
-        return None
+        try:
+            df = adapter.load()
+        except (AdapterError, ValidationError) as exc:
+            raise AdapterError(
+                f"Flexible adapter could not read {path}",
+                suggestion="Provide --field-map to map your custom metric names",
+                error_code="TRL_FALLBACK_FAILED",
+            ) from exc
+
+        return df
+
+    def _apply_legacy_aliases(self, df: pd.DataFrame) -> pd.DataFrame:
+        if df.empty:
+            return df
+
+        normalized = df.copy()
+
+        if "wall_time" not in normalized and "wall_time_ms" in normalized:
+            normalized["wall_time"] = pd.to_numeric(
+                normalized["wall_time_ms"], errors="coerce"
+            ) / 1000.0
+        if "wall_time_ms" in normalized.columns:
+            normalized = normalized.drop(columns=["wall_time_ms"])
+
+        for alias, canonical in self._COLUMN_ALIASES.items():
+            if canonical in normalized.columns:
+                continue
+            if alias in normalized.columns:
+                normalized[canonical] = normalized[alias]
+
+        return normalized
+
+
+__all__ = ["TRLAdapter"]
+

--- a/tests/integration/test_ingest_adapters.py
+++ b/tests/integration/test_ingest_adapters.py
@@ -3,13 +3,22 @@
 import json
 import os
 import tempfile
+from pathlib import Path
 
+import pandas as pd
 import pytest
 
 from rldk.adapters.openrlhf import OpenRLHFAdapter
 from rldk.adapters.trl import TRLAdapter
 from rldk.adapters.wandb import WandBAdapter
 from rldk.io.schema import MetricsSchema
+from rldk.utils.error_handling import AdapterError
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record) + "\n")
 
 
 class TestTRLAdapter:
@@ -39,77 +48,121 @@ class TestTRLAdapter:
             adapter = TRLAdapter(f.name)
             assert adapter.can_handle()
 
-    def test_load_jsonl(self):
-        """Test loading TRL JSONL data."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
-            # Write test data
-            for i in range(3):
-                json.dump(
-                    {
-                        "step": i,
-                        "phase": "train",
-                        "reward_mean": 0.5 + i * 0.1,
-                        "kl_mean": 0.1 + i * 0.01,
-                        "entropy_mean": 0.8 - i * 0.02,
-                        "loss": 0.4 - i * 0.05,
-                        "lr": 0.001,
-                        "wall_time": i * 10.0,
-                        "seed": 42,
-                        "run_id": "test_run",
-                        "git_sha": "abc123",
-                    },
-                    f,
-                )
-                f.write("\n")
-            f.flush()
+    def test_flat_and_nested_logs_normalize(self, tmp_path: Path):
+        """TRL adapter normalizes flat and nested records to the same table."""
 
-            adapter = TRLAdapter(f.name)
-            df = adapter.load()
+        flat_path = tmp_path / "flat.jsonl"
+        nested_path = tmp_path / "nested.jsonl"
 
-            assert len(df) == 3
-            assert "step" in df.columns
-            assert "reward_mean" in df.columns
-            assert "kl_mean" in df.columns
-            assert "wall_time" in df.columns
-            assert df["step"].iloc[0] == 0
-            assert df["reward_mean"].iloc[0] == 0.5
-
-    def test_round_trip_schema(self):
-        """Test round-trip conversion to and from schema."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
-            # Write test data
-            json.dump(
+        _write_jsonl(
+            flat_path,
+            [
                 {
-                    "step": 0,
+                    "step": 1,
                     "phase": "train",
                     "reward_mean": 0.5,
                     "kl_mean": 0.1,
                     "entropy_mean": 0.8,
-                    "loss": 0.4,
                     "lr": 0.001,
-                    "wall_time": 10.0,
-                    "seed": 42,
-                    "run_id": "test_run",
+                    "grad_norm": 0.2,
+                    "wall_time_ms": 2000,
+                    "seed": 11,
+                    "run_id": "trl-run",
                     "git_sha": "abc123",
+                    "tokens_in": 256,
+                    "tokens_out": 128,
                 },
-                f,
-            )
-            f.write("\n")
-            f.flush()
+                {
+                    "step": 2,
+                    "phase": "train",
+                    "reward_mean": 0.6,
+                    "kl_mean": 0.12,
+                    "entropy_mean": 0.75,
+                    "lr": 0.001,
+                    "grad_norm": 0.25,
+                    "wall_time_ms": 4000,
+                    "seed": 11,
+                    "run_id": "trl-run",
+                    "git_sha": "abc123",
+                    "tokens_in": 300,
+                    "tokens_out": 150,
+                },
+            ],
+        )
 
-            adapter = TRLAdapter(f.name)
-            df = adapter.load()
+        _write_jsonl(
+            nested_path,
+            [
+                {
+                    "step": 1,
+                    "wall_time": 2.0,
+                    "metrics": {
+                        "reward_mean": 0.5,
+                        "kl_mean": 0.1,
+                        "entropy_mean": 0.8,
+                        "lr": 0.001,
+                        "grad_norm": 0.2,
+                    },
+                    "data_slice": {"tokens_in": 256, "tokens_out": 128},
+                    "rng": {"seed": 11},
+                    "model_info": {
+                        "run_id": "trl-run",
+                        "phase": "train",
+                        "git_sha": "abc123",
+                    },
+                },
+                {
+                    "step": 2,
+                    "wall_time": 4.0,
+                    "metrics": {
+                        "reward_mean": 0.6,
+                        "kl_mean": 0.12,
+                        "entropy_mean": 0.75,
+                        "lr": 0.001,
+                        "grad_norm": 0.25,
+                    },
+                    "data_slice": {"tokens_in": 300, "tokens_out": 150},
+                    "rng": {"seed": 11},
+                    "model_info": {
+                        "run_id": "trl-run",
+                        "phase": "train",
+                        "git_sha": "abc123",
+                    },
+                },
+            ],
+        )
 
-            # Convert to schema
-            schema = MetricsSchema.from_dataframe(df)
-            assert len(schema.metrics) == 1
+        df_flat = TRLAdapter(flat_path).load()
+        df_nested = TRLAdapter(nested_path).load()
 
-            # Convert back to dataframe
-            df_round_trip = schema.to_dataframe()
-            assert len(df_round_trip) == 1
-            assert df_round_trip["reward_mean"].iloc[0] == 0.5
+        pd.testing.assert_frame_equal(df_flat, df_nested, check_dtype=False)
 
+    def test_unknown_shape_suggests_field_map(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ):
+        """Unrecognized shapes fall back to flexible adapter with guidance."""
 
+        path = tmp_path / "unknown.jsonl"
+        _write_jsonl(
+            path,
+            [
+                {
+                    "step": 1,
+                    "metrics": [
+                        {"name": "reward_mean", "value": 0.5},
+                    ],
+                }
+            ],
+        )
+
+        adapter = TRLAdapter(path)
+        caplog.set_level("WARNING")
+
+        df = adapter.load()
+
+        assert not df.empty
+        assert "step" in df.columns
+        assert any("field-map" in msg for msg in caplog.messages)
 class TestOpenRLHFAdapter:
     """Test OpenRLHF adapter functionality."""
 


### PR DESCRIPTION
## Summary
- refactor the TRL adapter to normalize JSONL inputs through the shared TrainingMetrics schema
- add coverage for flat, nested, and fallback scenarios so TRL ingestion stays resilient
- document the flexible fallback guidance in the TRL integration guide

## Testing
- pytest tests/integration/test_ingest_adapters.py::TestTRLAdapter -q
- pytest tests/integration/test_ingestion.py::TestTRLAdapter -q

------
https://chatgpt.com/codex/tasks/task_e_68cb45aecc58832f8e4b36bc17ff5e8e