### PR TITLE
Add length bias monitoring and forensics support

### DIFF
--- a/docs/COMPREHENSIVE_PPO_FORENSICS_SUMMARY.md
+++ b/docs/COMPREHENSIVE_PPO_FORENSICS_SUMMARY.md
@@ -209,7 +209,9 @@ forensics = ComprehensivePPOForensics(
     kl_target_tolerance=0.05,
     enable_kl_schedule_tracking=True,
     enable_gradient_norms_analysis=True,
-    enable_advantage_statistics=True
+    enable_advantage_statistics=True,
+    enable_length_bias_detection=True,
+    length_bias_threshold=0.35,
 )
 
 # Update with training data
@@ -229,6 +231,7 @@ metrics = forensics.update(
 # Get analysis
 analysis = forensics.get_comprehensive_analysis()
 health_summary = forensics.get_health_summary()
+length_bias = forensics.get_length_bias_analysis()
 anomalies = forensics.get_anomalies()
 ```
 
@@ -242,7 +245,9 @@ monitor = ComprehensivePPOMonitor(
     kl_target=0.1,
     enable_kl_schedule_tracking=True,
     enable_gradient_norms_analysis=True,
-    enable_advantage_statistics=True
+    enable_advantage_statistics=True,
+    enable_length_bias_detection=True,
+    length_bias_threshold=0.35,
 )
 
 # Add to trainer callbacks (TRL v0.22.2+ API)

--- a/docs/getting-started/monitor_rules_cookbook.md
+++ b/docs/getting-started/monitor_rules_cookbook.md
@@ -123,6 +123,19 @@ emits a warning and terminates the process specified with `--pid`.
 
 Mix and match these patterns with presets via `rldk monitor --rules ppo_safe` or your custom YAML.
 
+### New: length bias preset
+
+The `length_bias` preset watches for reward hacking driven by response length. It consumes the
+`length_bias_score`, `length_reward_correlation_abs`, and `length_reward_spearman_abs` metrics emitted
+by the comprehensive PPO forensics pipeline. When the configured thresholds (surfaced via the event
+metadata) are exceeded, the preset first warns and then halts persistent length-driven optimization.
+Enable it alongside PPO presets to stay ahead of length bias regressions during reward modeling or
+online PPO runs:
+
+```bash
+rldk monitor --rules ppo_safe --rules length_bias --stream artifacts/run.jsonl
+```
+
 ## Fullscale remediation hints
 
 The fullscale acceptance run reuses the following guardrails from

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -154,7 +154,8 @@ forensics = ComprehensivePPOForensics(
     kl_target=0.1,
     enable_kl_schedule_tracking=True,
     enable_gradient_norms_analysis=True,
-    enable_advantage_statistics=True
+    enable_advantage_statistics=True,
+    enable_length_bias_detection=True,
 )
 
 # Process each step
@@ -169,7 +170,8 @@ for _, row in df.iterrows():
         policy_grad_norm=1.2,
         value_grad_norm=0.8,
         advantage_mean=0.1,
-        advantage_std=0.5
+        advantage_std=0.5,
+        response_data=[{"response": "step" + str(row['step']), "reward": row['reward_mean']}],
     )
 
 # Get analysis results

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,8 @@ forensics = ComprehensivePPOForensics(
     kl_target=0.1,
     enable_kl_schedule_tracking=True,
     enable_gradient_norms_analysis=True,
-    enable_advantage_statistics=True
+    enable_advantage_statistics=True,
+    enable_length_bias_detection=True,
 )
 
 # Update with training data
@@ -58,7 +59,8 @@ metrics = forensics.update(
     policy_grad_norm=1.2,
     value_grad_norm=0.8,
     advantage_mean=0.1,
-    advantage_std=0.5
+    advantage_std=0.5,
+    response_data=[{"response": "long answer", "reward": 0.9}],
 )
 ```
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -193,7 +193,9 @@ forensics = ComprehensivePPOForensics(
     window_size=100,
     enable_kl_schedule_tracking=True,
     enable_gradient_norms_analysis=True,
-    enable_advantage_statistics=True
+    enable_advantage_statistics=True,
+    enable_length_bias_detection=True,
+    length_bias_threshold=0.35,
 )
 
 # Update with training data
@@ -219,6 +221,7 @@ metrics = forensics.update(
 analysis = forensics.get_comprehensive_analysis()
 anomalies = forensics.get_anomalies()
 health_summary = forensics.get_health_summary()
+length_bias = forensics.get_length_bias_analysis()
 forensics.save_analysis("analysis.json")
 ```
 

--- a/rules.yaml
+++ b/rules.yaml
@@ -1,3 +1,5 @@
+# Example monitoring rules. For length bias detection with dynamic thresholds,
+# use the built-in preset: `rldk monitor --rules length_bias`.
 rules:
   - id: stop_on_high_kl
     where: name == "kl"

--- a/src/rldk/cli.py
+++ b/src/rldk/cli.py
@@ -1072,6 +1072,7 @@ def forensics_kl_drift(
             kl_drift_threshold=drift_threshold,
             kl_drift_window_size=drift_window_size,
             kl_drift_reference_period=reference_period,
+            enable_length_bias_detection=False,
         )
 
         entropy_candidates = ["entropy", "entropy_mean", "ppo/policy/entropy"]

--- a/src/rldk/forensics/comprehensive_ppo_forensics.py
+++ b/src/rldk/forensics/comprehensive_ppo_forensics.py
@@ -1,10 +1,12 @@
 """Comprehensive PPO forensics with advanced tracking and analysis."""
 
+from __future__ import annotations
+
 import copy
 import json
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Sequence
 
 import numpy as np
 
@@ -15,6 +17,7 @@ from .advantage_statistics_tracker import (
 from .gradient_norms_analyzer import GradientNormsAnalyzer, GradientNormsMetrics
 from .kl_schedule_tracker import KLScheduleMetrics, KLScheduleTracker
 from .ppo_scan import scan_ppo_events
+from ..reward.length_bias import LengthBiasDetector, LengthBiasMetrics
 
 
 @dataclass
@@ -39,6 +42,18 @@ class ComprehensivePPOMetrics:
     training_stability_score: float = 1.0
     convergence_quality_score: float = 1.0
 
+    # Length bias metrics
+    length_bias_score: Optional[float] = None
+    length_reward_correlation: Optional[float] = None
+    length_reward_spearman: Optional[float] = None
+    length_reward_correlation_abs: Optional[float] = None
+    length_reward_spearman_abs: Optional[float] = None
+    mean_response_length: Optional[float] = None
+    length_bias_detected: bool = False
+    length_bias_threshold: Optional[float] = None
+    length_bias_corr_threshold: Optional[float] = None
+    length_bias_metrics: Optional[LengthBiasMetrics] = None
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary."""
         result = {
@@ -52,6 +67,23 @@ class ComprehensivePPOMetrics:
             "training_stability_score": self.training_stability_score,
             "convergence_quality_score": self.convergence_quality_score,
         }
+
+        result.update(
+            {
+                "length_bias_score": self.length_bias_score,
+                "length_reward_correlation": self.length_reward_correlation,
+                "length_reward_spearman": self.length_reward_spearman,
+                "length_reward_correlation_abs": self.length_reward_correlation_abs,
+                "length_reward_spearman_abs": self.length_reward_spearman_abs,
+                "mean_response_length": self.mean_response_length,
+                "length_bias_detected": self.length_bias_detected,
+                "length_bias_threshold": self.length_bias_threshold,
+                "length_bias_corr_threshold": self.length_bias_corr_threshold,
+            }
+        )
+
+        if self.length_bias_metrics:
+            result["length_bias_metrics"] = self.length_bias_metrics.to_dict()
 
         if self.kl_schedule_metrics:
             result.update({f"kl_schedule_{k}": v for k, v in self.kl_schedule_metrics.to_dict().items()})
@@ -80,6 +112,9 @@ class ComprehensivePPOForensics:
         kl_drift_threshold: float = 0.15,
         kl_drift_window_size: int = 100,
         kl_drift_reference_period: int = 500,
+        enable_length_bias_detection: bool = True,
+        length_bias_threshold: float = 0.35,
+        response_data: Optional[Sequence[Mapping[str, Any]]] = None,
     ):
         """Initialize comprehensive PPO forensics.
 
@@ -94,6 +129,9 @@ class ComprehensivePPOForensics:
             kl_drift_threshold: KL divergence threshold for drift detection
             kl_drift_window_size: Rolling window size for drift calculations
             kl_drift_reference_period: Number of steps used to build the reference distribution
+            enable_length_bias_detection: Toggle length bias detector integration
+            length_bias_threshold: Threshold applied to detector severity scores
+            response_data: Optional initial response/reward records for the detector
         """
         self.kl_target = kl_target
         self.kl_target_tolerance = kl_target_tolerance
@@ -133,6 +171,31 @@ class ComprehensivePPOForensics:
         self.enable_kl_drift_tracking = enable_kl_drift_tracking
         self.kl_drift_threshold = kl_drift_threshold
 
+        # Length bias detection configuration
+        self.enable_length_bias_detection = enable_length_bias_detection
+        self.length_bias_threshold = length_bias_threshold
+        self.length_bias_corr_threshold = max(0.2, min(0.6, length_bias_threshold + 0.05))
+        self._length_bias_detector: Optional[LengthBiasDetector] = (
+            LengthBiasDetector() if enable_length_bias_detection else None
+        )
+        self._length_bias_metrics_cache: LengthBiasMetrics = LengthBiasMetrics()
+        self._length_bias_analysis_cache: Dict[str, Any] = {
+            "enabled": enable_length_bias_detection,
+            "detected": False,
+            "threshold": length_bias_threshold,
+            "corr_threshold": self.length_bias_corr_threshold,
+            "metrics": self._length_bias_metrics_cache.to_dict(),
+            "recommendations": [],
+            "sample_count": 0,
+        }
+        self._response_records: List[Dict[str, Any]] = []
+        self._length_bias_dirty: bool = False
+        if response_data and enable_length_bias_detection:
+            self._ingest_response_batch(response_data)
+            self._update_length_bias_metrics()
+        elif enable_length_bias_detection:
+            self._apply_length_bias_metrics()
+
         # Analysis results
         self.anomalies: List[Dict[str, Any]] = []
         self.analysis_summary: Dict[str, Any] = {}
@@ -141,6 +204,7 @@ class ComprehensivePPOForensics:
         print(f"   KL Schedule Tracking: {enable_kl_schedule_tracking}")
         print(f"   Gradient Norms Analysis: {enable_gradient_norms_analysis}")
         print(f"   Advantage Statistics: {enable_advantage_statistics}")
+        print(f"   Length Bias Detection: {enable_length_bias_detection}")
 
     def update(
         self,
@@ -159,6 +223,10 @@ class ComprehensivePPOForensics:
         advantage_max: Optional[float] = None,
         advantage_median: Optional[float] = None,
         advantage_samples: Optional[List[float]] = None,
+        response_data: Optional[Sequence[Mapping[str, Any]]] = None,
+        response_length: Optional[float] = None,
+        response_text: Optional[str] = None,
+        response_reward: Optional[float] = None,
     ) -> ComprehensivePPOMetrics:
         """Update forensics with new training data."""
         # Update basic metrics
@@ -189,6 +257,34 @@ class ComprehensivePPOForensics:
             )
             self.current_metrics.advantage_statistics_metrics = advantage_metrics
 
+        # Update length bias detector
+        if self.enable_length_bias_detection and self._length_bias_detector:
+            batch: List[Mapping[str, Any]] = []
+            if response_data:
+                if isinstance(response_data, Mapping):
+                    batch.append(response_data)
+                else:
+                    batch.extend(response_data)
+            single_record: Dict[str, Any] = {}
+            if response_reward is not None:
+                single_record["reward"] = response_reward
+            if response_length is not None:
+                single_record["length"] = response_length
+            if response_text is not None:
+                single_record["response"] = response_text
+            if single_record.get("reward") is not None and (
+                single_record.get("length") is not None or single_record.get("response")
+            ):
+                batch.append(single_record)
+            if batch:
+                self._ingest_response_batch(batch)
+            if self._length_bias_dirty:
+                self._update_length_bias_metrics()
+            else:
+                self._apply_length_bias_metrics()
+        else:
+            self._reset_length_bias_metrics()
+
         # Calculate overall health scores
         self._calculate_overall_health_scores()
 
@@ -197,6 +293,15 @@ class ComprehensivePPOForensics:
         self.comprehensive_metrics_history.append(metrics_copy)
 
         return metrics_copy
+
+    def get_length_bias_analysis(self) -> Dict[str, Any]:
+        """Return cached length bias detector output."""
+
+        if not self.enable_length_bias_detection or not self._length_bias_detector:
+            return {}
+        if self._length_bias_dirty:
+            self._update_length_bias_metrics()
+        return copy.deepcopy(self._length_bias_analysis_cache)
 
     def _calculate_overall_health_scores(self):
         """Calculate overall health scores from all trackers."""
@@ -288,6 +393,9 @@ class ComprehensivePPOForensics:
         if self.advantage_statistics_tracker:
             analysis["trackers"]["advantage_statistics"] = self.advantage_statistics_tracker.get_summary()
 
+        if self.enable_length_bias_detection and self._length_bias_detector:
+            analysis["trackers"]["length_bias"] = self.get_length_bias_analysis()
+
         # Store analysis summary
         self.analysis_summary = analysis
 
@@ -350,6 +458,11 @@ class ComprehensivePPOForensics:
             advantage_max = event.get("advantage_max", event.get("adv_max", None))
             advantage_median = event.get("advantage_median", event.get("adv_median", None))
 
+            response_payload = event.get("response_data")
+            response_length = event.get("response_length", event.get("response_tokens", None))
+            response_text = event.get("response_text", event.get("response", None))
+            response_reward = event.get("response_reward", event.get("sample_reward", None))
+
             # Update comprehensive forensics
             self.update(
                 step=step,
@@ -366,6 +479,10 @@ class ComprehensivePPOForensics:
                 advantage_min=advantage_min,
                 advantage_max=advantage_max,
                 advantage_median=advantage_median,
+                response_data=response_payload,
+                response_length=response_length,
+                response_text=response_text,
+                response_reward=response_reward,
             )
 
         # Get comprehensive analysis
@@ -379,6 +496,142 @@ class ComprehensivePPOForensics:
         }
 
         return enhanced_scan
+
+    def _ingest_response_batch(
+        self, payloads: Sequence[Mapping[str, Any]] | Iterable[Mapping[str, Any]]
+    ) -> None:
+        """Normalize response payloads for incremental length bias detection."""
+
+        added = False
+        for payload in payloads:
+            if not isinstance(payload, Mapping):
+                continue
+            reward = payload.get("reward")
+            if reward is None:
+                continue
+            response = payload.get("response") or payload.get("response_text")
+            length = (
+                payload.get("length")
+                if payload.get("length") is not None
+                else payload.get("response_length")
+            )
+            record: Dict[str, Any] = {"reward": float(reward)}
+            if response is not None:
+                record["response"] = str(response)
+            if length is not None:
+                try:
+                    record["length"] = float(length)
+                except (TypeError, ValueError):
+                    record["length"] = None
+            if "response" not in record and record.get("length") is None:
+                continue
+            self._response_records.append(record)
+            added = True
+        if added:
+            self._length_bias_dirty = True
+
+    def _reset_length_bias_metrics(self) -> None:
+        """Clear length bias metrics when the detector is disabled."""
+
+        self.current_metrics.length_bias_score = None
+        self.current_metrics.length_reward_correlation = None
+        self.current_metrics.length_reward_spearman = None
+        self.current_metrics.length_reward_correlation_abs = None
+        self.current_metrics.length_reward_spearman_abs = None
+        self.current_metrics.mean_response_length = None
+        self.current_metrics.length_bias_detected = False
+        self.current_metrics.length_bias_threshold = None
+        self.current_metrics.length_bias_corr_threshold = None
+        self.current_metrics.length_bias_metrics = None
+
+    def _apply_length_bias_metrics(self) -> None:
+        """Mirror cached detector metrics onto the current metrics."""
+
+        if not self.enable_length_bias_detection:
+            self._reset_length_bias_metrics()
+            return
+
+        metrics = self._length_bias_metrics_cache
+        severity = metrics.bias_severity
+        detected = (
+            bool(metrics.valid_sample_count)
+            and severity is not None
+            and severity >= self.length_bias_threshold
+        )
+        self._length_bias_analysis_cache.update(
+            {
+                "detected": detected,
+                "threshold": self.length_bias_threshold,
+                "corr_threshold": self.length_bias_corr_threshold,
+                "metrics": metrics.to_dict(),
+                "recommendations": list(metrics.recommendations),
+                "sample_count": metrics.valid_sample_count,
+            }
+        )
+
+        self.current_metrics.length_bias_score = severity
+        self.current_metrics.length_reward_correlation = metrics.pearson_correlation
+        self.current_metrics.length_reward_spearman = metrics.spearman_correlation
+        self.current_metrics.length_reward_correlation_abs = (
+            abs(metrics.pearson_correlation) if metrics.pearson_correlation is not None else None
+        )
+        self.current_metrics.length_reward_spearman_abs = (
+            abs(metrics.spearman_correlation)
+            if metrics.spearman_correlation is not None
+            else None
+        )
+        self.current_metrics.mean_response_length = metrics.mean_length
+        self.current_metrics.length_bias_detected = detected
+        self.current_metrics.length_bias_threshold = self.length_bias_threshold
+        self.current_metrics.length_bias_corr_threshold = self.length_bias_corr_threshold
+        self.current_metrics.length_bias_metrics = metrics
+
+    def _update_length_bias_metrics(self) -> None:
+        """Recompute cached length bias metrics when new samples arrive."""
+
+        if not self.enable_length_bias_detection or not self._length_bias_detector:
+            self._reset_length_bias_metrics()
+            self._length_bias_dirty = False
+            return
+
+        if not self._response_records:
+            self._length_bias_metrics_cache = LengthBiasMetrics()
+            self._length_bias_dirty = False
+            self._apply_length_bias_metrics()
+            return
+
+        responses: List[str] = []
+        rewards: List[float] = []
+        lengths: List[Optional[float]] = []
+        include_lengths = False
+        for record in self._response_records:
+            responses.append(record.get("response", ""))
+            rewards.append(float(record["reward"]))
+            length_value = record.get("length")
+            if length_value is not None:
+                include_lengths = True
+                lengths.append(float(length_value))
+            else:
+                lengths.append(None)
+
+        length_inputs: Optional[List[Optional[float]]] = None
+        if include_lengths:
+            normalized_lengths: List[Optional[float]] = []
+            for value in lengths:
+                if value is None:
+                    normalized_lengths.append(None)
+                else:
+                    normalized_lengths.append(float(value))
+            length_inputs = normalized_lengths
+
+        metrics = self._length_bias_detector.analyze_length_bias(
+            responses,
+            rewards,
+            lengths=length_inputs,
+        )
+        self._length_bias_metrics_cache = metrics
+        self._length_bias_dirty = False
+        self._apply_length_bias_metrics()
 
     def save_analysis(self, output_path: str):
         """Save comprehensive analysis to file."""
@@ -424,4 +677,7 @@ class ComprehensivePPOForensics:
             "current_reward_mean": current.reward_mean,
             "current_entropy": current.entropy,
             "kl_drift": self.get_kl_drift_analysis() if self.enable_kl_drift_tracking else {},
+            "length_bias": self.get_length_bias_analysis()
+            if self.enable_length_bias_detection and self._length_bias_detector
+            else {},
         }

--- a/src/rldk/integrations/trl/monitors.py
+++ b/src/rldk/integrations/trl/monitors.py
@@ -764,6 +764,8 @@ class ComprehensivePPOMonitor(TrainerCallback):
         enable_kl_schedule_tracking: bool = True,
         enable_gradient_norms_analysis: bool = True,
         enable_advantage_statistics: bool = True,
+        enable_length_bias_detection: bool = True,
+        length_bias_threshold: float = 0.35,
         log_interval: int = 10,
         run_id: Optional[str] = None,
     ):
@@ -776,6 +778,8 @@ class ComprehensivePPOMonitor(TrainerCallback):
             enable_kl_schedule_tracking: Enable KL schedule tracking
             enable_gradient_norms_analysis: Enable gradient norms analysis
             enable_advantage_statistics: Enable advantage statistics tracking
+            enable_length_bias_detection: Enable length bias detection on collected responses
+            length_bias_threshold: Threshold used for severity-driven alerts
             log_interval: Steps between detailed logging
             run_id: Unique identifier for this run
         """
@@ -802,6 +806,8 @@ class ComprehensivePPOMonitor(TrainerCallback):
             enable_kl_schedule_tracking=enable_kl_schedule_tracking,
             enable_gradient_norms_analysis=enable_gradient_norms_analysis,
             enable_advantage_statistics=enable_advantage_statistics,
+            enable_length_bias_detection=enable_length_bias_detection,
+            length_bias_threshold=length_bias_threshold,
         )
 
         # Metrics storage
@@ -810,6 +816,10 @@ class ComprehensivePPOMonitor(TrainerCallback):
         print(f"🔍 Comprehensive PPO Monitor initialized - Run ID: {self.run_id}")
         print(f"📊 KL Target: {kl_target}±{kl_target_tolerance}")
         print(f"📁 Output directory: {self.output_dir}")
+        if enable_length_bias_detection:
+            print(
+                f"📏 Length bias threshold: {length_bias_threshold:.3f}"
+            )
 
     def on_step_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
         """Monitor PPO training at step end."""
@@ -1020,6 +1030,16 @@ class ComprehensivePPOMonitor(TrainerCallback):
         print(f"   Convergence Quality: {current_metrics.convergence_quality_score:.3f}")
         print(f"   KL: {current_metrics.kl:.4f}, KL Coef: {current_metrics.kl_coef:.4f}")
         print(f"   Reward: {current_metrics.reward_mean:.4f}±{current_metrics.reward_std:.4f}")
+
+        if (
+            current_metrics.length_bias_score is not None
+            and current_metrics.length_bias_threshold is not None
+        ):
+            print(
+                "   Length bias: "
+                f"{current_metrics.length_bias_score:.3f}"
+                f" (threshold={current_metrics.length_bias_threshold:.3f})"
+            )
 
         # Log tracker-specific metrics
         if current_metrics.kl_schedule_metrics:

--- a/src/rldk/integrations/trl/monitors.py
+++ b/src/rldk/integrations/trl/monitors.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import json
 import time
+from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -813,6 +814,11 @@ class ComprehensivePPOMonitor(TrainerCallback):
         # Metrics storage
         self.comprehensive_metrics_history: List[Dict[str, Any]] = []
 
+        # Response tracking for length-bias analysis
+        self._pending_response_payloads: List[Dict[str, Any]] = []
+        self._recent_response_fingerprints: deque[Tuple[Any, ...]] = deque(maxlen=512)
+        self._recent_response_fingerprint_set: set[Tuple[Any, ...]] = set()
+
         print(f"🔍 Comprehensive PPO Monitor initialized - Run ID: {self.run_id}")
         print(f"📊 KL Target: {kl_target}±{kl_target_tolerance}")
         print(f"📁 Output directory: {self.output_dir}")
@@ -825,6 +831,9 @@ class ComprehensivePPOMonitor(TrainerCallback):
         """Monitor PPO training at step end."""
         # Extract metrics from trainer state if available
         self._extract_metrics_from_state(state)
+
+        # Cache response payloads for length bias detection when available
+        self._queue_response_payloads(None, kwargs)
 
         # Log comprehensive metrics at intervals
         if state.global_step % self.log_interval == 0:
@@ -851,6 +860,13 @@ class ComprehensivePPOMonitor(TrainerCallback):
         advantage_min = logs.get('ppo/advantages/min', None)
         advantage_max = logs.get('ppo/advantages/max', None)
 
+        # Gather response payloads for length bias detection
+        self._queue_response_payloads(logs, kwargs)
+        response_payloads: Optional[List[Dict[str, Any]]] = None
+        if self._pending_response_payloads:
+            response_payloads = list(self._pending_response_payloads)
+            self._pending_response_payloads.clear()
+
         # Update comprehensive forensics
         comprehensive_metrics = self.forensics.update(
             step=step,
@@ -866,6 +882,7 @@ class ComprehensivePPOMonitor(TrainerCallback):
             advantage_std=advantage_std,
             advantage_min=advantage_min,
             advantage_max=advantage_max,
+            response_data=response_payloads,
         )
 
         # Store metrics
@@ -1019,6 +1036,286 @@ class ComprehensivePPOMonitor(TrainerCallback):
                     self.forensics.current_metrics.policy_value_grad_ratio = (
                         self.forensics.current_metrics.policy_grad_norm / self.forensics.current_metrics.value_grad_norm
                     )
+
+    def _queue_response_payloads(
+        self,
+        logs: Optional[Mapping[str, Any]],
+        callback_kwargs: Optional[Mapping[str, Any]],
+    ) -> None:
+        """Collect response payloads emitted by the PPO loop for length bias detection."""
+
+        if not getattr(self.forensics, "enable_length_bias_detection", False):
+            return
+
+        new_records = self._collect_response_payloads(logs, callback_kwargs)
+        for record in new_records:
+            fingerprint = self._fingerprint_response_record(record)
+            if not self._remember_response_fingerprint(fingerprint):
+                continue
+            self._pending_response_payloads.append(record)
+
+    def _collect_response_payloads(
+        self,
+        logs: Optional[Mapping[str, Any]],
+        callback_kwargs: Optional[Mapping[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Extract normalized response payloads from callback inputs."""
+
+        records: List[Dict[str, Any]] = []
+
+        def consume(source: Any) -> None:
+            if source is None:
+                return
+            if isinstance(source, Mapping):
+                records.extend(self._extract_records_from_mapping(source, consume))
+            elif isinstance(source, Sequence) and not isinstance(source, (str, bytes)):
+                for item in source:
+                    consume(item)
+
+        if callback_kwargs:
+            consume(callback_kwargs)
+        if logs:
+            consume(logs)
+
+        return records
+
+    def _extract_records_from_mapping(
+        self,
+        mapping: Mapping[str, Any],
+        consume: Any,
+    ) -> List[Dict[str, Any]]:
+        """Extract response records from a mapping and recurse into nested payloads."""
+
+        records = self._extract_batch_records(mapping)
+
+        single_record = self._extract_single_record(mapping)
+        if single_record:
+            records.append(single_record)
+
+        nested_keys = (
+            "response_data",
+            "responses",
+            "response_payloads",
+            "ppo_response_data",
+            "ppo_responses",
+            "ppo_response_payloads",
+            "samples",
+            "sample_batch",
+            "trajectories",
+            "episodes",
+            "rollouts",
+            "rollout_samples",
+            "ppo_rollouts",
+            "ppo_batch",
+            "batch",
+            "outputs",
+            "details",
+        )
+        for key in nested_keys:
+            nested = mapping.get(key)
+            if nested is not None and nested is not mapping:
+                consume(nested)
+
+        for value in mapping.values():
+            if value is mapping:
+                continue
+            if isinstance(value, Mapping):
+                consume(value)
+            elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+                consume(value)
+
+        return records
+
+    def _extract_batch_records(self, mapping: Mapping[str, Any]) -> List[Dict[str, Any]]:
+        """Extract response records from batch-style payloads."""
+
+        reward_seq = None
+        for key in ("rewards", "reward_scores", "scores", "returns"):
+            reward_seq = self._as_sequence(mapping.get(key))
+            if reward_seq:
+                break
+        if not reward_seq:
+            return []
+
+        response_seq = None
+        for key in ("responses", "response_texts", "response", "completions", "outputs"):
+            response_seq = self._as_sequence(mapping.get(key))
+            if response_seq:
+                break
+
+        length_seq = None
+        for key in (
+            "response_lengths",
+            "lengths",
+            "response_length",
+            "response_tokens",
+            "token_counts",
+            "tokens_out",
+            "output_lengths",
+            "output_tokens",
+        ):
+            length_seq = self._as_sequence(mapping.get(key))
+            if length_seq:
+                break
+
+        records: List[Dict[str, Any]] = []
+        for idx, reward_value in enumerate(reward_seq):
+            response_value = None
+            if response_seq and idx < len(response_seq):
+                response_value = response_seq[idx]
+            length_value = None
+            if length_seq and idx < len(length_seq):
+                length_value = length_seq[idx]
+
+            record = self._build_response_record(reward_value, response_value, length_value)
+            if record:
+                records.append(record)
+
+        return records
+
+    def _extract_single_record(self, mapping: Mapping[str, Any]) -> Optional[Dict[str, Any]]:
+        """Extract a single response record from scalar entries."""
+
+        reward_candidate = self._first_present(
+            mapping,
+            (
+                "reward",
+                "response_reward",
+                "reward_score",
+                "score",
+            ),
+        )
+        response_candidate = self._first_present(
+            mapping,
+            (
+                "response",
+                "response_text",
+                "completion",
+                "output",
+            ),
+        )
+        length_candidate = self._first_present(
+            mapping,
+            (
+                "length",
+                "response_length",
+                "response_tokens",
+                "tokens_out",
+                "output_length",
+            ),
+        )
+
+        if isinstance(response_candidate, Sequence) and not isinstance(response_candidate, (str, bytes)):
+            response_candidate = None
+        if isinstance(length_candidate, Sequence) and not isinstance(length_candidate, (str, bytes)):
+            length_candidate = None
+
+        return self._build_response_record(
+            reward_candidate,
+            response_candidate,
+            length_candidate,
+        )
+
+    def _build_response_record(
+        self,
+        reward: Any,
+        response: Any,
+        length: Any,
+    ) -> Optional[Dict[str, Any]]:
+        reward_value = self._to_float(reward)
+        if reward_value is None:
+            return None
+
+        record: Dict[str, Any] = {"reward": reward_value}
+
+        length_value = self._to_float(length)
+        if length_value is not None:
+            record["length"] = length_value
+
+        if response is not None:
+            record["response"] = str(response)
+
+        if "length" not in record and "response" not in record:
+            return None
+
+        return record
+
+    def _as_sequence(self, value: Any) -> Optional[List[Any]]:
+        if value is None or isinstance(value, (str, bytes)):
+            return None
+        if isinstance(value, Mapping):
+            return None
+        if hasattr(value, "detach") and hasattr(value, "cpu") and hasattr(value, "numpy"):
+            try:
+                value = value.detach().cpu().numpy()
+            except Exception:  # pragma: no cover - defensive
+                pass
+        if isinstance(value, np.ndarray):
+            return value.tolist()
+        if hasattr(value, "tolist"):
+            try:
+                candidate = value.tolist()
+                if isinstance(candidate, (list, tuple)):
+                    return list(candidate)
+            except Exception:  # pragma: no cover - defensive
+                pass
+        if isinstance(value, Sequence):
+            return list(value)
+        return None
+
+    def _to_float(self, value: Any) -> Optional[float]:
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, np.generic):
+            return float(value.item())
+        if hasattr(value, "item"):
+            try:
+                return float(value.item())
+            except Exception:  # pragma: no cover - defensive
+                pass
+        if hasattr(value, "detach") and hasattr(value, "cpu") and hasattr(value, "item"):
+            try:
+                return float(value.detach().cpu().item())
+            except Exception:  # pragma: no cover - defensive
+                pass
+        if isinstance(value, str):
+            try:
+                return float(value)
+            except ValueError:
+                return None
+        try:
+            return float(value)
+        except Exception:
+            return None
+
+    def _first_present(self, mapping: Mapping[str, Any], keys: Tuple[str, ...]) -> Any:
+        for key in keys:
+            if key in mapping:
+                value = mapping[key]
+                if value is not None:
+                    return value
+        return None
+
+    def _fingerprint_response_record(self, record: Mapping[str, Any]) -> Tuple[Any, ...]:
+        reward = record.get("reward")
+        length = record.get("length")
+        response = record.get("response")
+        reward_key = None if reward is None else round(float(reward), 6)
+        length_key = None if length is None else round(float(length), 3)
+        response_key = None if response is None else str(response)[:128]
+        return (reward_key, length_key, response_key)
+
+    def _remember_response_fingerprint(self, fingerprint: Tuple[Any, ...]) -> bool:
+        if fingerprint in self._recent_response_fingerprint_set:
+            return False
+        if len(self._recent_response_fingerprints) >= self._recent_response_fingerprints.maxlen:
+            oldest = self._recent_response_fingerprints.popleft()
+            self._recent_response_fingerprint_set.discard(oldest)
+        self._recent_response_fingerprints.append(fingerprint)
+        self._recent_response_fingerprint_set.add(fingerprint)
+        return True
 
     def _log_comprehensive_metrics(self):
         """Log comprehensive metrics at intervals."""

--- a/src/rldk/monitor/presets.py
+++ b/src/rldk/monitor/presets.py
@@ -69,6 +69,51 @@ RULE_PRESETS: Dict[str, RulePreset] = {
                     },
                 ],
             },
+            {
+                "id": "ppo_length_bias_severity",
+                "where": "name == \"length_bias_score\"",
+                "condition": "value > meta.length_bias_threshold",
+                "window": {"size": 3, "kind": "consecutive"},
+                "grace_steps": 6,
+                "cooldown_steps": 12,
+                "actions": [
+                    {
+                        "warn": {
+                            "msg": "Length bias severity {value:.3f} exceeds threshold"
+                        }
+                    }
+                ],
+            },
+            {
+                "id": "ppo_length_bias_corr",
+                "where": "name == \"length_reward_correlation_abs\"",
+                "condition": "value > meta.length_bias_corr_threshold",
+                "window": {"size": 6, "kind": "rolling"},
+                "grace_steps": 8,
+                "cooldown_steps": 12,
+                "actions": [
+                    {
+                        "warn": {
+                            "msg": "Absolute Pearson corr {value:.3f} with length"
+                        }
+                    }
+                ],
+            },
+            {
+                "id": "ppo_length_bias_rank_corr",
+                "where": "name == \"length_reward_spearman_abs\"",
+                "condition": "value > meta.length_bias_corr_threshold",
+                "window": {"size": 6, "kind": "rolling"},
+                "grace_steps": 8,
+                "cooldown_steps": 12,
+                "actions": [
+                    {
+                        "warn": {
+                            "msg": "Absolute Spearman corr {value:.3f} with length"
+                        }
+                    }
+                ],
+            },
         ]
     },
     "ppo_strict": {
@@ -137,6 +182,56 @@ RULE_PRESETS: Dict[str, RulePreset] = {
                             "msg": "Strict KL drift gate fired (score={kl_drift_score:.3f})"
                         }
                     },
+                ],
+            },
+            {
+                "id": "ppo_strict_length_bias_severity",
+                "where": "name == \"length_bias_score\"",
+                "condition": "value > meta.length_bias_threshold",
+                "window": {"size": 2, "kind": "consecutive"},
+                "grace_steps": 4,
+                "cooldown_steps": 10,
+                "actions": [
+                    {
+                        "warn": {
+                            "msg": "Strict length bias guard fired: {value:.3f}"
+                        }
+                    },
+                    {
+                        "stop": {
+                            "msg": "Stopping run due to persistent length bias"
+                        }
+                    },
+                ],
+            },
+            {
+                "id": "ppo_strict_length_bias_corr",
+                "where": "name == \"length_reward_correlation_abs\"",
+                "condition": "value > meta.length_bias_corr_threshold",
+                "window": {"size": 4, "kind": "rolling"},
+                "grace_steps": 6,
+                "cooldown_steps": 10,
+                "actions": [
+                    {
+                        "warn": {
+                            "msg": "Length bias correlation {value:.3f} exceeded strict guard"
+                        }
+                    }
+                ],
+            },
+            {
+                "id": "ppo_strict_length_bias_rank_corr",
+                "where": "name == \"length_reward_spearman_abs\"",
+                "condition": "value > meta.length_bias_corr_threshold",
+                "window": {"size": 4, "kind": "rolling"},
+                "grace_steps": 6,
+                "cooldown_steps": 10,
+                "actions": [
+                    {
+                        "warn": {
+                            "msg": "Rank correlation {value:.3f} indicates reward-length coupling"
+                        }
+                    }
                 ],
             },
         ]
@@ -219,6 +314,60 @@ RULE_PRESETS: Dict[str, RulePreset] = {
                             "msg": "Emergency stop due to critical KL drift"
                         }
                     },
+                ],
+            },
+        ]
+    },
+    "length_bias": {
+        "rules": [
+            {
+                "id": "length_bias_severity_gate",
+                "where": "name == \"length_bias_score\"",
+                "condition": "value > meta.length_bias_threshold",
+                "window": {"size": 3, "kind": "consecutive"},
+                "grace_steps": 5,
+                "cooldown_steps": 12,
+                "actions": [
+                    {
+                        "warn": {
+                            "msg": "Length bias severity {value:.3f} exceeds configured guard"
+                        }
+                    },
+                    {
+                        "stop": {
+                            "msg": "Halting run: length bias severity over limit"
+                        }
+                    },
+                ],
+            },
+            {
+                "id": "length_bias_corr_guard",
+                "where": "name == \"length_reward_correlation_abs\"",
+                "condition": "value > meta.length_bias_corr_threshold",
+                "window": {"size": 5, "kind": "rolling"},
+                "grace_steps": 6,
+                "cooldown_steps": 10,
+                "actions": [
+                    {
+                        "warn": {
+                            "msg": "Absolute Pearson correlation {value:.3f} with response length"
+                        }
+                    }
+                ],
+            },
+            {
+                "id": "length_bias_rank_corr_guard",
+                "where": "name == \"length_reward_spearman_abs\"",
+                "condition": "value > meta.length_bias_corr_threshold",
+                "window": {"size": 5, "kind": "rolling"},
+                "grace_steps": 6,
+                "cooldown_steps": 10,
+                "actions": [
+                    {
+                        "warn": {
+                            "msg": "Absolute Spearman correlation {value:.3f} with response length"
+                        }
+                    }
                 ],
             },
         ]

--- a/tests/unit/test_comprehensive_length_bias.py
+++ b/tests/unit/test_comprehensive_length_bias.py
@@ -1,9 +1,15 @@
 import math
 from datetime import datetime
+from types import SimpleNamespace
 
 import pytest
 
-from src.rldk.forensics.comprehensive_ppo_forensics import ComprehensivePPOForensics
+from src.rldk.forensics.comprehensive_ppo_forensics import (
+    ComprehensivePPOForensics,
+    ComprehensivePPOMetrics,
+)
+from src.rldk.integrations.trl import monitors as trl_monitors
+from src.rldk.integrations.trl.monitors import ComprehensivePPOMonitor
 from src.rldk.monitor.engine import Event, MonitorEngine, load_rules
 from src.rldk.monitor.presets import get_rule_preset
 
@@ -18,6 +24,30 @@ def response_batch() -> list[dict[str, float | str]]:
         {"response": "mega", "length": 20, "reward": 0.85},
         {"response": "ultra", "length": 24, "reward": 1.05},
     ]
+
+
+class DummyForensics:
+    """Lightweight forensics stub for monitor interaction tests."""
+
+    def __init__(self) -> None:
+        self.enable_length_bias_detection = True
+        self.length_bias_threshold = 0.3
+        self.length_bias_corr_threshold = 0.2
+        self.current_metrics = ComprehensivePPOMetrics()
+        self.update_calls: list[dict[str, object]] = []
+
+    def update(self, **kwargs):  # type: ignore[no-untyped-def]
+        self.update_calls.append(kwargs)
+        return ComprehensivePPOMetrics()
+
+    def get_anomalies(self):  # type: ignore[no-untyped-def]
+        return []
+
+    def get_health_summary(self):  # type: ignore[no-untyped-def]
+        return {}
+
+    def save_analysis(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+        return None
 
 
 def test_length_bias_detection_enabled(response_batch: list[dict[str, float | str]]) -> None:
@@ -92,6 +122,75 @@ def test_length_bias_rule_presets_register() -> None:
         "length_bias_corr_guard",
         "length_bias_rank_corr_guard",
     }
+
+
+def _make_dummy_state(step: int = 1) -> SimpleNamespace:
+    return SimpleNamespace(global_step=step)
+
+
+def _make_logs() -> dict[str, float]:
+    return {
+        "ppo/rewards/mean": 0.5,
+        "ppo/rewards/std": 0.1,
+        "ppo/policy/kl_mean": 0.05,
+        "ppo/policy/kl_coef": 1.0,
+        "ppo/policy/entropy": 1.2,
+    }
+
+
+def test_comprehensive_monitor_wires_response_payloads(
+    response_batch: list[dict[str, float | str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(trl_monitors, "TRL_AVAILABLE", True)
+
+    monitor = ComprehensivePPOMonitor(enable_length_bias_detection=True, log_interval=1)
+    monitor.forensics = DummyForensics()
+
+    args = SimpleNamespace()
+    control = SimpleNamespace()
+    state = _make_dummy_state(1)
+
+    monitor.on_log(args, state, control, _make_logs(), response_data=response_batch)
+
+    assert monitor.forensics.update_calls, "Monitor did not invoke forensics update"
+    recorded = monitor.forensics.update_calls[-1]["response_data"]
+    assert isinstance(recorded, list)
+    assert len(recorded or []) == len(response_batch)
+    for record, original in zip(recorded or [], response_batch):
+        assert pytest.approx(float(original["reward"])) == record["reward"]
+        assert pytest.approx(float(original["length"])) == record.get("length")
+        assert record.get("response") == original["response"]
+
+
+def test_comprehensive_monitor_deduplicates_batch_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(trl_monitors, "TRL_AVAILABLE", True)
+
+    monitor = ComprehensivePPOMonitor(enable_length_bias_detection=True, log_interval=1)
+    monitor.forensics = DummyForensics()
+
+    args = SimpleNamespace()
+    control = SimpleNamespace()
+    state = _make_dummy_state(2)
+
+    batch_payload = {
+        "responses": ["short", "long"],
+        "rewards": [0.2, 0.8],
+        "response_lengths": [4, 12],
+    }
+
+    monitor.on_step_end(args, state, control, batch=batch_payload)
+    monitor.on_log(args, state, control, _make_logs(), batch=batch_payload)
+
+    recorded = monitor.forensics.update_calls[-1]["response_data"]
+    assert isinstance(recorded, list)
+    assert len(recorded or []) == 2
+    assert recorded == [
+        {"reward": pytest.approx(0.2), "response": "short", "length": pytest.approx(4.0)},
+        {"reward": pytest.approx(0.8), "response": "long", "length": pytest.approx(12.0)},
+    ]
 
 
 def test_length_bias_preset_fires_alerts() -> None:

--- a/tests/unit/test_comprehensive_length_bias.py
+++ b/tests/unit/test_comprehensive_length_bias.py
@@ -1,0 +1,139 @@
+import math
+from datetime import datetime
+
+import pytest
+
+from src.rldk.forensics.comprehensive_ppo_forensics import ComprehensivePPOForensics
+from src.rldk.monitor.engine import Event, MonitorEngine, load_rules
+from src.rldk.monitor.presets import get_rule_preset
+
+
+@pytest.fixture
+def response_batch() -> list[dict[str, float | str]]:
+    return [
+        {"response": "short", "length": 4, "reward": 0.2},
+        {"response": "medium", "length": 8, "reward": 0.35},
+        {"response": "longer", "length": 12, "reward": 0.55},
+        {"response": "longest", "length": 16, "reward": 0.7},
+        {"response": "mega", "length": 20, "reward": 0.85},
+        {"response": "ultra", "length": 24, "reward": 1.05},
+    ]
+
+
+def test_length_bias_detection_enabled(response_batch: list[dict[str, float | str]]) -> None:
+    forensics = ComprehensivePPOForensics(
+        enable_length_bias_detection=True,
+        length_bias_threshold=0.3,
+    )
+
+    metrics = forensics.update(
+        step=1,
+        kl=0.1,
+        kl_coef=0.2,
+        entropy=2.0,
+        reward_mean=0.5,
+        reward_std=0.2,
+        response_data=response_batch,
+    )
+
+    analysis = forensics.get_length_bias_analysis()
+    assert analysis["detected"] is True
+    assert analysis["metrics"]["valid_sample_count"] == len(response_batch)
+
+    assert metrics.length_bias_detected is True
+    assert metrics.length_bias_score is not None and metrics.length_bias_score > 0.3
+    assert math.isclose(
+        metrics.length_bias_threshold or 0.0,
+        forensics.length_bias_threshold,
+        rel_tol=1e-6,
+    )
+    assert metrics.length_reward_correlation_abs is not None
+    assert metrics.length_reward_spearman_abs is not None
+
+
+def test_length_bias_detection_disabled(response_batch: list[dict[str, float | str]]) -> None:
+    forensics = ComprehensivePPOForensics(enable_length_bias_detection=False)
+
+    metrics = forensics.update(
+        step=5,
+        kl=0.05,
+        kl_coef=0.2,
+        entropy=2.3,
+        reward_mean=0.4,
+        reward_std=0.1,
+        response_data=response_batch,
+    )
+
+    assert forensics.get_length_bias_analysis() == {}
+    assert metrics.length_bias_score is None
+    assert metrics.length_bias_detected is False
+    assert metrics.length_bias_metrics is None
+
+
+def test_length_bias_rule_presets_register() -> None:
+    safe_preset = get_rule_preset("ppo_safe")
+    assert safe_preset is not None
+    ids = {rule["id"] for rule in safe_preset["rules"]}
+    assert "ppo_length_bias_severity" in ids
+    assert "ppo_length_bias_corr" in ids
+    assert "ppo_length_bias_rank_corr" in ids
+
+    strict_preset = get_rule_preset("ppo_strict")
+    assert strict_preset is not None
+    strict_ids = {rule["id"] for rule in strict_preset["rules"]}
+    assert "ppo_strict_length_bias_severity" in strict_ids
+    assert "ppo_strict_length_bias_corr" in strict_ids
+    assert "ppo_strict_length_bias_rank_corr" in strict_ids
+
+    length_bias = get_rule_preset("length_bias")
+    assert length_bias is not None
+    assert {rule["id"] for rule in length_bias["rules"]} == {
+        "length_bias_severity_gate",
+        "length_bias_corr_guard",
+        "length_bias_rank_corr_guard",
+    }
+
+
+def test_length_bias_preset_fires_alerts() -> None:
+    rules = load_rules("length_bias")
+    engine = MonitorEngine(rules)
+
+    meta = {
+        "length_bias_threshold": 0.4,
+        "length_bias_corr_threshold": 0.25,
+    }
+
+    alerts = []
+    for idx in range(1, 8):
+        alerts.extend(
+            engine.process_event(
+                Event(
+                    time=datetime.utcnow().isoformat() + "Z",
+                    step=idx,
+                    name="length_bias_score",
+                    value=0.6,
+                    run_id="run-1",
+                    tags={},
+                    meta=meta,
+                )
+            )
+        )
+
+    assert any(alert.rule_id == "length_bias_severity_gate" for alert in alerts)
+
+    corr_alerts = []
+    for idx in range(20, 27):
+        corr_alerts.extend(
+            engine.process_event(
+                Event(
+                    time=datetime.utcnow().isoformat() + "Z",
+                    step=idx,
+                    name="length_reward_correlation_abs",
+                    value=0.5,
+                    run_id="run-1",
+                    tags={},
+                    meta=meta,
+                )
+            )
+        )
+    assert any(alert.rule_id == "length_bias_corr_guard" for alert in corr_alerts)


### PR DESCRIPTION
## Summary
- add incremental length bias tracking and cached analysis to `ComprehensivePPOForensics`
- emit and monitor length-bias metrics through new preset rules and TRL integration wiring
- document the preset/options and cover the behavior with targeted unit tests

## Testing
- pytest tests/unit/test_comprehensive_length_bias.py

------
https://chatgpt.com/codex/tasks/task_e_68d16b65a8bc832faadb7f4d112be88c