### PR TITLE
feat: normalize eval inputs via training metrics

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -224,28 +224,33 @@ rldk reward reward-health gate --from ./reports/health.json
 
 ### `rldk evals evaluate`
 
-Run evaluation suite on JSONL data.
+Run evaluation suite on normalized training runs or evaluation datasets.
 
 ```bash
-rldk evals evaluate INPUT_FILE [OPTIONS]
+rldk evals evaluate INPUT_PATH [OPTIONS]
 ```
 
 **Arguments:**
-- `INPUT_FILE`: Path to JSONL input file
+- `INPUT_PATH`: Path to a training run directory, metrics table, or evaluation dataset
 
 **Options:**
-- `--suite`, `-s`: Evaluation suite to run (`quick`/`comprehensive`/`safety`) (default: `quick`)
+- `--suite`, `-s`: Evaluation suite to run (`quick`/`comprehensive`/`safety`/`training_metrics`) (default: `quick`)
 - `--output`, `-o`: Path to output JSON file
 - `--output-column`: Column name containing model outputs (default: `output`)
 - `--events-column`: Column name containing event logs (default: `events`)
 - `--min-samples`: Minimum samples required for evaluation (default: `10`)
 - `--timeout`: Timeout in seconds for evaluation (default: `300`)
 - `--verbose`, `-v`: Enable verbose logging
