### PR TITLE
Fix reward health verdict key in acceptance summary

### DIFF
--- a/scripts/fullscale_acceptance.sh
+++ b/scripts/fullscale_acceptance.sh
@@ -126,7 +126,7 @@ else:
 
 if reward_summary.exists():
     reward_payload = json.loads(reward_summary.read_text())
-    summary_lines.append(f"- Reward health verdict: {reward_payload.get('verdict', 'unknown')}")
+    summary_lines.append(f"- Reward health verdict: {reward_payload.get('overall_status', 'unknown')}")
     if not reward_payload.get("passed", False):
         summary_lines.append("  - ⚠️ Reward health reported issues")
 else:


### PR DESCRIPTION
## Summary
- update the fullscale acceptance summary script to read the reward health `overall_status` field when reporting the verdict

## Testing
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68cc7b98b7d0832f9e75f8ef8b732bf5