### PR TITLE
Integrate length bias metrics into reward health pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,8 +541,11 @@ determinism_check = check(cmd="python train.py", replicas=5)
 health_result = reward_health(
     training_data,  # DataFrame, list of dicts, or path to JSONL/table logs
     reference_data,
+    response_col="response_text",
+    length_col="tokens_out",
 )
 print(health_result.report.passed)
+print(health_result.report.length_bias_metrics.bias_severity)
 ```
 
 ## 📊 **What You Get**

--- a/docs/API_CONTRACT.md
+++ b/docs/API_CONTRACT.md
@@ -37,6 +37,7 @@ This document defines the public API contract for RLDK, including Python symbols
 - `RewardHealthReport`
   - Data class containing reward model health analysis results
   - Includes drift detection, saturation analysis, calibration metrics
+  - Provides dedicated length-bias metrics, severity scores, and remediation tips
 
 - `EvalResult`
   - Data class containing evaluation suite results

--- a/docs/health_thresholds.md
+++ b/docs/health_thresholds.md
@@ -173,6 +173,8 @@ threshold_saturation: 0.8
 threshold_calibration: 0.7
 threshold_shortcut: 0.6
 threshold_leakage: 0.3
+threshold_length_bias: 0.4
+enable_length_bias_detection: true
 ```
 
 ## Best Practices
@@ -199,6 +201,9 @@ You can disable detectors that aren't relevant for your use case:
 detectors:
   reward_length_correlation:
     enabled: false  # Disable if length bias is acceptable
+
+# Legacy switch to disable the dedicated detector
+enable_length_bias_detection: false
 ```
 
 ## Troubleshooting

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -298,12 +298,18 @@ from rldk import HealthAnalysisResult, reward_health
 analysis = reward_health(
     run_data=[{"step": 1, "reward_mean": 0.5}, {"step": 2, "reward_mean": 0.6}],
     reward_col="reward_mean",
+    response_col="response_text",  # Optional column with completions
+    length_col="tokens_out",       # Optional column with token counts
+    threshold_length_bias=0.3,
 )
 
 assert isinstance(analysis, HealthAnalysisResult)
 print(analysis.report.passed)
 print(analysis.metrics.head())
 summary = analysis.to_dict()
+# Dedicated length bias detector metrics
+print(analysis.report.length_bias_metrics.bias_severity)
+print(analysis.report.length_bias_recommendations)
 ```
 
 #### `HealthAnalysisResult`
@@ -315,6 +321,10 @@ The object returned by `reward_health` combines the underlying
 - `metrics`: Normalized training metrics DataFrame for the run
 - `reference_metrics`: Optional normalized reference DataFrame
 - `to_dict()`: JSON-ready summary for serialization or logging
+- Length bias fields:
+  - `length_bias_detected`: Boolean flag indicating severity crossed the configured threshold
+  - `length_bias_metrics`: Structured metrics (correlations, ODIN heuristics, quartiles)
+  - `length_bias_recommendations`: Human-readable remediation tips from the detector
 
 ### Evaluation Suites
 
@@ -558,11 +568,18 @@ class DeterminismReport:
 class RewardHealthReport:
     passed: bool
     drift_detected: bool
-    saturation_issues: List[Dict[str, Any]]
+    saturation_issues: List[str]
     calibration_score: float
-    shortcut_signals: List[Dict[str, Any]]
+    shortcut_signals: List[str]
     label_leakage_risk: float
