### PR TITLE
Document fullscale acceptance pipeline defaults and remediation

### DIFF
--- a/docs/getting-started/monitor_rules_cookbook.md
+++ b/docs/getting-started/monitor_rules_cookbook.md
@@ -123,6 +123,24 @@ emits a warning and terminates the process specified with `--pid`.
 
 Mix and match these patterns with presets via `rldk monitor --rules ppo_safe` or your custom YAML.
 
+## Fullscale remediation hints
+
+The fullscale acceptance run reuses the following guardrails from
+`rules/fullscale_rules.yaml`. When they fire, apply the same remediations suggested by the
+alerts:
+
+- **KL spike guard (`kl_spike_guard`)** – Lower the policy temperature or learning rate to
+  tighten updates. The acceptance defaults are `--temperature 0.95` and `--learning-rate 8e-5`.
+- **Reward collapse watch (`reward_collapse_watch`)** – Increase the batch size for steadier
+  gradients or reduce the sampling temperature. Defaults are `--batch-size 4` and
+  `--temperature 0.95`.
+- **Gradient norm ceiling (`grad_norm_ceiling`)** – Ensure clipping is enabled with
+  `--max-grad-norm 2.5` or lower the learning rate when gradients breach the ceiling.
+
+These are the same hints echoed by the monitor when `scripts/fullscale_acceptance.sh`
+detects issues, so you can remediate failures locally before rerunning the acceptance
+pipeline.
+
 ## Action reference
 
 | Action | Description | Key fields |

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -90,6 +90,39 @@ summary = tracker.finish_experiment()
 print(f"Experiment completed: {summary['experiment_id']}")
 ```
 
+## 3½. Validate the fullscale pipeline
+
+Before digging into ad-hoc experiments, run `scripts/fullscale_acceptance.sh` to confirm the
+tooling works end-to-end on your machine. The script provisions a temporary virtual
+environment, installs RLDK in editable mode, and chains together:
+
+1. A **primary** and **baseline** invocation of `scripts/fullscale_train_rl.py` so you can
+   diff an updating policy against a frozen control run.
+2. The **monitor once** workflow with `rules/fullscale_rules.yaml`, producing alerts and a
+   detailed report.
+3. **Metrics ingestion**, **reward health analysis**, and **reward card** generation to gate
+   on the default detectors.
+4. A **diff** against the baseline and a **determinism** replay to ensure reproducibility.
+
+The helper exits with a non-zero status when those monitor rules raise warning-or-higher
+alerts beyond their thresholds or when the reward card reports issues. Check the generated
+`artifacts/fullscale/ACCEPTANCE_SUMMARY.md` for the same verdicts the CI gate expects.
+
+### Tuned defaults and anomaly simulation
+
+The acceptance trainer uses CPU-friendly defaults that still exercise every gate:
+
+- `--learning-rate`: `8e-5`
+- `--batch-size`: `4`
+- `--temperature`: `0.95`
+- `--max-grad-norm`: `2.5`
+
+Keep the defaults for a healthy baseline run. Pass `--simulate-anomalies` to
+`scripts/fullscale_train_rl.py` if you want the deterministic KL spikes and reward collapse
+scenario that force alert paths. The remediation advice in
+[`monitor_rules_cookbook.md`](monitor_rules_cookbook.md#fullscale-remediation-hints) mirrors the
+suggestions emitted by `rules/fullscale_rules.yaml` when those guards activate.
+
 ## 3. Run Forensics Analysis
 
 Now let's analyze some training data for anomalies:

--- a/docs/index.md
+++ b/docs/index.md
@@ -171,6 +171,45 @@ rldk evals evaluate data.jsonl --suite quick --output results.json
 rldk bisect --good abc123 --bad def456 --cmd "python train.py"
 ```
 
+## 🧪 Fullscale Acceptance Pipeline
+
+Run `scripts/fullscale_acceptance.sh` when you need an end-to-end validation of the toolkit.
+The helper script provisions an isolated virtual environment, installs RLDK in editable
+mode, and then orchestrates the following stages:
+
+- **Primary and baseline training runs** using `scripts/fullscale_train_rl.py` so you have
+  both an updating policy and a frozen control group to diff.
+- **Monitor verification** with `rules/fullscale_rules.yaml`, capturing alerts, a JSON
+  report, and human-readable summaries.
+- **Metrics ingestion and reward health analysis** to materialize normalized metrics and
+  gate on the default reward health detectors.
+- **Diff and determinism checks** that compare the primary run against the baseline and
+  ensure seeded replays stay within tolerance.
+- **Reward card generation** summarizing reward quality and health signals.
+
+The script exits non-zero when the monitor emits warning-or-higher alerts that exceed the
+guard bands or when the reward card reports issues, mirroring the gating you will see in
+`artifacts/fullscale/ACCEPTANCE_SUMMARY.md`.
+
+### Tuned defaults and anomaly simulation
+
+The acceptance trainer ships with tuned defaults so CPU runs finish in a few hours while
+still exercising all gates:
+
+- `--learning-rate`: `8e-5`
+- `--batch-size`: `4`
+- `--temperature`: `0.95`
+- `--max-grad-norm`: `2.5`
+
+Pass `--simulate-anomalies` to `scripts/fullscale_train_rl.py` when you want the legacy
+stressors (reward collapses and KL spikes) that guarantee monitor activations. Leaving the
+flag unset keeps the run in its healthy configuration so you can validate green-path
+behavior.
+
+Refer to the [monitor remediation hints](getting-started/monitor_rules_cookbook.md#fullscale-remediation-hints)
+for the adjustments the KL, reward, and gradient guards expect—these match the guidance
+emitted directly from `rules/fullscale_rules.yaml`.
+
 ## 📊 What You Get
 
 ### Complete Reproducibility


### PR DESCRIPTION
## Summary
- add documentation on running scripts/fullscale_acceptance.sh and its gated stages to the main index and quickstart guide
- document the tuned fullscale training defaults and how to use --simulate-anomalies for stress testing
- add monitor remediation hints that mirror the guidance emitted by rules/fullscale_rules.yaml

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cd7d0253a8832fa81e32cd2ee21773