### PR TITLE
Adjust fullscale defaults and document anomaly opt-in

### DIFF
--- a/artifacts/final_report.md
+++ b/artifacts/final_report.md
@@ -94,3 +94,14 @@ The verification demonstrates:
 The TRL API compatibility issue encountered in Path C is a technical implementation detail that doesn't affect the core monitoring functionality, which was successfully demonstrated in Paths A and B.
 
 **FINAL VERDICT: LIVE MONITORING PASS** ✅
+
+## Appendix: Fullscale Acceptance Expectations
+
+- Default hyperparameters for `scripts/fullscale_train_rl.py` now use a lower learning
+  rate (8e-5), a cooler sampling temperature (0.95), a batch size of 4, and a higher
+  gradient clipping threshold (2.5).
+- The scripted reward collapse and KL spike toggles are disabled by default so the
+  acceptance recordings reflect genuine optimization. Use `--simulate-anomalies` if
+  you need the previous alert-heavy traces.
+- Expect few or zero monitor alerts when executing `scripts/fullscale_acceptance.sh`
+  with the new defaults because alerts now depend on organic training dynamics.

--- a/scripts/fullscale_acceptance.sh
+++ b/scripts/fullscale_acceptance.sh
@@ -25,7 +25,7 @@ RUN_JSON="${ARTIFACT_DIR}/run.jsonl"
 BASELINE_JSON="${ARTIFACT_DIR}/baseline.jsonl"
 rm -f "${RUN_JSON}" "${BASELINE_JSON}"
 
-TRAIN_COMMON=("python" "${ROOT_DIR}/scripts/fullscale_train_rl.py" "--max-steps" "40" "--batch-size" "1" "--max-new-tokens" "32" "--learning-rate" "3e-4" "--kl-coeff" "0.08" "--aux-weight" "0.35" "--noise-weight" "0.2" "--temperature" "1.05" "--outdir" "${ARTIFACT_DIR}" "--print-interval" "10")
+TRAIN_COMMON=("python" "${ROOT_DIR}/scripts/fullscale_train_rl.py" "--max-steps" "40" "--batch-size" "4" "--max-new-tokens" "32" "--learning-rate" "8e-5" "--kl-coeff" "0.08" "--aux-weight" "0.35" "--noise-weight" "0.2" "--temperature" "0.95" "--max-grad-norm" "2.5" "--outdir" "${ARTIFACT_DIR}" "--print-interval" "10")
 
 (
   echo "=== TRAINING: primary run ==="
@@ -53,7 +53,7 @@ python -m rldk.cli diff --a "${RUN_JSON}" --b "${BASELINE_JSON}" --signals "rewa
 
 DETERMINISM_DIR="${ARTIFACT_DIR}/determinism_report"
 mkdir -p "${DETERMINISM_DIR}"
-DETERMINISM_CMD="python ${ROOT_DIR}/scripts/fullscale_train_rl.py --seed 2718 --max-steps 12 --batch-size 1 --max-new-tokens 24 --learning-rate 3e-4 --kl-coeff 0.08 --aux-weight 0.35 --noise-weight 0.2 --temperature 1.05 --outdir ${ARTIFACT_DIR}/determinism --run-id det"
+DETERMINISM_CMD="python ${ROOT_DIR}/scripts/fullscale_train_rl.py --seed 2718 --max-steps 12 --batch-size 4 --max-new-tokens 24 --learning-rate 8e-5 --kl-coeff 0.08 --aux-weight 0.35 --noise-weight 0.2 --temperature 0.95 --max-grad-norm 2.5 --outdir ${ARTIFACT_DIR}/determinism --run-id det"
 python -m rldk.cli check-determinism --cmd "${DETERMINISM_CMD}" --compare "reward_mean,kl,loss" --runs 2 --stride 1 --output-dir "${DETERMINISM_DIR}" --tolerance 0.5 | tee -a "${LOG_FILE}"
 
 CARD_DIR="${ARTIFACT_DIR}/cards"

--- a/scripts/fullscale_train_rl.py
+++ b/scripts/fullscale_train_rl.py
@@ -6,7 +6,9 @@ RLDK.  It exercises a PPO-lite training loop that uses a frozen GPT-2 backbone w
 an adapter head trained via REINFORCE-style updates.  Metrics are emitted through the
 canonical :class:`rldk.emit.EventWriter` interface so downstream tooling can ingest the
 run and normalize it into the ``TrainingMetrics`` table.  The defaults are tuned so the
-script runs on CPU within a few hours while still producing a rich event stream.
+script runs on CPU within a few hours while still producing a rich event stream.  Use
+``--simulate-anomalies`` to opt back into the older scripted collapse/spike perturbations
+if you need deterministic alert demonstrations.
 
 The implementation focuses on debuggability rather than raw throughput.  Extensive
 logging, deterministic seeding, and reward decomposition make it easier for RLDK
@@ -351,22 +353,27 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser(description="Fullscale RL acceptance training run")
     parser.add_argument("--seed", type=int, default=13)
     parser.add_argument("--max-steps", type=int, default=160)
-    parser.add_argument("--batch-size", type=int, default=2)
-    parser.add_argument("--learning-rate", type=float, default=3e-4)
+    parser.add_argument("--batch-size", type=int, default=4)
+    parser.add_argument("--learning-rate", type=float, default=8e-5)
     parser.add_argument("--kl-coeff", type=float, default=0.08)
     parser.add_argument("--aux-weight", type=float, default=0.35)
     parser.add_argument("--noise-weight", type=float, default=0.2)
     parser.add_argument("--max-new-tokens", type=int, default=48)
-    parser.add_argument("--temperature", type=float, default=1.05)
+    parser.add_argument("--temperature", type=float, default=0.95)
     parser.add_argument("--dataset-size", type=int, default=4096)
     parser.add_argument("--model-name", type=str, default="gpt2-medium")
     parser.add_argument("--outdir", type=Path, default=Path("artifacts/fullscale"))
     parser.add_argument("--run-id", type=str, default="run")
     parser.add_argument("--ema-beta", type=float, default=0.04)
-    parser.add_argument("--max-grad-norm", type=float, default=1.5)
+    parser.add_argument("--max-grad-norm", type=float, default=2.5)
     parser.add_argument("--disable-updates", action="store_true", help="Skip optimizer updates for baseline runs")
     parser.add_argument("--override-event-path", type=str, default=None)
     parser.add_argument("--print-interval", type=int, default=10)
+    parser.add_argument(
+        "--simulate-anomalies",
+        action="store_true",
+        help="Re-enable scripted collapse/spike behavior for alert demos",
+    )
 
     args = parser.parse_args(argv)
 
@@ -389,6 +396,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 "dataset_size": args.dataset_size,
                 "model_name": args.model_name,
                 "disable_updates": args.disable_updates,
+                "simulate_anomalies": args.simulate_anomalies,
             },
             indent=2,
         )
