### PR TITLE
feat(cli): normalize card inputs via training metrics

### DIFF
--- a/docs/card_field_reference.md
+++ b/docs/card_field_reference.md
@@ -206,7 +206,14 @@ rldk card drift runs/clean_ppo runs/doctored_ppo
 
 # Reward card
 rldk card reward runs/clean_ppo
+
+# Reward card from JSONL stream with preset mapping
+rldk card reward logs/reward_stream.jsonl --preset trl
 ```
+
+The command accepts run directories or standalone metrics files (JSONL, CSV, TSV,
+or Parquet) and supports `--preset` / `--field-map` options to align custom
+column names with the TrainingMetrics schema.
 
 ## Schema Validation
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -518,11 +518,13 @@ rldk card CARD_TYPE RUN_A [RUN_B] [OPTIONS]
 
 **Arguments:**
 - `CARD_TYPE`: Type of card to generate (`determinism`, `drift`, `reward`)
-- `RUN_A`: Path to first run directory (required)
-- `RUN_B`: Path to second run directory (for drift cards)
+- `RUN_A`: Path to the primary run directory or metrics file (required)
+- `RUN_B`: Path to the comparison run directory or metrics file (drift cards only)
 
 **Options:**
 - `--output-dir`, `-o`: Output directory for cards
+- `--preset`: Field map preset for common trainer outputs (e.g. `trl`)
+- `--field-map`: JSON object mapping source columns to canonical training metrics
 
 **Examples:**
 ```bash
@@ -531,6 +533,9 @@ rldk card determinism ./runs/experiment_1
 
 # Generate drift card comparing two runs
 rldk card drift ./runs/experiment_1 ./runs/experiment_2
+
+# Generate reward card from a JSONL metrics stream using the TRL preset
+rldk card reward ./logs/trl_stream.jsonl --preset trl
 
 # Generate reward card
 rldk card reward ./runs/experiment_1

--- a/src/rldk/cli.py
+++ b/src/rldk/cli.py
@@ -33,11 +33,7 @@ from rldk.evals.suites import COMPREHENSIVE_SUITE, QUICK_SUITE, SAFETY_SUITE
 from rldk.forensics.ckpt_diff import diff_checkpoints
 from rldk.forensics.env_audit import audit_environment
 from rldk.forensics.log_scan import scan_logs
