### PR TITLE
Update determinism CLI invocation in acceptance script

### DIFF
--- a/scripts/fullscale_acceptance.sh
+++ b/scripts/fullscale_acceptance.sh
@@ -54,7 +54,7 @@ python -m rldk.cli diff --a "${RUN_JSON}" --b "${BASELINE_JSON}" --signals "rewa
 DETERMINISM_DIR="${ARTIFACT_DIR}/determinism_report"
 mkdir -p "${DETERMINISM_DIR}"
 DETERMINISM_CMD="python ${ROOT_DIR}/scripts/fullscale_train_rl.py --seed 2718 --max-steps 12 --batch-size 1 --max-new-tokens 24 --learning-rate 3e-4 --kl-coeff 0.08 --aux-weight 0.35 --noise-weight 0.2 --temperature 1.05 --outdir ${ARTIFACT_DIR}/determinism --run-id det"
-python -m rldk.cli determinism --cmd "${DETERMINISM_CMD}" --compare "reward_mean,kl,loss" --runs 2 --stride 1 --output-dir "${DETERMINISM_DIR}" --tolerance 0.5 | tee -a "${LOG_FILE}"
+python -m rldk.cli check-determinism --cmd "${DETERMINISM_CMD}" --compare "reward_mean,kl,loss" --runs 2 --stride 1 --output-dir "${DETERMINISM_DIR}" --tolerance 0.5 | tee -a "${LOG_FILE}"
 
 CARD_DIR="${ARTIFACT_DIR}/cards"
 python -m rldk.cli card reward "${RUN_JSON}" --output-dir "${CARD_DIR}" | tee -a "${LOG_FILE}"


### PR DESCRIPTION
## Summary
- switch the fullscale acceptance determinism check to use the new check-determinism CLI entrypoint

## Testing
- ./scripts/fullscale_acceptance.sh *(fails: huggingface.co download blocked by proxy 403, before determinism stage)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7b95e5f0832fbefed22fd9741501