### PR TITLE
Enhance fullscale monitor actions with remediation guidance

### DIFF
--- a/rules/fullscale_rules.yaml
+++ b/rules/fullscale_rules.yaml
@@ -9,6 +9,9 @@ rules:
     cooldown_steps: 10
     actions:
       - warn:
+          severity: high
+          remediation: "Nudge --kl-coeff downward or shorten the PPO clip range to pull KL back under the 0.35-0.38 band."
+          runbook: "https://rldk.ai/runbooks/kl-spikes"
           msg: "KL divergence {value:.3f} exceeded guard band at step {step}"
   - id: reward_collapse_watch
     description: Alert when reward mean collapses for an extended window.
@@ -21,6 +24,9 @@ rules:
     cooldown_steps: 25
     actions:
       - warn:
+          severity: critical
+          remediation: "Inspect the reward head for saturation and consider lowering --vf-coeff or refreshing preference data."
+          runbook: "https://rldk.ai/runbooks/reward-collapse"
           msg: "Reward running mean {value:.3f} indicates collapse near step {step}"
   - id: grad_norm_ceiling
     description: Warn when gradient norms exceed the tuned ceiling.
@@ -31,4 +37,7 @@ rules:
       kind: consecutive
     actions:
       - warn:
+          severity: medium
+          remediation: "Try reducing --learning-rate to ≤1e-4 or increasing --max-grad-norm to 1.2 to tame the spike."
+          runbook: "https://rldk.ai/runbooks/gradient-instability"
           msg: "Gradient norm {value:.3f} breached ceiling at step {step}"

--- a/src/rldk/monitor/engine.py
+++ b/src/rldk/monitor/engine.py
@@ -350,6 +350,15 @@ class Alert:
                 f"[{self.rule_id}] {self.event.name} {self.event.value:.4f} "
                 f"at step {self.event.step} ({self.action})"
             )
+        severity = None
+        remediation = None
+        if self.details:
+            severity = self.details.get("severity")
+            remediation = self.details.get("remediation")
+        if severity:
+            base = f"[{str(severity).upper()}] {base}"
+        if remediation:
+            base = f"{base} | Remediation: {remediation}"
         if self.status == "error":
             return f"ERROR: {base}"
         if self.status not in {"success", "ok"}:
@@ -1008,6 +1017,24 @@ def _format_action_value(value: Any, context: Dict[str, Any]) -> Any:
     return value
 
 
+def _prepare_action_context(
+    action: ActionConfig,
+    rule: RuleDefinition,
+    event: Event,
+    extra_context: Optional[Dict[str, Any]] = None,
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    merged_context = dict(extra_context or {})
+    merged_context.setdefault("action", action.kind)
+    base_context = _template_context(rule, event, merged_context)
+    formatted_options = {
+        key: _format_action_value(value, base_context)
+        for key, value in action.options.items()
+    }
+    full_context = dict(base_context)
+    full_context.update(formatted_options)
+    return full_context, formatted_options
+
+
 def _render_action_message(
     action: ActionConfig,
     rule: RuleDefinition,
@@ -1016,14 +1043,22 @@ def _render_action_message(
 ) -> str:
     default_template = DEFAULT_ACTION_MESSAGES.get(action.kind, DEFAULT_ACTION_MESSAGES["warn"])
     template = action.message_template or default_template
-    merged_context = dict(extra_context or {})
-    merged_context.setdefault("action", action.kind)
-    context = _template_context(rule, event, merged_context)
+    context, _ = _prepare_action_context(action, rule, event, extra_context)
     try:
         return template.format(**context)
     except Exception as exc:  # pragma: no cover - formatting guard
         logger.warning("Failed to format message for rule '%s': %s", rule.id, exc)
         return template
+
+
+def _render_action_details(
+    action: ActionConfig,
+    rule: RuleDefinition,
+    event: Event,
+    extra_context: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    _, details = _prepare_action_context(action, rule, event, extra_context)
+    return details
 
 
 def _create_alert(
@@ -1091,7 +1126,15 @@ class SimpleActionExecutor(ActionExecutor):
         if action.kind != "warn":
             raise ValueError(f"Unsupported action '{action.kind}' for simple executor")
         message = _render_action_message(action, rule, event, {})
-        return _create_alert(rule, event, "warn", message=message, status="success", details={})
+        details = _render_action_details(action, rule, event, {})
+        return _create_alert(
+            rule,
+            event,
+            "warn",
+            message=message,
+            status="success",
+            details=details,
+        )
 
 
 class ActionDispatcher(ActionExecutor):

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -568,6 +568,45 @@ rules:
     assert len(alerts_text.read_text().strip().splitlines()) == 2
 
 
+def test_fullscale_rules_emit_remediation(tmp_path: Path, runner: CliRunner) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    rules_path = repo_root / "rules" / "fullscale_rules.yaml"
+    events_path = tmp_path / "events.jsonl"
+    events = [
+        {"time": _now_iso(), "step": 1, "name": "grad_norm", "value": 1.2},
+        {"time": _now_iso(), "step": 2, "name": "grad_norm", "value": 1.3},
+        {"time": _now_iso(), "step": 3, "name": "grad_norm", "value": 1.4},
+    ]
+    events_path.write_text("\n".join(json.dumps(evt) for evt in events) + "\n")
+    alerts_path = tmp_path / "alerts.jsonl"
+    alerts_text_path = tmp_path / "alerts.txt"
+    result = runner.invoke(
+        app,
+        [
+            "monitor",
+            "--once",
+            str(events_path),
+            "--rules",
+            str(rules_path),
+            "--alerts",
+            str(alerts_path),
+            "--alerts-txt",
+            str(alerts_text_path),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    assert "Remediation: Try reducing --learning-rate to ≤1e-4 or increasing --max-grad-norm to 1.2 to tame the spike." in result.stdout
+    lines = alerts_path.read_text().strip().splitlines()
+    assert lines, "expected at least one alert"  # defensive
+    payloads = [json.loads(line) for line in lines]
+    remediation_hints = [payload.get("details", {}).get("remediation") for payload in payloads]
+    assert any(
+        hint
+        and "Try reducing --learning-rate to ≤1e-4 or increasing --max-grad-norm to 1.2 to tame the spike." in hint
+        for hint in remediation_hints
+    )
+
+
 def test_monitor_cli_field_map_preset(tmp_path: Path, runner: CliRunner) -> None:
     log_path = tmp_path / "metrics.jsonl"
     values = [0.2, 0.36, 0.38, 0.4, 0.42, 0.44]


### PR DESCRIPTION
## Summary
- enrich the fullscale monitoring rules with severity levels, remediation hints, and runbook links for each warn action
- propagate warn action metadata into alert details and summaries so CLI output surfaces remediation guidance
- add CLI regression coverage ensuring the grad-norm remediation hint is emitted when the fullscale rule fires

## Testing
- pytest tests/test_monitor_core.py::test_fullscale_rules_emit_remediation

------
https://chatgpt.com/codex/tasks/task_e_68cce800d160832fb69e635f6a34c936