### PR TITLE
Ensure ingest_runs_to_events skips missing metrics

### DIFF
--- a/src/rldk/io/event_schema.py
+++ b/src/rldk/io/event_schema.py
@@ -177,10 +177,16 @@ def create_event_from_row(
 
     metrics: Dict[str, float] = {}
     for field in [*_CORE_METRIC_FIELDS, *_NETWORK_METRIC_FIELDS]:
-        if field in row and row[field] is not None:
-            numeric_value = _coerce_numeric(row[field])
-            if numeric_value is not None:
-                metrics[field] = numeric_value
+        if field not in row:
+            continue
+
+        value = row[field]
+        if _is_missing(value):
+            continue
+
+        numeric_value = _coerce_numeric(value)
+        if numeric_value is not None:
+            metrics[field] = numeric_value
 
     rng = {
         "seed": row.get("seed"),
@@ -342,6 +348,8 @@ def dataframe_to_events(
             "" if dropped == 1 else "s",
         )
         standardized = standardized.loc[~invalid_steps].copy()
+
+    standardized = standardized.sort_values("step", kind="mergesort").reset_index(drop=True)
 
     events: List[Event] = []
     for _, row in standardized.iterrows():

--- a/tests/test_dataframe_event_converters.py
+++ b/tests/test_dataframe_event_converters.py
@@ -102,3 +102,36 @@ def test_dataframe_to_events_preserves_network_metrics() -> None:
     restored = events_to_dataframe(events)
     assert restored.loc[0, "network_bandwidth"] == pytest.approx(250.0)
     assert restored.loc[0, "latency_ms"] == pytest.approx(12.5)
+
+
+def test_dataframe_to_events_ignores_missing_metrics() -> None:
+    df = pd.DataFrame(
+        {
+            "step": [0, 1],
+            "reward_mean": [None, 0.75],
+            "kl_mean": [0.12, float("nan")],
+        }
+    )
+
+    events = dataframe_to_events(df, run_id="missing-metrics")
+
+    assert len(events) == 2
+    assert "reward_mean" not in events[0].metrics
+    assert events[1].metrics["reward_mean"] == pytest.approx(0.75)
+    assert events[0].metrics["kl_mean"] == pytest.approx(0.12)
+    assert "kl_mean" not in events[1].metrics
+
+
+def test_dataframe_to_events_orders_by_step_stably() -> None:
+    df = pd.DataFrame(
+        {
+            "step": [3, 1, 2, 1],
+            "reward_mean": [0.3, 0.1, 0.2, 0.15],
+            "wall_time": [30.0, 10.0, 20.0, 11.0],
+        }
+    )
+
+    events = dataframe_to_events(df, run_id="ordering")
+
+    assert [event.step for event in events] == [1, 1, 2, 3]
+    assert [event.metrics["reward_mean"] for event in events] == [0.1, 0.15, 0.2, 0.3]


### PR DESCRIPTION
## Summary
- guard normalized event creation against missing numeric values when converting training metrics into events
- stabilize ingest event ordering by sorting on step with a stable sort before conversion
- add regression coverage for missing-metric handling and ordering expectations

## Testing
- pytest tests/test_dataframe_event_converters.py

------
https://chatgpt.com/codex/tasks/task_e_68cb61ac3934832faa9223054995875f