-from rldk.ingest import (
-    ingest_runs,
-    ingest_runs_to_events,
-    normalize_training_metrics_source,
-)
+from rldk.ingest import ingest_runs, normalize_training_metrics_source
 from rldk.io import (
     CkptDiffReportV1,
     DeterminismCardV1,
@@ -51,6 +47,7 @@ from rldk.io import (
     write_json,
     write_png,
 )
+from rldk.io.event_schema import dataframe_to_events
 from rldk.io import write_json as write_json_report
 from rldk.monitor import (
     ActionDispatcher,
@@ -3149,21 +3146,75 @@ def card(
     card_type: str = typer.Argument(
         ..., help="Type of card to generate (determinism, drift, reward)"
     ),
-    run_a: str = typer.Argument(..., help="Path to first run directory"),
+    run_a: str = typer.Argument(
+        ..., help="Path to first run directory or metrics file"
+    ),
     run_b: Optional[str] = typer.Argument(
         None, help="Path to second run directory (for drift cards)"
     ),
     output_dir: Optional[str] = typer.Option(
         None, "--output-dir", "-o", help="Output directory for cards"
     ),
+    preset: Optional[str] = typer.Option(
+        None,
+        "--preset",
+        help=(
+            "Field map preset to normalize training metrics"
+            f" ({', '.join(sorted(FIELD_MAP_PRESETS))})"
+            if FIELD_MAP_PRESETS
+            else "Field map preset name (e.g. trl)."
+        ),
+    ),
+    field_map: Optional[str] = typer.Option(
+        None,
+        "--field-map",
+        help="JSON object mapping source columns to canonical training metrics.",
+    ),
 ):
     """Generate trust cards for RL training runs."""
     try:
+        try:
+            combined_field_map = _combine_field_maps(preset, field_map)
+        except ValueError as exc:
+            typer.echo(f"Invalid field map: {exc}", err=True)
+            raise typer.Exit(1)
+
+        def _normalize_to_events(path: str) -> Tuple[pd.DataFrame, List[Any]]:
+            try:
+                df = normalize_training_metrics_source(
+                    path, field_map=combined_field_map
+                )
+            except ValidationError as exc:
+                typer.echo(format_structured_error_message(exc), err=True)
+                raise typer.Exit(1)
+
+            run_id_value: Optional[str] = None
+            if "run_id" in df.columns:
+                non_null = df["run_id"].dropna()
+                if not non_null.empty:
+                    run_id_value = str(non_null.iloc[0])
+
+            git_sha_value: Optional[str] = None
+            if "git_sha" in df.columns:
+                git_non_null = df["git_sha"].dropna()
+                if not git_non_null.empty:
+                    git_sha_value = str(git_non_null.iloc[0])
+
+            try:
+                events = dataframe_to_events(
+                    df, run_id=run_id_value, git_sha=git_sha_value
+                )
+            except ValidationError as exc:
+                typer.echo(format_structured_error_message(exc), err=True)
+                raise typer.Exit(1)
+
+            return df, events
+
         if card_type == "determinism":
             typer.echo(f"Generating determinism card for run: {run_a}")
 
-            # Ingest events
-            events = ingest_runs_to_events(run_a)
+            # Normalize run to events
+            _, events = _normalize_to_events(run_a)
 
             # Generate card
             card_data = generate_determinism_card(events, run_a, output_dir)
@@ -3182,9 +3233,9 @@ def card(
             typer.echo(f"  Run A: {run_a}")
             typer.echo(f"  Run B: {run_b}")
 
-            # Ingest events
-            events_a = ingest_runs_to_events(run_a)
-            events_b = ingest_runs_to_events(run_b)
+            # Normalize runs to events
+            _, events_a = _normalize_to_events(run_a)
+            _, events_b = _normalize_to_events(run_b)
 
             # Generate card
             card_data = generate_drift_card(
@@ -3200,8 +3251,15 @@ def card(
         elif card_type == "reward":
             typer.echo(f"Generating reward card for run: {run_a}")
 
-            # Ingest events
-            events = ingest_runs_to_events(run_a)
+            # Normalize run to events
+            metrics_df, events = _normalize_to_events(run_a)
+
+            if metrics_df.empty or metrics_df["reward_mean"].dropna().empty:
+                typer.echo(
+                    "Warning: No reward_mean values found after normalization. "
+                    "Use --preset or --field-map to map your reward metric.",
+                    err=True,
+                )
 
             # Generate card
             card_data = generate_reward_card(events, run_a, output_dir)

--- a/tests/test_cards_cli.py
+++ b/tests/test_cards_cli.py
@@ -1,0 +1,68 @@
+"""Tests for the `rldk card` CLI command."""
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from rldk.cli import app
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Provide a CLI runner for invoking Typer commands."""
+
+    return CliRunner()
+
+
+def test_reward_card_cli_from_jsonl(tmp_path: Path, runner: CliRunner) -> None:
+    """The reward card command should normalize JSONL inputs and emit artifacts."""
+
+    source = Path("tests/fixtures/phase_ab/stream_small.jsonl")
+    output_dir = tmp_path / "cards"
+
+    result = runner.invoke(
+        app,
+        [
+            "card",
+            "reward",
+            str(source),
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr or result.stdout
+    assert (output_dir / "reward_card.json").exists()
+    assert (output_dir / "reward_card.png").exists()
+
+
+def test_reward_card_cli_warns_when_reward_missing(
+    tmp_path: Path, runner: CliRunner
+) -> None:
+    """A friendly warning should be emitted when reward metrics are absent."""
+
+    source = tmp_path / "no_reward.jsonl"
+    source.write_text(
+        '{"time": 1700000001, "step": 1, "name": "kl_mean", "value": 0.1}\n'
+    )
+
+    output_dir = tmp_path / "cards"
+
+    result = runner.invoke(
+        app,
+        [
+            "card",
+            "reward",
+            str(source),
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    assert result.exit_code == 0, result.stderr or result.stdout
+    warning_output = (result.stderr or "") + (result.stdout or "")
+    assert "Use --preset or --field-map" in warning_output
+    assert (output_dir / "reward_card.json").exists()
+    assert (output_dir / "reward_card.png").exists()
+


### PR DESCRIPTION
## Summary
- allow the `rldk card` command to normalize run directories or metric files through the TrainingMetrics pipeline
- add preset and field-map options plus a warning when reward metrics are missing
- document the new inputs and exercise the reward card CLI on JSONL in automated tests

## Testing
- pytest tests/test_cards_cli.py
- pytest tests/unit/test_api_contract.py::TestCLICommands::test_card_command

------
https://chatgpt.com/codex/tasks/task_e_68cb842d6440832fbe155275d31d0b64