### PR TITLE
Add remediation hints to fullscale rules and test

### DIFF
--- a/rules/fullscale_rules.yaml
+++ b/rules/fullscale_rules.yaml
@@ -9,7 +9,7 @@ rules:
     cooldown_steps: 10
     actions:
       - warn:
-          msg: "KL divergence {value:.3f} exceeded guard band at step {step}"
+          msg: "KL divergence {value:.3f} exceeded guard band at step {step}; consider lowering --temperature (default 0.95) or reducing --learning-rate (default 8e-5) to tighten updates"
   - id: reward_collapse_watch
     description: Alert when reward mean collapses for an extended window.
     where: name == "reward_mean"
@@ -21,7 +21,7 @@ rules:
     cooldown_steps: 25
     actions:
       - warn:
-          msg: "Reward running mean {value:.3f} indicates collapse near step {step}"
+          msg: "Reward running mean {value:.3f} indicates collapse near step {step}; consider increasing --batch-size (default 4) for steadier gradients or lowering --temperature to curb degenerate sampling"
   - id: grad_norm_ceiling
     description: Warn when gradient norms exceed the tuned ceiling.
     where: name == "grad_norm"
@@ -31,4 +31,4 @@ rules:
       kind: consecutive
     actions:
       - warn:
-          msg: "Gradient norm {value:.3f} breached ceiling at step {step}"
+          msg: "Gradient norm {value:.3f} breached ceiling at step {step}; ensure gradient clipping via --max-grad-norm (default 2.5) is active or lower --learning-rate to reduce update size"

--- a/tests/test_monitor_core.py
+++ b/tests/test_monitor_core.py
@@ -568,6 +568,40 @@ rules:
     assert len(alerts_text.read_text().strip().splitlines()) == 2
 
 
+def test_fullscale_rules_include_remediation_hints(tmp_path: Path, runner: CliRunner) -> None:
+    events_path = tmp_path / "events.jsonl"
+    with events_path.open("w", encoding="utf-8") as handle:
+        for step in range(1, 6):
+            payload = {"time": _now_iso(), "step": step, "name": "kl", "value": 0.5}
+            handle.write(json.dumps(payload) + "\n")
+
+    rules_path = Path(__file__).resolve().parents[1] / "rules" / "fullscale_rules.yaml"
+    alerts_path = tmp_path / "alerts.jsonl"
+    result = runner.invoke(
+        app,
+        [
+            "monitor",
+            "--once",
+            str(events_path),
+            "--rules",
+            str(rules_path),
+            "--alerts",
+            str(alerts_path),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+
+    alerts = [json.loads(line) for line in alerts_path.read_text().splitlines() if line.strip()]
+    assert alerts, "expected at least one alert from KL spike guard"
+    messages = "\n".join(alert.get("message", "") for alert in alerts)
+    assert "--temperature" in messages
+    assert "--learning-rate" in messages
+
+    text_summary = alerts_path.with_suffix(".txt").read_text()
+    assert "--temperature" in text_summary
+    assert "--learning-rate" in text_summary
+
+
 def test_monitor_cli_field_map_preset(tmp_path: Path, runner: CliRunner) -> None:
     log_path = tmp_path / "metrics.jsonl"
     values = [0.2, 0.36, 0.38, 0.4, 0.42, 0.44]


### PR DESCRIPTION
## Summary
- extend the fullscale monitoring rule messages with actionable remediation guidance tied to the training script hyperparameters
- add a monitor CLI test to assert the emitted alert payloads/text include the new guidance

## Testing
- pytest tests/test_monitor_core.py::test_fullscale_rules_include_remediation_hints

------
https://chatgpt.com/codex/tasks/task_e_68ccedac54c4832f826a786ee74ab2f4