-    drift_metrics: Optional[pd.DataFrame]
+    fixes: List[str]
+    drift_metrics: pd.DataFrame
+    calibration_details: Dict[str, Any]
+    shortcut_analysis: Dict[str, float]
+    saturation_analysis: Dict[str, Any]
+    length_bias_detected: bool
+    length_bias_metrics: LengthBiasMetrics
+    length_bias_recommendations: List[str]
 ```
 
 #### `DivergenceReport`

--- a/reference/expected/reward_analysis/reward_health_summary.json
+++ b/reference/expected/reward_analysis/reward_health_summary.json
@@ -13,6 +13,8 @@
     "zero_ratio": 0.0
   },
   "shortcut_analysis": {
-    "length_correlation": NaN
-  }
+  },
+  "length_bias_detected": false,
+  "length_bias_recommendations": [],
+  "length_bias_metrics": {}
 }

--- a/reference/expected/reward_card.json
+++ b/reference/expected/reward_card.json
@@ -13,6 +13,8 @@
     "zero_ratio": 0.0
   },
   "shortcut_analysis": {
-    "length_correlation": NaN
-  }
+  },
+  "length_bias_detected": false,
+  "length_bias_recommendations": [],
+  "length_bias_metrics": {}
 }

--- a/src/rldk/cli.py
+++ b/src/rldk/cli.py
@@ -36,6 +36,7 @@ from rldk.forensics.ckpt_diff import diff_checkpoints
 from rldk.forensics.env_audit import audit_environment
 from rldk.forensics.log_scan import scan_logs
 from rldk.ingest import ingest_runs, normalize_training_metrics_source
+from rldk.ingest.training_metrics_normalizer import normalize_training_metrics
 from rldk.io import (
     CkptDiffReportV1,
     DeterminismCardV1,
@@ -144,6 +145,32 @@ def _combine_field_maps(
     if custom_mapping:
         mapping.update(custom_mapping)
     return mapping or None
+
+
+def _fallback_directory_load(
+    directory: Path, field_map: Optional[Dict[str, str]]
+) -> pd.DataFrame:
+    typer.echo("Fallback: loading metrics table directly...")
+    candidates = sorted(directory.glob("*"))
+    table: Optional[pd.DataFrame] = None
+    for candidate in candidates:
+        suffix = candidate.suffix.lower()
+        try:
+            if suffix == ".csv":
+                table = pd.read_csv(candidate)
+            elif suffix == ".tsv":
+                table = pd.read_csv(candidate, sep="\t")
+            elif suffix == ".parquet":
+                table = pd.read_parquet(candidate)
+        except Exception:
+            continue
+        if table is not None:
+            break
+    if table is None:
+        raise TypeError(
+            "Unable to load metrics table from directory; no supported files found"
+        )
+    return normalize_training_metrics(table, field_map=field_map)
 
 
 def _normalize_signals_option(signals: Sequence[str]) -> List[str]:
@@ -1482,8 +1509,11 @@ def reward_health_run(
         generate_reward_health_report(health_report, out)
 
         # Display results
+        severity = health_report.length_bias_metrics.bias_severity
         if health_report.passed:
             typer.echo("\n✅ Reward health check passed")
+            if severity is not None:
+                typer.echo(f"  Length bias severity: {severity:.3f}")
             exit_code = 0
         else:
             typer.echo("\n🚨 Reward health issues detected")
@@ -2648,6 +2678,26 @@ def reward_health(
     threshold_leakage: float = typer.Option(
         0.3, "--threshold-leakage", help="Threshold for label leakage risk"
     ),
+    response_col: Optional[str] = typer.Option(
+        None,
+        "--response-col",
+        help="Column containing response text for length bias detection",
+    ),
+    length_col: Optional[str] = typer.Option(
+        None,
+        "--length-col",
+        help="Column containing response lengths or token counts",
+    ),
+    threshold_length_bias: float = typer.Option(
+        0.4,
+        "--threshold-length-bias",
+        help="Severity threshold for length bias detection",
+    ),
+    enable_length_bias_detection: bool = typer.Option(
+        True,
+        "--enable-length-bias-detection/--disable-length-bias-detection",
+        help="Toggle dedicated length bias detection",
+    ),
     gate: bool = typer.Option(
         False, "--gate", help="Enable CI gate mode with exit codes (0=pass, 1=warn, 2=fail)"
     ),
@@ -2686,7 +2736,12 @@ def reward_health(
 
         # Normalize run data
         typer.echo("Normalizing run data...")
-        run_data = normalize_training_metrics_source(run_path, field_map=mapping_dict)
+        try:
+            run_data = normalize_training_metrics_source(run_path, field_map=mapping_dict)
+        except TypeError as exc:
+            if "arg must be a list" not in str(exc) or not Path(run_path).is_dir():
+                raise
+            run_data = _fallback_directory_load(Path(run_path), mapping_dict)
 
         if run_data.empty:
             raise ValidationError(
@@ -2701,9 +2756,14 @@ def reward_health(
         reference_data = None
         if reference_path:
             typer.echo("Normalizing reference data...")
-            reference_data = normalize_training_metrics_source(
-                reference_path, field_map=mapping_dict
-            )
+            try:
+                reference_data = normalize_training_metrics_source(
+                    reference_path, field_map=mapping_dict
+                )
+            except TypeError as exc:
+                if "arg must be a list" not in str(exc) or not Path(reference_path).is_dir():
+                    raise
+                reference_data = _fallback_directory_load(Path(reference_path), mapping_dict)
             if reference_data.empty:
                 raise ValidationError(
                     "Normalized reference data is empty",
@@ -2725,6 +2785,10 @@ def reward_health(
             threshold_calibration=threshold_calibration,
             threshold_shortcut=threshold_shortcut,
             threshold_leakage=threshold_leakage,
+            response_col=response_col,
+            length_col=length_col,
+            threshold_length_bias=threshold_length_bias,
+            enable_length_bias_detection=enable_length_bias_detection,
         )
 
         # Generate reports
@@ -2732,8 +2796,11 @@ def reward_health(
         generate_reward_health_report(health_report, output_dir)
 
         # Display results
+        severity = health_report.length_bias_metrics.bias_severity
         if health_report.passed:
             typer.echo("\n✅ Reward health check passed")
+            if severity is not None:
+                typer.echo(f"  Length bias severity: {severity:.3f}")
             exit_code = 0
         else:
             typer.echo("\n🚨 Reward health issues detected")
@@ -2755,6 +2822,16 @@ def reward_health(
             if health_report.label_leakage_risk > threshold_leakage:
                 typer.echo(
                     f"  - Label leakage risk: {health_report.label_leakage_risk:.3f}"
+                )
+            if health_report.length_bias_detected:
+                typer.echo(
+                    f"  - Length bias severity {severity:.3f} exceeds threshold"
+                    if severity is not None
+                    else "  - Length bias detected"
+                )
+            elif severity is not None:
+                typer.echo(
+                    f"  - Length bias severity: {severity:.3f} (below threshold)"
                 )
 
             # Determine exit code based on severity

--- a/src/rldk/io/consolidated_writers.py
+++ b/src/rldk/io/consolidated_writers.py
@@ -9,6 +9,31 @@ import pandas as pd
 
 from .consolidated_schemas import Event, MetricsSchema
 from .unified_writer import UnifiedWriter
+from ..reward.length_bias import LengthBiasMetrics
+
+
+def _length_bias_metrics_to_dict(metrics: LengthBiasMetrics) -> Dict[str, Any]:
+    if isinstance(metrics, LengthBiasMetrics):
+        return metrics.to_dict()
+    if hasattr(metrics, "to_dict"):
+        return metrics.to_dict()
+    if isinstance(metrics, dict):
+        return metrics
+    return {}
+
+
+def _format_optional_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "Yes" if value else "No"
+    if isinstance(value, (int, np.integer)):
+        return str(int(value))
+    if isinstance(value, (float, np.floating)):
+        if np.isnan(value):
+            return "N/A"
+        return f"{float(value):.3f}"
+    if value is None:
+        return "N/A"
+    return str(value)
 
 
 def write_drift_card(drift_data: Dict[str, Any], output_dir: Union[str, Path]) -> None:
@@ -136,6 +161,12 @@ def _generate_reward_health_card_md(report) -> str:
     lines.append(f"- **Calibration Score:** {report.calibration_score:.3f}\n")
     lines.append(f"- **Shortcut Signals:** {len(report.shortcut_signals)}\n")
     lines.append(f"- **Label Leakage Risk:** {report.label_leakage_risk:.3f}\n")
+    severity = report.length_bias_metrics.bias_severity
+    severity_str = f"{severity:.3f}" if severity is not None else "N/A"
+    lines.append(
+        f"- **Length Bias Detected:** {'Yes' if report.length_bias_detected else 'No'}\n"
+    )
+    lines.append(f"- **Length Bias Severity:** {severity_str}\n")
 
     # Detailed analysis sections
     if report.drift_detected:
@@ -221,6 +252,53 @@ def _generate_reward_health_card_md(report) -> str:
             "The reward model may have access to training signals it shouldn't see.\n"
         )
 
+    length_metrics_dict = _length_bias_metrics_to_dict(report.length_bias_metrics)
+    if report.length_bias_detected or length_metrics_dict or report.length_bias_recommendations:
+        lines.append("## 🧵 Length Bias Analysis\n")
+        status_line = (
+            "**Status:** 🚨 Length bias detected\n"
+            if report.length_bias_detected
+            else "**Status:** ✅ No significant length bias detected\n"
+        )
+        lines.append(status_line)
+
+        if length_metrics_dict:
+            lines.append("### Key Metrics\n")
+            key_fields = {
+                "Valid Samples": length_metrics_dict.get("valid_sample_count"),
+                "Pearson Correlation": length_metrics_dict.get("pearson_correlation"),
+                "Spearman Correlation": length_metrics_dict.get("spearman_correlation"),
+                "Variance Explained": length_metrics_dict.get("variance_explained"),
+                "Bias Severity": length_metrics_dict.get("bias_severity"),
+                "ODIN Reward per Token": length_metrics_dict.get(
+                    "odin_reward_per_token"
+                ),
+                "ODIN Optimization Flag": length_metrics_dict.get(
+                    "odin_optimization_flag"
+                ),
+            }
+            for label, value in key_fields.items():
+                lines.append(f"- **{label}:** {_format_optional_value(value)}\n")
+
+            quartiles = length_metrics_dict.get("quartile_metrics") or {}
+            if quartiles:
+                lines.append("\n### Quartile Summary\n")
+                lines.append("| Quartile | Length Range | Mean Reward | Count |\n")
+                lines.append("|----------|--------------|-------------|-------|\n")
+                for name, values in quartiles.items():
+                    length_min = _format_optional_value(values.get("length_min"))
+                    length_max = _format_optional_value(values.get("length_max"))
+                    reward_mean = _format_optional_value(values.get("mean_reward"))
+                    count = _format_optional_value(values.get("count"))
+                    lines.append(
+                        f"| {name.upper()} | {length_min} - {length_max} | {reward_mean} | {count} |\n"
+                    )
+
+        if report.length_bias_recommendations:
+            lines.append("\n### Recommendations\n")
+            for recommendation in report.length_bias_recommendations:
+                lines.append(f"- {recommendation}\n")
+
     # Recommended fixes
     if report.fixes:
         lines.append("## 🔧 Recommended Fixes\n")
@@ -261,6 +339,11 @@ def write_reward_health_summary(report, output_dir: Path) -> None:
         "fixes": report.fixes,
         "saturation_analysis": report.saturation_analysis,
         "shortcut_analysis": report.shortcut_analysis,
+        "length_bias_detected": report.length_bias_detected,
+        "length_bias_recommendations": report.length_bias_recommendations,
+        "length_bias_metrics": _length_bias_metrics_to_dict(
+            report.length_bias_metrics
+        ),
     }
 
     # Add drift summary if available

--- a/src/rldk/io/reward_writers.py
+++ b/src/rldk/io/reward_writers.py
@@ -1,12 +1,13 @@
 """Report writers for reward health analysis."""
 
 from pathlib import Path
-from typing import Union
+from typing import Any, Dict, Union
 
 import numpy as np
 import pandas as pd
 
 from ..reward.health_analysis import RewardHealthReport
+from ..reward.length_bias import LengthBiasMetrics
 from .unified_writer import UnifiedWriter
 
 
@@ -40,6 +41,30 @@ def _json_serialize(obj):
         return obj
 
 
+def _length_bias_metrics_to_dict(metrics: LengthBiasMetrics) -> Dict[str, Any]:
+    if isinstance(metrics, LengthBiasMetrics):
+        return metrics.to_dict()
+    if hasattr(metrics, "to_dict"):
+        return metrics.to_dict()
+    if isinstance(metrics, dict):
+        return metrics
+    return {}
+
+
+def _format_optional_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "Yes" if value else "No"
+    if isinstance(value, (int, np.integer)):
+        return str(int(value))
+    if isinstance(value, (float, np.floating)):
+        if np.isnan(value):
+            return "N/A"
+        return f"{float(value):.3f}"
+    if value is None:
+        return "N/A"
+    return str(value)
+
+
 def write_reward_health_card(report: RewardHealthReport, output_dir: Path) -> None:
     """Write reward health card to markdown file."""
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -67,6 +92,12 @@ def write_reward_health_card(report: RewardHealthReport, output_dir: Path) -> No
         f.write(f"- **Calibration Score:** {report.calibration_score:.3f}\n")
         f.write(f"- **Shortcut Signals:** {len(report.shortcut_signals)}\n")
         f.write(f"- **Label Leakage Risk:** {report.label_leakage_risk:.3f}\n\n")
+        severity = report.length_bias_metrics.bias_severity
+        severity_str = f"{severity:.3f}" if severity is not None else "N/A"
+        f.write(
+            f"- **Length Bias Detected:** {'Yes' if report.length_bias_detected else 'No'}\n"
+        )
+        f.write(f"- **Length Bias Severity:** {severity_str}\n\n")
 
         # Detailed analysis sections
         if report.drift_detected:
@@ -152,6 +183,60 @@ def write_reward_health_card(report: RewardHealthReport, output_dir: Path) -> No
                 "The reward model may have access to training signals it shouldn't see.\n"
             )
 
+        length_metrics_dict = _length_bias_metrics_to_dict(report.length_bias_metrics)
+        if report.length_bias_detected or length_metrics_dict or report.length_bias_recommendations:
+            f.write("## 🧵 Length Bias Analysis\n\n")
+            status_line = (
+                "**Status:** 🚨 Length bias detected\n\n"
+                if report.length_bias_detected
+                else "**Status:** ✅ No significant length bias detected\n\n"
+            )
+            f.write(status_line)
+
+            if length_metrics_dict:
+                f.write("### Key Metrics\n\n")
+                key_fields = {
+                    "Valid Samples": length_metrics_dict.get("valid_sample_count"),
+                    "Pearson Correlation": length_metrics_dict.get(
+                        "pearson_correlation"
+                    ),
+                    "Spearman Correlation": length_metrics_dict.get(
+                        "spearman_correlation"
+                    ),
+                    "Variance Explained": length_metrics_dict.get(
+                        "variance_explained"
+                    ),
+                    "Bias Severity": length_metrics_dict.get("bias_severity"),
+                    "ODIN Reward per Token": length_metrics_dict.get(
+                        "odin_reward_per_token"
+                    ),
+                    "ODIN Optimization Flag": length_metrics_dict.get(
+                        "odin_optimization_flag"
+                    ),
+                }
+                for label, value in key_fields.items():
+                    formatted = _format_optional_value(value)
+                    f.write(f"- **{label}:** {formatted}\n")
+
+                quartiles = length_metrics_dict.get("quartile_metrics") or {}
+                if quartiles:
+                    f.write("\n### Quartile Summary\n\n")
+                    f.write("| Quartile | Length Range | Mean Reward | Count |\n")
+                    f.write("|----------|--------------|-------------|-------|\n")
+                    for name, values in quartiles.items():
+                        length_min = _format_optional_value(values.get("length_min"))
+                        length_max = _format_optional_value(values.get("length_max"))
+                        reward_mean = _format_optional_value(values.get("mean_reward"))
+                        count = _format_optional_value(values.get("count"))
+                        f.write(
+                            f"| {name.upper()} | {length_min} - {length_max} | {reward_mean} | {count} |\n"
+                        )
+
+            if report.length_bias_recommendations:
+                f.write("\n### Recommendations\n\n")
+                for recommendation in report.length_bias_recommendations:
+                    f.write(f"- {recommendation}\n")
+
         # Recommended fixes
         if report.fixes:
             f.write("## 🔧 Recommended Fixes\n\n")
@@ -192,6 +277,11 @@ def write_reward_health_summary(report: RewardHealthReport, output_dir: Path) ->
         "fixes": report.fixes,
         "saturation_analysis": report.saturation_analysis,
         "shortcut_analysis": report.shortcut_analysis,
+        "length_bias_detected": report.length_bias_detected,
+        "length_bias_recommendations": report.length_bias_recommendations,
+        "length_bias_metrics": _length_bias_metrics_to_dict(
+            report.length_bias_metrics
+        ),
     }
 
     # Add drift summary if available

--- a/src/rldk/reward/api.py
+++ b/src/rldk/reward/api.py
@@ -11,6 +11,7 @@ import pandas as pd
 from ..ingest.training_metrics_normalizer import normalize_training_metrics
 from ..utils.error_handling import ValidationError
 from .health_analysis import RewardHealthReport, health
+from .length_bias import LengthBiasMetrics
 
 TrainingMetricsInput = Union[pd.DataFrame, Sequence[Mapping[str, Any]], str, Path]
 
@@ -37,7 +38,21 @@ class HealthAnalysisResult:
             "saturation_analysis": self.report.saturation_analysis,
             "shortcut_analysis": self.report.shortcut_analysis,
             "calibration_details": self.report.calibration_details,
+            "length_bias_detected": self.report.length_bias_detected,
+            "length_bias_recommendations": list(
+                self.report.length_bias_recommendations
+            ),
         }
+
+        metrics_value = self.report.length_bias_metrics
+        if isinstance(metrics_value, LengthBiasMetrics):
+            report_dict["length_bias_metrics"] = metrics_value.to_dict()
+        elif hasattr(metrics_value, "to_dict"):
+            report_dict["length_bias_metrics"] = metrics_value.to_dict()
+        elif isinstance(metrics_value, dict):
+            report_dict["length_bias_metrics"] = metrics_value
+        else:
+            report_dict["length_bias_metrics"] = {}
 
         if (
             self.report.drift_metrics is not None
@@ -89,6 +104,10 @@ def reward_health(
     threshold_calibration: float = 0.7,
     threshold_shortcut: float = 0.6,
     threshold_leakage: float = 0.3,
+    response_col: Optional[str] = None,
+    length_col: Optional[str] = None,
+    threshold_length_bias: float = 0.4,
+    enable_length_bias_detection: bool = True,
 ) -> HealthAnalysisResult:
     """Run reward health analysis with flexible input formats."""
 
@@ -126,6 +145,10 @@ def reward_health(
         threshold_calibration=threshold_calibration,
         threshold_shortcut=threshold_shortcut,
         threshold_leakage=threshold_leakage,
+        response_col=response_col,
+        length_col=length_col,
+        threshold_length_bias=threshold_length_bias,
+        enable_length_bias_detection=enable_length_bias_detection,
     )
 
     return HealthAnalysisResult(report=report, metrics=run_metrics, reference_metrics=reference_metrics)

--- a/src/rldk/reward/health_analysis.py
+++ b/src/rldk/reward/health_analysis.py
@@ -1,13 +1,14 @@
 """Main reward health checking functionality."""
 
-from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
 
 from .calibration import analyze_calibration
 from .drift import detect_reward_drift
+from .length_bias import LengthBiasDetector, LengthBiasMetrics
 
 
 @dataclass
@@ -25,6 +26,9 @@ class RewardHealthReport:
     calibration_details: Dict[str, Any]
     shortcut_analysis: Dict[str, float]
     saturation_analysis: Dict[str, Any]
+    length_bias_detected: bool = False
+    length_bias_metrics: LengthBiasMetrics = field(default_factory=LengthBiasMetrics)
+    length_bias_recommendations: List[str] = field(default_factory=list)
 
 
 def health(
@@ -37,6 +41,10 @@ def health(
     threshold_calibration: float = 0.7,
     threshold_shortcut: float = 0.6,
     threshold_leakage: float = 0.3,
+    response_col: Optional[str] = None,
+    length_col: Optional[str] = None,
+    threshold_length_bias: float = 0.4,
+    enable_length_bias_detection: bool = True,
 ) -> RewardHealthReport:
     """
     Analyze reward model health and detect pathologies.
@@ -51,6 +59,10 @@ def health(
         threshold_calibration: Threshold for calibration quality
         threshold_shortcut: Threshold for shortcut signal detection
         threshold_leakage: Threshold for label leakage risk
+        response_col: Optional column containing response text
+        length_col: Optional column containing precomputed response lengths
+        threshold_length_bias: Threshold on length bias severity for failures
+        enable_length_bias_detection: Toggle for length bias detector
 
     Returns:
         RewardHealthReport with comprehensive analysis
@@ -114,6 +126,46 @@ def health(
         issues.extend(shortcut_signals)
         fixes.append("Remove or balance shortcut features from training data")
 
+    # 4b. Detect length bias using dedicated detector
+    length_bias_detected = False
+    length_bias_metrics = LengthBiasMetrics()
+    length_bias_recommendations: List[str] = []
+    if enable_length_bias_detection:
+        responses, lengths = _prepare_length_bias_inputs(
+            run_data, response_col, length_col
+        )
+        if responses is not None or lengths is not None:
+            detector = LengthBiasDetector()
+            rewards = run_data[reward_col].tolist()
+            response_inputs: Iterable[Any]
+            if responses is None:
+                response_inputs = [""] * len(rewards)
+            else:
+                response_inputs = responses
+            metrics = detector.analyze_length_bias(
+                response_inputs,
+                rewards,
+                lengths,
+            )
+            length_bias_metrics = metrics
+            length_bias_recommendations = list(metrics.recommendations)
+            severity = metrics.bias_severity or 0.0
+            if severity >= threshold_length_bias:
+                length_bias_detected = True
+                message = f"Length bias detected (severity {severity:.2f})"
+                issues.append(message)
+                shortcut_signals.append(message)
+            for recommendation in metrics.recommendations:
+                if recommendation and recommendation not in fixes:
+                    fixes.append(recommendation)
+        else:
+            skip_message = (
+                "Length bias detection skipped: no response or length data available."
+            )
+            length_bias_recommendations = [skip_message]
+            if skip_message not in fixes:
+                fixes.append(skip_message)
+
     # 5. Detect label leakage
     label_leakage_risk = _detect_label_leakage(run_data, reward_col, threshold_leakage)
     if label_leakage_risk > threshold_leakage:
@@ -135,6 +187,9 @@ def health(
         calibration_details=calibration_details,
         shortcut_analysis=shortcut_analysis,
         saturation_analysis=saturation_analysis,
+        length_bias_detected=length_bias_detected,
+        length_bias_metrics=length_bias_metrics,
+        length_bias_recommendations=length_bias_recommendations,
     )
 
 
@@ -192,17 +247,8 @@ def _detect_shortcut_signals(
     issues = []
     analysis = {}
 
-    # Check for length bias
-    if "tokens_out" in run_data.columns:
-        try:
-            length_corr = np.corrcoef(run_data["tokens_out"], run_data[reward_col])[0, 1]
-            if not np.isnan(length_corr):
-                analysis["length_correlation"] = float(length_corr)
-                if abs(length_corr) > threshold:
-                    issues.append(f"Length bias detected: correlation {length_corr:.3f}")
-        except (ValueError, np.linalg.LinAlgError):
-            # Correlation cannot be computed (e.g., constant values)
-            pass
+    # Length bias detection is handled by LengthBiasDetector in ``health``.
+    # Avoid duplicating alerts here so we can control severity thresholds in one place.
 
     # Check for repetition bias
     if "repetition_penalty" in run_data.columns:
@@ -244,6 +290,69 @@ def _detect_shortcut_signals(
             pass
 
     return issues, analysis
+
+
+def _prepare_length_bias_inputs(
+    run_data: pd.DataFrame,
+    response_col: Optional[str],
+    length_col: Optional[str],
+) -> Tuple[Optional[List[Any]], Optional[List[Optional[float]]]]:
+    """Collect response text and length information for length-bias analysis."""
+
+    responses: Optional[List[Any]] = None
+    lengths: Optional[List[Optional[float]]] = None
+
+    candidate_response_cols: Tuple[Optional[str], ...] = (
+        response_col,
+        "response_text",
+        "response",
+        "completion",
+        "output_text",
+    )
+    for column in candidate_response_cols:
+        if column and column in run_data.columns:
+            responses = run_data[column].tolist()
+            break
+
+    candidate_length_cols: Tuple[Optional[str], ...] = (
+        length_col,
+        "response_length",
+        "response_tokens",
+        "tokens_out",
+        "token_count",
+        "length",
+    )
+    for column in candidate_length_cols:
+        if column and column in run_data.columns:
+            raw_values = run_data[column].tolist()
+            converted: List[Optional[float]] = []
+            for value in raw_values:
+                if value is None:
+                    converted.append(None)
+                else:
+                    try:
+                        converted.append(float(value))
+                    except (TypeError, ValueError):
+                        converted.append(None)
+            lengths = converted
+            break
+
+    if responses is None and lengths is not None:
+        # Ensure the detector receives a placeholder iterable with the correct length.
+        responses = [""] * len(lengths)
+
+    if responses is not None and lengths is not None:
+        if len(responses) != len(lengths):
+            raise ValueError(
+                "Response and length columns must have matching sample counts"
+            )
+
+    if responses is not None and len(responses) == 0:
+        responses = None
+    if lengths is not None and len(lengths) == 0:
+        lengths = None
+
+    return responses, lengths
 
 
 def _detect_label_leakage(

--- a/src/rldk/reward/health_config/config.py
+++ b/src/rldk/reward/health_config/config.py
@@ -143,6 +143,8 @@ def get_legacy_thresholds(config: Dict[str, Any]) -> Dict[str, float]:
         'threshold_calibration': config.get('threshold_calibration', 0.7),
         'threshold_shortcut': config.get('threshold_shortcut', 0.6),
         'threshold_leakage': config.get('threshold_leakage', 0.3),
+        'threshold_length_bias': config.get('threshold_length_bias', 0.4),
+        'enable_length_bias_detection': config.get('enable_length_bias_detection', True),
     }
 
 

--- a/src/rldk/reward/health_config/data/health_default.yaml
+++ b/src/rldk/reward/health_config/data/health_default.yaml
@@ -44,3 +44,5 @@ threshold_saturation: 0.8
 threshold_calibration: 0.7
 threshold_shortcut: 0.6
 threshold_leakage: 0.3
+threshold_length_bias: 0.4
+enable_length_bias_detection: true

--- a/tests/integration/test_reward_health.py
+++ b/tests/integration/test_reward_health.py
@@ -7,6 +7,7 @@ import pytest
 from rldk.reward.calibration import analyze_calibration
 from rldk.reward.drift import detect_reward_drift
 from rldk.reward.health_analysis import RewardHealthReport, health
+from rldk.reward.length_bias import LengthBiasMetrics
 
 
 class TestRewardHealth:
@@ -53,6 +54,9 @@ class TestRewardHealth:
         assert hasattr(report, "shortcut_signals")
         assert hasattr(report, "label_leakage_risk")
         assert hasattr(report, "fixes")
+        assert hasattr(report, "length_bias_detected")
+        assert hasattr(report, "length_bias_metrics")
+        assert hasattr(report, "length_bias_recommendations")
 
     def test_health_with_reference_data(self):
         """Test reward health analysis with reference data."""
@@ -90,18 +94,22 @@ class TestRewardHealth:
         assert len(report.saturation_issues) > 0
         assert any("upper saturation" in issue for issue in report.saturation_issues)
 
-    def test_health_shortcut_detection(self):
-        """Test shortcut signal detection."""
-        # Create data with strong length correlation
-        shortcut_data = self.sample_data.copy()
-        shortcut_data["reward_mean"] = (
-            shortcut_data["tokens_out"] * 0.01
-        )  # Strong correlation
+    def test_health_length_bias_detection(self):
+        """Test dedicated length bias detection."""
+        correlated = self.sample_data.copy()
+        correlated["reward_mean"] = correlated["tokens_out"] * 0.02
 
-        report = health(shortcut_data, threshold_shortcut=0.5)
+        report = health(
+            correlated,
+            threshold_shortcut=0.5,
+            threshold_length_bias=0.2,
+        )
 
-        assert len(report.shortcut_signals) > 0
-        assert any("Length bias" in signal for signal in report.shortcut_signals)
+        assert report.length_bias_detected is True
+        assert report.length_bias_metrics.bias_severity is not None
+        assert any(
+            "Length bias" in signal for signal in report.shortcut_signals
+        )
 
     def test_health_label_leakage_detection(self):
         """Test label leakage detection."""
@@ -135,6 +143,7 @@ class TestRewardHealth:
             threshold_calibration=0.1,  # Very lenient
             threshold_shortcut=0.9,  # Very lenient
             threshold_leakage=0.9,  # Very lenient
+            threshold_length_bias=0.9,
         )
 
         # Lenient thresholds should result in fewer issues
@@ -155,6 +164,21 @@ class TestRewardHealth:
 
         assert isinstance(report, RewardHealthReport)
         # Should handle single row gracefully
+
+    def test_health_disable_length_bias(self):
+        """Ensure length bias detector can be disabled."""
+        correlated = self.sample_data.copy()
+        correlated["reward_mean"] = correlated["tokens_out"] * 0.02
+
+        report = health(
+            correlated,
+            enable_length_bias_detection=False,
+            threshold_length_bias=0.1,
+        )
+
+        assert report.length_bias_detected is False
+        assert report.length_bias_metrics.valid_sample_count == 0
+        assert not any("Length bias" in signal for signal in report.shortcut_signals)
 
 
 class TestCalibration:
@@ -304,6 +328,9 @@ class TestRewardHealthReport:
             calibration_details={},
             shortcut_analysis={},
             saturation_analysis={},
+            length_bias_detected=False,
+            length_bias_metrics=LengthBiasMetrics(),
+            length_bias_recommendations=[],
         )
 
         assert report.passed is True
@@ -328,6 +355,9 @@ class TestRewardHealthReport:
             calibration_details={"error": "Poor calibration"},
             shortcut_analysis={"length_correlation": 0.8},
             saturation_analysis={"upper_saturation_ratio": 0.9},
+            length_bias_detected=True,
+            length_bias_metrics=LengthBiasMetrics(bias_severity=0.8),
+            length_bias_recommendations=["Audit prompts for response length bias."],
         )
 
         assert report.passed is False

--- a/tests/reward_health/test_api_inputs.py
+++ b/tests/reward_health/test_api_inputs.py
@@ -52,6 +52,15 @@ def test_reward_health_accepts_list(base_metrics: pd.DataFrame, dataframe_result
     assert list_result.report.saturation_analysis == dataframe_result.report.saturation_analysis
     assert list_result.report.shortcut_analysis == dataframe_result.report.shortcut_analysis
     assert list_result.report.calibration_details == dataframe_result.report.calibration_details
+    assert (
+        list_result.report.length_bias_detected
+        == dataframe_result.report.length_bias_detected
+    )
+    assert (
+        list_result.report.length_bias_recommendations
+        == dataframe_result.report.length_bias_recommendations
+    )
+    assert list_result.report.length_bias_metrics.to_dict() == dataframe_result.report.length_bias_metrics.to_dict()
     assert list_result.reference_metrics is None
     if list_result.report.drift_metrics is None:
         assert dataframe_result.report.drift_metrics is None
@@ -101,6 +110,15 @@ def test_reward_health_accepts_jsonl(tmp_path: Path, base_metrics: pd.DataFrame,
     assert jsonl_result.report.saturation_analysis == dataframe_result.report.saturation_analysis
     assert jsonl_result.report.shortcut_analysis == dataframe_result.report.shortcut_analysis
     assert jsonl_result.report.calibration_details == dataframe_result.report.calibration_details
+    assert (
+        jsonl_result.report.length_bias_detected
+        == dataframe_result.report.length_bias_detected
+    )
+    assert (
+        jsonl_result.report.length_bias_recommendations
+        == dataframe_result.report.length_bias_recommendations
+    )
+    assert jsonl_result.report.length_bias_metrics.to_dict() == dataframe_result.report.length_bias_metrics.to_dict()
     assert jsonl_result.reference_metrics is None
     if jsonl_result.report.drift_metrics is None:
         assert dataframe_result.report.drift_metrics is None
@@ -108,3 +126,15 @@ def test_reward_health_accepts_jsonl(tmp_path: Path, base_metrics: pd.DataFrame,
         pd.testing.assert_frame_equal(
             jsonl_result.report.drift_metrics, dataframe_result.report.drift_metrics
         )
+
+
+def test_health_analysis_to_dict_includes_length_bias(
+    dataframe_result: HealthAnalysisResult,
+) -> None:
+    payload = dataframe_result.to_dict()
+    report = payload["report"]
+
+    assert "length_bias_detected" in report
+    assert "length_bias_metrics" in report
+    assert "length_bias_recommendations" in report
+    assert isinstance(report["length_bias_metrics"], dict)

--- a/tests/unit/reward/test_reward_writers.py
+++ b/tests/unit/reward/test_reward_writers.py
@@ -1,0 +1,58 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from src.rldk.io.reward_writers import write_reward_health_summary
+from src.rldk.io.consolidated_writers import write_reward_health_summary as consolidated_summary
+from src.rldk.reward.health_analysis import RewardHealthReport
+from src.rldk.reward.length_bias import LengthBiasMetrics
+
+
+@pytest.fixture()
+def sample_report() -> RewardHealthReport:
+    metrics = LengthBiasMetrics(
+        valid_sample_count=5,
+        pearson_correlation=0.42,
+        spearman_correlation=0.4,
+        variance_explained=0.2,
+        bias_severity=0.55,
+        recommendations=["Review reward model prompts for length bias."],
+    )
+    return RewardHealthReport(
+        passed=False,
+        drift_detected=False,
+        saturation_issues=["High zero clustering"],
+        calibration_score=0.65,
+        shortcut_signals=["Length bias detected (severity 0.55)"],
+        label_leakage_risk=0.1,
+        fixes=["Review reward model prompts for length bias."],
+        drift_metrics=pd.DataFrame(),
+        calibration_details={},
+        shortcut_analysis={},
+        saturation_analysis={},
+        length_bias_detected=True,
+        length_bias_metrics=metrics,
+        length_bias_recommendations=metrics.recommendations,
+    )
+
+
+def _load_summary(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+@pytest.mark.parametrize("writer_func", [write_reward_health_summary, consolidated_summary])
+def test_reward_health_summary_serializes_length_bias(tmp_path: Path, sample_report: RewardHealthReport, writer_func) -> None:
+    writer_func(sample_report, tmp_path)
+    summary_path = tmp_path / "reward_health_summary.json"
+    assert summary_path.exists()
+
+    payload = _load_summary(summary_path)
+
+    assert payload["length_bias_detected"] is True
+    assert pytest.approx(payload["length_bias_metrics"]["bias_severity"], rel=1e-6) == 0.55
+    assert payload["length_bias_recommendations"] == [
+        "Review reward model prompts for length bias."
+    ]


### PR DESCRIPTION
## Summary
- add dedicated length bias metrics to the reward health analysis pipeline and thread new parameters through the public API and CLI
- surface metrics in writers/config/docs, including a CLI fallback loader for directory inputs
- extend reward health tests to cover length bias detection and serialization outputs

## Testing
- pytest tests/reward_health/test_api_inputs.py tests/integration/test_reward_health.py tests/unit/reward/test_reward_writers.py tests/test_reward_health_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68d0abaa1de4832f84ed793c402d1926