+- `--preset`: Field map preset to normalize training metrics before evaluation
+- `--field-map`: JSON object mapping source columns to canonical training metrics
 
 **Examples:**
 ```bash
-# Quick evaluation
-rldk evals evaluate data.jsonl --suite quick
+# Quick evaluation on a run directory
+rldk evals evaluate /path/to/run --suite quick --preset trl
+
+# Training metrics suite with a metrics table
+rldk evals evaluate metrics.csv --suite training_metrics --field-map '{"progress":"step"}'
 
 # Comprehensive evaluation with custom output
 rldk evals evaluate data.jsonl --suite comprehensive --output results.json

--- a/src/rldk/cli.py
+++ b/src/rldk/cli.py
@@ -1459,9 +1459,22 @@ def run_evaluation_suite(
             sample_size=min_samples if min_samples > 0 else None,
             column_mapping=column_mapping
         )
-        
+
+        raw_scores = result.scores
+        failed_from_metadata = set(result.metadata.get("failed_evaluations", []))
+        skipped_from_metadata = set(result.metadata.get("skipped_evaluations", []))
+        skipped_from_scores = {
+            name
+            for name, score in raw_scores.items()
+            if pd.isna(score) and name not in failed_from_metadata
+        }
+
+        skipped_all = skipped_from_metadata.union(skipped_from_scores)
+        failed_evaluations = len(failed_from_metadata)
+        skipped_evaluations = len(skipped_all)
+
         serializable_scores = {}
-        for key, value in result.scores.items():
+        for key, value in raw_scores.items():
             if pd.isna(value):
                 serializable_scores[key] = None
             elif callable(value):
@@ -1477,28 +1490,25 @@ def run_evaluation_suite(
                 serializable_metadata[key] = {k: (str(v) if callable(v) else v) for k, v in value.items()}
             else:
                 serializable_metadata[key] = value
-        
-        skipped_evaluations = 0
-        failed_evaluations = 0
-        
-        if suite_name == "training_metrics":
-            # Check if evaluations were skipped due to missing columns
-            skipped_warning = any("Skipped evaluations due to missing columns" in str(w) for w in result.warnings)
-            if skipped_warning:
-                skipped_evaluations = len([s for s in result.scores.values() if pd.isna(s)])
-                failed_evaluations = 0
-            else:
-                failed_evaluations = len([s for s in result.scores.values() if pd.isna(s)])
-        else:
-            failed_evaluations = len([s for s in result.scores.values() if pd.isna(s)])
-        
+
+        if skipped_all and "skipped_evaluations" not in serializable_metadata:
+            serializable_metadata["skipped_evaluations"] = sorted(skipped_all)
+
+        successful_evaluations = len(
+            [
+                name
+                for name, score in raw_scores.items()
+                if not pd.isna(score) and name not in failed_from_metadata
+            ]
+        )
+
         return {
             "suite_name": suite_name,
             "suite_description": f"Evaluation suite: {suite_name}",
             "evaluations": serializable_scores,
             "summary": {
-                "total_evaluations": len(result.scores),
-                "successful_evaluations": len([s for s in result.scores.values() if not pd.isna(s)]),
+                "total_evaluations": len(raw_scores),
+                "successful_evaluations": successful_evaluations,
                 "failed_evaluations": failed_evaluations,
                 "skipped_evaluations": skipped_evaluations,
                 "overall_score": float(result.overall_score) if not pd.isna(result.overall_score) else None,
@@ -1528,23 +1538,61 @@ def run_evaluation_suite(
 
 @evals_app.command()
 def evaluate(
-    input_file: Path = typer.Argument(..., help="Path to JSONL input file"),
-    suite: str = typer.Option("quick", "--suite", "-s", help="Evaluation suite to run (quick/comprehensive/safety/training_metrics)"),
-    output_file: Optional[Path] = typer.Option(None, "--output", "-o", help="Path to output JSON file"),
-    output_column: str = typer.Option("output", "--output-column", help="Column name containing model outputs"),
-    events_column: str = typer.Option("events", "--events-column", help="Column name containing event logs"),
-    min_samples: int = typer.Option(10, "--min-samples", help="Minimum samples required for evaluation"),
-    timeout: int = typer.Option(300, "--timeout", help="Timeout in seconds for evaluation"),
-    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose logging"),
-    column_mapping: Optional[str] = typer.Option(None, "--column-mapping", help="Column mapping as JSON or key=value pairs (e.g., 'global_step=step,kl=kl_mean' or '{\"global_step\":\"step\"}')")
+    input_path: Path = typer.Argument(
+        ..., help="Path to run directory, metrics table, or evaluation dataset"
+    ),
+    suite: str = typer.Option(
+        "quick",
+        "--suite",
+        "-s",
+        help="Evaluation suite to run (quick/comprehensive/safety/training_metrics)",
+    ),
+    output_file: Optional[Path] = typer.Option(
+        None, "--output", "-o", help="Path to output JSON file"
+    ),
+    output_column: str = typer.Option(
+        "output", "--output-column", help="Column name containing model outputs"
+    ),
+    events_column: str = typer.Option(
+        "events", "--events-column", help="Column name containing event logs"
+    ),
+    min_samples: int = typer.Option(
+        10, "--min-samples", help="Minimum samples required for evaluation"
+    ),
+    timeout: int = typer.Option(
+        300, "--timeout", help="Timeout in seconds for evaluation"
+    ),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Enable verbose logging"
+    ),
+    column_mapping: Optional[str] = typer.Option(
+        None,
+        "--column-mapping",
+        help="Column mapping as JSON or key=value pairs (e.g., 'global_step=step,kl=kl_mean' or '{\"global_step\":\"step\"}')",
+    ),
+    preset: Optional[str] = typer.Option(
+        None,
+        "--preset",
+        help=(
+            "Field map preset to normalize training metrics "
+            f"({', '.join(sorted(FIELD_MAP_PRESETS))})"
+            if FIELD_MAP_PRESETS
+            else "Field map preset name (e.g. trl)."
+        ),
+    ),
+    field_map: Optional[str] = typer.Option(
+        None,
+        "--field-map",
+        help="JSON object mapping source columns to canonical training metrics.",
+    ),
 ):
     """
-    Run evaluation suite on JSONL data.
+    Run evaluation suite on normalized runs or prepared datasets.
 
     Examples:
-        rldk evals evaluate data.jsonl --suite training_metrics --column-mapping global_step=step,kl=kl_mean
+        rldk evals evaluate /path/to/run --suite quick --preset trl
+        rldk evals evaluate metrics.csv --suite training_metrics --field-map '{"progress":"step"}'
         rldk evals evaluate data.jsonl --suite comprehensive --output results.json
-        rldk evals evaluate data.jsonl --suite training_metrics --column-mapping '{"global_step":"step","reward":"reward_mean"}'
         rldk evals evaluate data.jsonl --suite quick --min-samples 50 --verbose
         rldk evals evaluate data.jsonl --suite safety --timeout 600
     """
@@ -1556,8 +1604,8 @@ def evaluate(
         # Validate input
         print_operation_status("Validating input", "start")
 
-        # Validate input file
-        validate_file_path(input_file, must_exist=True, file_extensions=[".jsonl"])
+        # Validate input path
+        resolved_path = validate_file_path(input_path, must_exist=True)
 
         # Validate suite
         valid_suites = ["quick", "comprehensive", "safety", "training_metrics"]
@@ -1569,10 +1617,10 @@ def evaluate(
             )
 
         # Validate min_samples
-        if min_samples < 1:
+        if min_samples < 0:
             raise ValidationError(
-                f"Minimum samples must be at least 1, got: {min_samples}",
-                suggestion="Use a positive integer for minimum samples",
+                f"Minimum samples must be non-negative, got: {min_samples}",
+                suggestion="Use zero to auto-detect or a positive integer to sample",
                 error_code="INVALID_MIN_SAMPLES"
             )
 
@@ -1601,15 +1649,66 @@ def evaluate(
                     error_code="INVALID_COLUMN_MAPPING"
                 )
 
+        try:
+            combined_field_map = _combine_field_maps(preset, field_map)
+        except ValueError as exc:
+            raise ValidationError(
+                f"Invalid field map: {exc}",
+                suggestion="Provide JSON like '{\"source\":\"canonical\"}' or use --preset",
+                error_code="INVALID_FIELD_MAP",
+            ) from exc
+
+        if combined_field_map:
+            logging.info(f"Using field map: {combined_field_map}")
+
+        use_normalizer = False
+        suffix = resolved_path.suffix.lower()
+        if resolved_path.is_dir() or suffix in {".csv", ".tsv", ".parquet"}:
+            use_normalizer = True
+        elif suite == "training_metrics" or combined_field_map:
+            use_normalizer = True
+        elif suffix in {".jsonl", ".ndjson"}:
+            first_record = None
+            try:
+                with resolved_path.open("r", encoding="utf-8") as handle:
+                    for raw_line in handle:
+                        raw_line = raw_line.strip()
+                        if not raw_line:
+                            continue
+                        first_record = json.loads(raw_line)
+                        break
+            except (json.JSONDecodeError, OSError):
+                first_record = None
+
+            if isinstance(first_record, dict):
+                keys = {str(key) for key in first_record.keys()}
+                output_like = {"output", "response", "completion", "text", "generation"}
+                if not keys.intersection(output_like):
+                    metric_keys = {
+                        "reward",
+                        "reward_mean",
+                        "kl",
+                        "kl_mean",
+                        "tokens_in",
+                        "tokens_out",
+                    }
+                    if {"name", "value"}.issubset(keys) or keys.intersection(metric_keys):
+                        use_normalizer = True
+
         # Load data with progress indication
         with timed_operation_context("Data loading"):
-            logging.info(f"Loading data from {input_file}")
-            data = load_jsonl_data(input_file)
+            logging.info(f"Loading data from {resolved_path}")
+            if use_normalizer:
+                data = normalize_training_metrics_source(
+                    resolved_path, field_map=combined_field_map
+                )
+            else:
+                data = load_jsonl_data(resolved_path)
 
             if data.empty:
                 raise ValidationError(
-                    "No data found in input file",
-                    suggestion="Ensure the JSONL file contains valid data",
+                    "No data found in source",
+                    suggestion="Ensure the path contains valid training metrics or evaluation data",
                     error_code="NO_DATA_FOUND"
                 )
 
@@ -1720,12 +1819,13 @@ def evaluate(
     except ValidationError as e:
         typer.echo(format_error_message(e), err=True)
         print_usage_examples("evaluate", [
-            "rldk evals evaluate data.jsonl --suite comprehensive --output results.json",
-            "rldk evals evaluate data.jsonl --suite quick --min-samples 50 --verbose",
-            "rldk evals evaluate data.jsonl --suite safety --timeout 600"
+            "rldk evals evaluate /path/to/run --suite quick --preset trl",
+            "rldk evals evaluate metrics.csv --suite training_metrics --field-map '{\"progress\":\"step\"}'",
+            "rldk evals evaluate data.jsonl --suite comprehensive --output results.json"
         ])
         print_troubleshooting_tips([
-            "Ensure the input file is a valid JSONL file",
+            "Ensure the input path exists and points to a run, table, or dataset",
+            "Use --preset or --field-map to align custom metric column names",
             "Check that the specified columns exist in your data",
             "Use --verbose flag for detailed output",
             "Try reducing --min-samples if you have limited data"

--- a/tests/test_evals_cli.py
+++ b/tests/test_evals_cli.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from typer.testing import CliRunner
+
+from rldk.cli import app
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_evals_cli_runs_quick_suite_from_training_metrics(
+    tmp_path: Path, runner: CliRunner
+) -> None:
+    metrics = pd.DataFrame(
+        {
+            "step": [1, 2, 3, 4],
+            "reward_mean": [0.2, 0.25, 0.3, 0.35],
+            "kl_mean": [0.1, 0.11, 0.09, 0.1],
+        }
+    )
+    metrics_path = tmp_path / "training_metrics.csv"
+    metrics.to_csv(metrics_path, index=False)
+
+    output_path = tmp_path / "results.json"
+    result = runner.invoke(
+        app,
+        [
+            "evals",
+            "evaluate",
+            str(metrics_path),
+            "--suite",
+            "quick",
+            "--min-samples",
+            "0",
+            "--output",
+            str(output_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert output_path.exists()
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    evaluations = payload.get("evaluations")
+    assert isinstance(evaluations, dict)
+    assert evaluations, "expected per-metric status entries in evaluations output"
+    assert payload.get("summary", {}).get("total_evaluations") == len(evaluations)


### PR DESCRIPTION
Global context to paste at the top of every PR

Project goal: Make RLDK framework agnostic with a single data path. Any training run can emit JSONL events or table like logs, and every CLI will normalize these into the TrainingMetrics table and the Normalized Events that cards and analyses use. Monitoring stays live and light. Everything else should “just work” on the same schema.

High level design:

Three data layers

Stream Event: time, step, name, value, optional run_id, tags, meta

TrainingMetrics table: step and a stable set of numeric columns such as reward_mean, kl_mean, loss, lr, grad_norm, tokens_in, tokens_out, plus metadata like run_id and seed

Normalized Events: the event form used by cards and some analyses

One normalization hop everywhere

All CLIs that read user data first call a shared normalizer that returns a TrainingMetrics DataFrame

Converters exist both ways: stream events to table, table to normalized events

Consistent UX

Every data reading CLI supports: --preset, --field-map, and accepts files or directories

Guardrails

Numeric coercion, None handling, and friendly errors before any math

This phase: See the PR title for the exact slice of work. Each PR must be small, additive, and independently shippable.

Definition of done for every PR:

Unit tests and CLI tests pass

Docs and help text updated

New code follows the three layer model

Friendly error messages for invalid inputs

No breaking changes unless explicitly noted, with a migration note

Phase plan and PR index

Phase A: Normalization core

PR1: stream JSONL to TrainingMetrics normalizer

PR2: numeric coercion and None guards in schema standardizer

PR3: table to normalized events and the reverse helpers

Phase B: Reward health and drift on the unified path
4. PR4: reward health CLI accepts JSONL and tables, uses normalizer
5. PR5: reward drift supports score file mode in addition to model folders
6. PR6: reward health API accepts list, JSONL, or DataFrame

Phase C: Ingestion adapters unified
7. PR7: TRL adapter becomes a thin preset over the common normalizer
8. PR8: Flexible adapter shares the same standardizer and presets registry
9. PR9: ingest_runs_to_events None safety and ordering

Phase D: Other CLIs on the unified path
10. PR10: diff CLI auto ingests A and B then compares tables
11. PR11: evals CLI auto ingests then computes metrics
12. PR12: cards CLI auto ingests then builds normalized events

Phase E: Validation, UX, and docs
13. PR13: validate jsonl CLI for line wise checks and schema hints
14. PR14: shared preset and field map options across all data reading CLIs
15. PR15: error messages and exit codes made consistent

Phase F: Tests and fixtures
16. PR16: golden path data fixtures in three formats that normalize to the same table
17. PR17: end to end CLI tests for reward health, drift, diff, cards
18. PR18: docs and examples update, notebook mojibake fix, JSONL validation notes

Optional quality passes if you want to keep going
19. PR19: performance pass on normalization for very large runs
20. PR20: release notes and minor version bump

__
DO PR11: evals CLI auto ingests then computes metrics

Goal: Ensure rldk evals can read normalized run tables in addition to native eval datasets.

Inputs:

A run path or file, or a prepared eval dataset

Outputs:

JSON results per suite

What it should do:

When given a run, extract the relevant columns such as reward and kl and compute the subset of metrics that only need those signals

Acceptance criteria:

quick suite runs on a minimal run with reward and kl

Missing optional columns reduce metric coverage with a warning rather than a crash

Tests:

CLI test with a tiny run and a tiny suite

Verify that the results file exists and contains per metric status

## Summary
- extend `rldk evals evaluate` to accept run directories and metrics tables, with optional presets and field maps that normalize inputs before running suites and with auto-detection of training metrics streams
- treat metrics without values as skipped instead of fatal failures so suites degrade gracefully when only reward and KL are present
- document the broader input support and add a CLI test that exercises the quick suite on a minimal training-metrics CSV

## Testing
- `pytest tests/test_evals_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68cb811ccb70832f84863875bbe2e660