@@ -484,12 +492,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
         logged_reward = total_reward
         logged_kl = kl_value
-        collapse_active = 1.0 if step % 55 in range(28, 52) else 0.0
-        spike_active = 1.0 if step % 60 == 0 else 0.0
-        if collapse_active:
-            logged_reward -= 0.35
-        if spike_active:
-            logged_kl += 0.45
+        collapse_active = 0.0
+        spike_active = 0.0
+        if args.simulate_anomalies:
+            collapse_active = 1.0 if step % 55 in range(28, 52) else 0.0
+            spike_active = 1.0 if step % 60 == 0 else 0.0
+            if collapse_active:
+                logged_reward -= 0.35
+            if spike_active:
+                logged_kl += 0.45
 
         wall_time = time.time() - step_start
         ema_reward_gap = total_reward - ema_reward


### PR DESCRIPTION
## Summary
- lower the default learning rate and sampling temperature in `fullscale_train_rl.py`, raise batch size/max grad norm, and add a `--simulate-anomalies` escape hatch
- guard the previous collapse/spike metric manipulation behind the new flag so default metrics reflect real optimization
- update the acceptance harness defaults and documentation to describe the calmer alert profile

## Testing
- python -m compileall scripts/fullscale_train_rl.py scripts/fullscale_acceptance.sh

## Notes
- Re-recording the fullscale acceptance artifacts failed in this environment because the Hugging Face model download for `gpt2-medium` is blocked behind a proxy (HTTP 403).

------
https://chatgpt.com/codex/tasks/task_e_68cce7fd4884832facf17a5218fc001b