### PR TITLE
Add length bias trust card generation and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ rldk card reward run_a
 ### **Comprehensive Analysis**
 - **Health scoring** - Overall training health, stability, and convergence quality metrics
 - **Statistical evaluation** - Multiple evaluation suites (quick, comprehensive, safety) with confidence intervals
-- **Card generation** - Visual trust cards for determinism, drift, and reward analysis
+- **Card generation** - Visual trust cards for determinism, drift, length bias, and reward analysis
 - **Data ingestion** - Support for TRL, OpenRLHF, WandB, and custom JSONL formats
 - **Seeded replay** - Exact reproduction of training runs with tolerance-based verification
 
@@ -575,7 +575,7 @@ print(health_result.report.length_bias_metrics.bias_severity)
 - ✅ **Evaluation suites** - Multiple test suites (quick, comprehensive, safety) with statistical analysis
 - ✅ **Regression detection** - Git bisect integration for finding problematic commits
 - ✅ **Health analysis** - Overall training health, stability, and convergence quality metrics
-- ✅ **Card generation** - Visual trust cards for determinism, drift, and reward analysis
+- ✅ **Card generation** - Visual trust cards for determinism, drift, length bias, and reward analysis
 
 ### **Data Ingestion & Integration**
 - ✅ **Multi-framework support** - TRL, OpenRLHF, WandB, and custom JSONL adapters
@@ -1009,7 +1009,7 @@ df = wandb_adapter.load()
 - ✅ **Seeded replay** - Exact reproduction of training runs
 - ✅ **Data ingestion** - Support for TRL, OpenRLHF, WandB, and custom formats
 - ✅ **CLI interface** - Comprehensive command-line tools
-- ✅ **Card generation** - Visual trust cards for analysis results
+- ✅ **Card generation** - Visual trust cards for analysis results (determinism, drift, length bias, reward)
 - ✅ **Git bisect integration** - Regression detection and debugging
 
 ### **Integration Support (Available Now)**

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -80,6 +80,8 @@ The evaluation suite provides three core metrics designed to be lightweight, int
 
 **Purpose**: Identify demographic bias and stereotyping in model outputs.
 
+> **Need reward length bias coverage?** See the dedicated [Length Bias Trust Card](guides/length_bias.md) for correlation plots, ODIN metrics, and CLI workflows that complement the demographic checks below.
+
 **Methodology**:
 - Detects demographic mentions across categories (gender, race, age, religion, nationality)
 - Analyzes sentiment differences across demographic groups

--- a/docs/guides/length_bias.md
+++ b/docs/guides/length_bias.md
@@ -1,0 +1,86 @@
+# Length Bias Trust Card
+
+The length bias trust card surfaces how reward models behave when responses get longer or shorter. It combines correlation checks, quartile analysis, and ODIN-inspired efficiency metrics so you can quickly spot length-driven reward hacking.
+
+## Concept Overview
+
+Length bias occurs when the learned reward function systematically favors longer (or shorter) responses regardless of quality. The trust card visualizes three complementary signals:
+
+- **Correlation scatter**: Pearson and Spearman correlation between response length and reward score, annotated with overall severity.
+- **Quartile comparison**: Average reward per length quartile and the share of variance explained by length alone. Large gaps between Q1 and Q4 highlight suspicious optimization patterns.
+- **ODIN heuristics**: Inspired by OpenAI's ODIN work, we report reward-per-token efficiency and flag when long responses dominate the reward budget.
+- **Timeline**: Rolling reward trends coloured by length buckets reveal when bias emerges during training.
+
+These panels complement the raw metrics already emitted by the [`LengthBiasDetector`](../reference/api.md) and the reward health pipeline. For background on other evaluation primitives, see the [evaluation metrics guide](../evaluation.md#3-bias-evaluation).
+
+## Configuration & Threshold Guidance
+
+The command defaults to a severity threshold of `0.35`, matching the built-in reward health presets. Tune it based on:
+
+- **Tighter guardrails (`0.20`–`0.30`)** for high-stakes deployments or reinforcement learning from human feedback (RLHF) systems with short-form prompts.
+- **Looser guardrails (`0.40`–`0.50`)** when prompts intentionally elicit long-form answers (technical reports, essays) and you already audit completion length elsewhere.
+
+Additional configuration tips:
+
+- Provide `--length-col` when metrics already contain token counts (e.g., `response_tokens`). Otherwise supply `--tokenizer-name` so the detector can measure tokens consistently.
+- Use `--sample-size` to downsample large logs deterministically (`--seed`) for reproducible comparisons across runs.
+- Align thresholds with your monitoring presets—[`health_thresholds.md`](../health_thresholds.md) includes reference values for CI gates.
+
+## CLI Usage
+
+```bash
+# Run the detector on a JSONL run and emit a trust card
+rldk reward length-bias \
+  --run-path runs/my-run/events.jsonl \
+  --response-col response_text \
+  --reward-col reward_mean \
+  --length-col response_tokens \
+  --generate-card
+
+# Leverage tokenizer-based length estimation
+rldk reward length-bias \
+  --run-path wandb://entity/project/run \
+  --reward-col score \
+  --tokenizer-name gpt2 \
+  --threshold 0.30 \
+  --sample-size 1000 \
+  --generate-card
+```
+
+When `--generate-card` is set, artifacts are written to:
+
+```
+runs/<run_id>/rldk_cards/length_bias/
+  ├── length_bias_card.json
+  └── length_bias_card.png
+```
+
+If `--output-dir` is also provided, the CLI copies both files into that directory alongside `length_bias_report.json`.
+
+## Monitoring & Presets
+
+The live monitor presets now include dedicated length-bias guards. Pair the card with streaming alerts for continuous coverage:
+
+```bash
+# Enable the length bias preset together with PPO safeguards
+rldk monitor --stream artifacts/run.jsonl \
+  --rules ppo_safe,length_bias \
+  --preset trl
+```
+
+The preset surfaces severity, correlation, and rank-correlation alerts so you can trigger retraining before the severity score crosses your configured gate. See the updated [monitor rules cookbook](../getting-started/monitor_rules_cookbook.md#new-length-bias-preset) for rule IDs and tuning tips.
+
+## Interpreting ODIN Metrics
+
+The ODIN panel tracks reward-per-token efficiency (`reward_per_token`) and normalized efficiency (`efficiency`). A rising optimization flag indicates long responses collect disproportionate reward relative to shorter completions—an early sign of exploitative behavior. Use it in tandem with quartile deltas to decide whether to:
+
+- Tighten KL or entropy schedules.
+- Resample prompts that invite rambling outputs.
+- Introduce explicit penalties for excessive verbosity.
+
+## Next Steps
+
+- Integrate the JSON payload into dashboards or CI gates by reading `runs/<run_id>/rldk_cards/length_bias/length_bias_card.json`.
+- Combine with the reward health report (`rldk reward reward-health run`) to correlate length bias with saturation, drift, and calibration findings.
+- Browse the `examples/length_bias_card_demo.py` script for a programmatic workflow that generates cards from synthetic data.
+

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -313,6 +313,7 @@ summary = analysis.to_dict()
 # Dedicated length bias detector metrics
 print(analysis.report.length_bias_metrics.bias_severity)
 print(analysis.report.length_bias_recommendations)
+# Visual guide: docs/guides/length_bias.md
 ```
 
 #### `HealthAnalysisResult`

--- a/examples/length_bias_card_demo.py
+++ b/examples/length_bias_card_demo.py
@@ -1,0 +1,69 @@
+"""Generate a synthetic length bias trust card for demonstration purposes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from rldk.cards import generate_length_bias_card
+from rldk.evals.metrics.length_bias import evaluate_length_bias
+
+
+def make_synthetic_run(seed: int = 41, samples: int = 200) -> pd.DataFrame:
+    """Create a synthetic run with mild length-reward correlation."""
+
+    rng = np.random.default_rng(seed)
+    base_lengths = rng.normal(loc=80, scale=18, size=samples)
+    base_lengths = np.clip(base_lengths, 20, 140)
+    rewards = 0.004 * base_lengths + rng.normal(0.0, 0.08, size=samples)
+
+    records = []
+    for idx, (length, reward) in enumerate(zip(base_lengths, rewards), start=1):
+        tokens = int(round(length))
+        response = f"Synthetic response {idx}: " + ("x" * max(tokens // 4, 1))
+        records.append(
+            {
+                "step": idx,
+                "run_id": "length_bias_demo",
+                "response": response,
+                "reward_mean": float(reward),
+                "response_tokens": tokens,
+            }
+        )
+
+    return pd.DataFrame.from_records(records)
+
+
+def main() -> None:
+    """Evaluate synthetic data and generate a demo length bias card."""
+
+    df = make_synthetic_run()
+    result = evaluate_length_bias(
+        df,
+        response_col="response",
+        reward_col="reward_mean",
+        length_col="response_tokens",
+        threshold=0.3,
+    )
+
+    output_dir = Path("artifacts/length_bias_demo")
+    card_data, card_dir = generate_length_bias_card(
+        result,
+        responses=df["response"].tolist(),
+        rewards=df["reward_mean"].tolist(),
+        lengths=df["response_tokens"].astype(float).tolist(),
+        run_id="length_bias_demo",
+        source="synthetic_length_bias",
+        output_dir=str(output_dir),
+    )
+
+    print("Length bias card written to:", card_dir)
+    print("Summary score:", card_data.get("score"))
+    print("Severity:", card_data.get("severity"))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,6 +137,8 @@ nav:
     - Core API: reference/api.md
   - CLI Reference:
     - Commands: reference/commands.md
+  - Guides:
+    - Length Bias Trust Card: guides/length_bias.md
 
 # Extra
 extra:

--- a/src/rldk/cards/__init__.py
+++ b/src/rldk/cards/__init__.py
@@ -2,11 +2,12 @@
 
 from .determinism import generate_determinism_card
 from .drift import generate_drift_card, generate_kl_drift_card
-from .reward import generate_reward_card
+from .reward import generate_length_bias_card, generate_reward_card
 
 __all__ = [
     "generate_determinism_card",
     "generate_drift_card",
     "generate_reward_card",
     "generate_kl_drift_card",
+    "generate_length_bias_card",
 ]

--- a/src/rldk/cards/reward.py
+++ b/src/rldk/cards/reward.py
@@ -4,11 +4,12 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+import seaborn as sns
 
 from ..io.event_schema import Event
 
@@ -683,3 +684,423 @@ def _generate_reward_visualization(
     plt.tight_layout()
     plt.savefig(output_path, dpi=150, bbox_inches="tight")
     plt.close()
+
+
+def _sanitize_length_bias_series(
+    responses: Sequence[Any],
+    rewards: Sequence[Any],
+    lengths: Optional[Sequence[Optional[Any]]],
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Return aligned numpy arrays for response lengths and rewards."""
+
+    if len(responses) != len(rewards):
+        raise ValueError(
+            "Responses and rewards must be the same length for card visualizations"
+        )
+
+    reward_values: List[float] = []
+    for value in rewards:
+        if value is None:
+            reward_values.append(np.nan)
+            continue
+        try:
+            reward_values.append(float(value))
+        except (TypeError, ValueError):
+            reward_values.append(np.nan)
+
+    if lengths is None:
+        length_values = [float(len(str(resp))) if resp is not None else np.nan for resp in responses]
+    else:
+        if len(lengths) != len(responses):
+            raise ValueError(
+                "Length sequence must match the number of responses for card visualizations"
+            )
+        length_values = []
+        for value in lengths:
+            if value is None:
+                length_values.append(np.nan)
+                continue
+            try:
+                length_values.append(float(value))
+            except (TypeError, ValueError):
+                length_values.append(np.nan)
+
+    return np.asarray(length_values, dtype=float), np.asarray(reward_values, dtype=float)
+
+
+def plot_length_reward_correlation(
+    ax: "plt.Axes",
+    length_array: np.ndarray,
+    reward_array: np.ndarray,
+    metrics: Dict[str, Any],
+) -> None:
+    """Scatter plot highlighting correlation between response length and reward."""
+
+    sns.set_theme(style="whitegrid", context="notebook")
+
+    valid_mask = (~np.isnan(length_array)) & (~np.isnan(reward_array))
+
+    if valid_mask.sum() < 3:
+        ax.text(
+            0.5,
+            0.5,
+            "Insufficient data\nfor correlation plot",
+            ha="center",
+            va="center",
+            fontsize=11,
+        )
+        ax.set_axis_off()
+        return
+
+    data = pd.DataFrame(
+        {
+            "Length": length_array[valid_mask],
+            "Reward": reward_array[valid_mask],
+        }
+    )
+
+    sns.regplot(
+        data=data,
+        x="Length",
+        y="Reward",
+        ax=ax,
+        scatter_kws={"alpha": 0.45, "s": 32},
+        line_kws={"color": "#1f77b4", "linewidth": 1.5},
+    )
+    ax.set_title("Length vs Reward", fontsize=12, fontweight="bold")
+    ax.set_xlabel("Response length (tokens or characters)")
+    ax.set_ylabel("Reward score")
+
+    annotations: List[str] = []
+    pearson = metrics.get("pearson_correlation")
+    if pearson is not None:
+        annotations.append(f"Pearson: {pearson:.2f}")
+    spearman = metrics.get("spearman_correlation")
+    if spearman is not None:
+        annotations.append(f"Spearman: {spearman:.2f}")
+    severity = metrics.get("bias_severity")
+    if severity is not None:
+        annotations.append(f"Severity: {severity:.2f}")
+
+    if annotations:
+        ax.text(
+            0.02,
+            0.98,
+            "\n".join(annotations),
+            ha="left",
+            va="top",
+            transform=ax.transAxes,
+            fontsize=9,
+            bbox={"facecolor": "white", "alpha": 0.8, "boxstyle": "round,pad=0.3"},
+        )
+
+
+def plot_length_quartile_analysis(
+    ax: "plt.Axes", metrics: Dict[str, Any]
+) -> None:
+    """Visualize reward differences across response length quartiles."""
+
+    sns.set_theme(style="whitegrid", context="notebook")
+
+    quartiles = metrics.get("quartile_metrics") or {}
+    if not quartiles:
+        ax.text(
+            0.5,
+            0.5,
+            "Quartile statistics\nnot available",
+            ha="center",
+            va="center",
+            fontsize=11,
+        )
+        ax.set_axis_off()
+        return
+
+    quartile_df = pd.DataFrame.from_dict(quartiles, orient="index")
+    if "mean_reward" not in quartile_df.columns:
+        ax.text(
+            0.5,
+            0.5,
+            "Quartile reward means\nmissing",
+            ha="center",
+            va="center",
+            fontsize=11,
+        )
+        ax.set_axis_off()
+        return
+
+    quartile_df = quartile_df.reset_index().rename(columns={"index": "quartile"})
+    quartile_df["quartile"] = quartile_df["quartile"].str.upper()
+    quartile_df = quartile_df.dropna(subset=["mean_reward"])
+
+    if quartile_df.empty:
+        ax.text(
+            0.5,
+            0.5,
+            "Quartile reward means\nmissing",
+            ha="center",
+            va="center",
+            fontsize=11,
+        )
+        ax.set_axis_off()
+        return
+
+    sns.barplot(
+        data=quartile_df,
+        x="quartile",
+        y="mean_reward",
+        ax=ax,
+        palette="viridis",
+    )
+    ax.set_title("Reward by Length Quartile", fontsize=12, fontweight="bold")
+    ax.set_xlabel("Length quartile")
+    ax.set_ylabel("Mean reward")
+
+    variance = metrics.get("variance_explained")
+    if variance is not None:
+        ax.text(
+            0.98,
+            0.02,
+            f"Variance explained: {variance:.2%}",
+            ha="right",
+            va="bottom",
+            transform=ax.transAxes,
+            fontsize=9,
+        )
+
+
+def plot_odin_metrics(ax: "plt.Axes", metrics: Dict[str, Any]) -> None:
+    """Plot ODIN-inspired efficiency heuristics."""
+
+    sns.set_theme(style="whitegrid", context="notebook")
+
+    odin_reward = metrics.get("odin_reward_per_token")
+    odin_efficiency = metrics.get("odin_efficiency")
+    values = {
+        "Reward/token": odin_reward,
+        "Efficiency": odin_efficiency,
+    }
+    filtered = {k: v for k, v in values.items() if v is not None}
+
+    if not filtered:
+        ax.text(
+            0.5,
+            0.5,
+            "ODIN metrics\nnot available",
+            ha="center",
+            va="center",
+            fontsize=11,
+        )
+        ax.set_axis_off()
+        return
+
+    ax.barh(list(filtered.keys()), list(filtered.values()), color="#6baed6")
+    ax.set_title("ODIN Efficiency", fontsize=12, fontweight="bold")
+    ax.set_xlabel("Value")
+
+    flag = bool(metrics.get("odin_optimization_flag", False))
+    ax.text(
+        0.02,
+        0.02,
+        f"Optimization flag: {'Yes' if flag else 'No'}",
+        ha="left",
+        va="bottom",
+        transform=ax.transAxes,
+        fontsize=9,
+        bbox={"facecolor": "white", "alpha": 0.8, "boxstyle": "round,pad=0.3"},
+    )
+
+
+def plot_length_bias_timeline(
+    ax: "plt.Axes",
+    length_array: np.ndarray,
+    reward_array: np.ndarray,
+    severity: Optional[float] = None,
+) -> None:
+    """Plot reward timeline with length context to highlight bias drift."""
+
+    sns.set_theme(style="whitegrid", context="notebook")
+
+    valid_mask = (~np.isnan(length_array)) & (~np.isnan(reward_array))
+
+    if valid_mask.sum() == 0:
+        ax.text(
+            0.5,
+            0.5,
+            "No reward timeline\navailable",
+            ha="center",
+            va="center",
+            fontsize=11,
+        )
+        ax.set_axis_off()
+        return
+
+    df = pd.DataFrame(
+        {
+            "Index": np.arange(valid_mask.sum()),
+            "Reward": reward_array[valid_mask],
+            "Length": length_array[valid_mask],
+        }
+    )
+
+    if df["Length"].nunique() > 4:
+        try:
+            df["LengthBin"] = pd.qcut(
+                df["Length"], q=4, labels=["Q1", "Q2", "Q3", "Q4"], duplicates="drop"
+            )
+            hue = "LengthBin"
+        except ValueError:
+            hue = None
+    else:
+        hue = None
+
+    if hue:
+        sns.scatterplot(data=df, x="Index", y="Reward", hue=hue, palette="viridis", ax=ax, s=32)
+    else:
+        sns.scatterplot(data=df, x="Index", y="Reward", hue="Length", palette="viridis", ax=ax, s=32, legend=False)
+
+    window = max(5, int(len(df) * 0.1))
+    if len(df) >= window:
+        rolling = df["Reward"].rolling(window=window, min_periods=max(3, window // 2)).mean()
+        ax.plot(df["Index"], rolling, color="#ff7f0e", linewidth=1.5, label=f"Rolling mean ({window})")
+        ax.legend(loc="upper left", fontsize=8)
+
+    ax.set_title("Reward timeline", fontsize=12, fontweight="bold")
+    ax.set_xlabel("Sample index")
+    ax.set_ylabel("Reward score")
+
+    if severity is not None:
+        ax.text(
+            0.98,
+            0.02,
+            f"Severity: {severity:.2f}",
+            ha="right",
+            va="bottom",
+            transform=ax.transAxes,
+            fontsize=9,
+        )
+
+
+def _normalize_run_identifier(run_id: Optional[str]) -> str:
+    if not run_id:
+        return "unknown"
+    sanitized = "".join(
+        ch if ch.isalnum() or ch in {"-", "_", "."} else "_" for ch in str(run_id)
+    ).strip("_")
+    return sanitized or "unknown"
+
+
+def _json_ready(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        return {k: _json_ready(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_json_ready(item) for item in obj]
+    if hasattr(obj, "item"):
+        try:
+            return obj.item()
+        except Exception:  # pragma: no cover - defensive
+            return str(obj)
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    return obj
+
+
+def _generate_length_bias_visualization(
+    card_data: Dict[str, Any],
+    output_path: Path,
+    responses: Sequence[Any],
+    rewards: Sequence[Any],
+    lengths: Optional[Sequence[Optional[Any]]],
+) -> None:
+    """Render the length bias trust card visualization."""
+
+    fig, axes = plt.subplots(2, 2, figsize=(12, 10))
+    fig.suptitle(
+        f"Length Bias Card - {card_data['run_id']}", fontsize=16, fontweight="bold"
+    )
+
+    metrics = card_data.get("metrics", {})
+    severity = card_data.get("severity")
+
+    length_array, reward_array = _sanitize_length_bias_series(responses, rewards, lengths)
+
+    plot_length_reward_correlation(axes[0, 0], length_array, reward_array, metrics)
+    plot_length_quartile_analysis(axes[0, 1], metrics)
+    plot_odin_metrics(axes[1, 0], metrics)
+    plot_length_bias_timeline(axes[1, 1], length_array, reward_array, severity)
+
+    plt.tight_layout(rect=[0, 0, 1, 0.96])
+    plt.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+def generate_length_bias_card(
+    result: Dict[str, Any],
+    *,
+    responses: Sequence[Any],
+    rewards: Sequence[Any],
+    lengths: Optional[Sequence[Optional[Any]]] = None,
+    run_id: Optional[str] = None,
+    source: Optional[str] = None,
+    output_dir: Optional[str] = None,
+) -> Tuple[Dict[str, Any], Path]:
+    """Generate a dedicated trust card summarizing reward length bias analysis."""
+
+    normalized_run_id = _normalize_run_identifier(run_id)
+    base_output = (
+        Path(output_dir)
+        if output_dir is not None
+        else Path(f"runs/{normalized_run_id}/rldk_cards/length_bias")
+    )
+    base_output.mkdir(parents=True, exist_ok=True)
+
+    resolved_lengths, resolved_rewards = _sanitize_length_bias_series(
+        responses, rewards, lengths
+    )
+
+    metrics = result.get("metrics", {})
+    metrics_safe = _json_ready(metrics)
+    severity = result.get("severity")
+    score = result.get("score")
+    threshold = result.get("threshold")
+
+    card_data: Dict[str, Any] = {
+        "version": "1.0",
+        "generated_at": datetime.utcnow().isoformat(),
+        "run_id": normalized_run_id,
+        "source": source,
+        "passed": bool(result.get("passed", False)),
+        "score": float(score) if score is not None else None,
+        "severity": float(severity) if severity is not None else None,
+        "threshold": float(threshold) if threshold is not None else None,
+        "response_count": int(result.get("response_count", len(responses))),
+        "valid_samples": int(result.get("num_samples", np.count_nonzero(~np.isnan(resolved_rewards)))),
+        "recommendations": result.get("recommendations", []),
+        "details": {
+            "optimization_patterns": metrics_safe.get("optimization_patterns", []),
+            "bias_severity": metrics_safe.get("bias_severity"),
+            "pearson_correlation": metrics_safe.get("pearson_correlation"),
+            "spearman_correlation": metrics_safe.get("spearman_correlation"),
+            "odin_efficiency": metrics_safe.get("odin_efficiency"),
+        },
+        "metrics": metrics_safe,
+    }
+
+    json_path = base_output / "length_bias_card.json"
+    with open(json_path, "w", encoding="utf-8") as fp:
+        json.dump(card_data, fp, indent=2, default=_json_ready)
+
+    png_path = base_output / "length_bias_card.png"
+    _generate_length_bias_visualization(
+        card_data,
+        png_path,
+        responses,
+        rewards,
+        lengths,
+    )
+
+    card_data["artifacts"] = {
+        "json": str(json_path),
+        "png": str(png_path),
+    }
+
+    return card_data, base_output

--- a/src/rldk/cli.py
+++ b/src/rldk/cli.py
@@ -3,6 +3,8 @@
 import json
 import logging
 import os
+import re
+import shutil
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -19,6 +21,7 @@ from rldk.bisect import bisect_commits
 from rldk.cards import (
     generate_determinism_card,
     generate_drift_card,
+    generate_length_bias_card,
     generate_kl_drift_card,
     generate_reward_card,
 )
@@ -31,6 +34,7 @@ from rldk.evals.metrics import (
     evaluate_length_bias,
     evaluate_throughput,
     evaluate_toxicity,
+    prepare_length_bias_inputs,
 )
 
 # Import evaluation modules
@@ -1479,6 +1483,73 @@ def reward_drift(
         raise typer.Exit(1)
 
 
+def _infer_length_bias_run_id(data: pd.DataFrame, source: Optional[str]) -> str:
+    """Infer a stable run identifier for card artifact locations."""
+
+    candidate_columns = (
+        "run_id",
+        "run",
+        "runid",
+        "run_name",
+        "experiment_id",
+        "name",
+        "model_id",
+    )
+    for column in candidate_columns:
+        if column in data.columns:
+            series = data[column].dropna()
+            if not series.empty:
+                value = str(series.iloc[0])
+                break
+    else:
+        candidate = str(source).rstrip("/") if source else ""
+        if candidate:
+            segments = re.split(r"[/\\]", candidate)
+            value = next((seg for seg in reversed(segments) if seg), candidate)
+        else:
+            value = "unknown"
+
+    sanitized = re.sub(r"[^A-Za-z0-9._-]", "_", value).strip("_")
+    return sanitized or "unknown"
+
+
+def _resolve_card_lengths(
+    responses: Sequence[Any],
+    lengths: Optional[Sequence[Optional[float]]],
+    tokenizer: Optional[Any],
+) -> List[Optional[float]]:
+    """Resolve explicit length values for card visualization purposes."""
+
+    if lengths is not None:
+        return [float(val) if val is not None else None for val in lengths]
+
+    resolved: List[Optional[float]] = []
+    for response in responses:
+        if response is None:
+            resolved.append(None)
+            continue
+
+        if tokenizer is not None:
+            try:
+                if hasattr(tokenizer, "encode"):
+                    tokens = tokenizer.encode(str(response))
+                else:
+                    tokens = tokenizer(str(response))
+                    if isinstance(tokens, dict) and "input_ids" in tokens:
+                        tokens = tokens["input_ids"]
+                    elif hasattr(tokens, "input_ids"):
+                        tokens = tokens.input_ids
+                if isinstance(tokens, (list, tuple, np.ndarray)):
+                    resolved.append(float(len(tokens)))
+                    continue
+            except Exception:  # pragma: no cover - best-effort tokenization
+                pass
+
+        resolved.append(float(len(str(response))))
+
+    return resolved
+
+
 @reward_app.command(name="length-bias")
 def reward_length_bias(
     run_path: str = typer.Option(
@@ -1549,14 +1620,31 @@ def reward_length_bias(
         typer.echo(str(exc), err=True)
         raise typer.Exit(1)
 
+    working_data = run_data
+    if sample_size is not None and sample_size < len(working_data):
+        working_data = working_data.sample(n=sample_size, random_state=seed).reset_index(
+            drop=True
+        )
+
+    try:
+        responses, reward_values, explicit_lengths = prepare_length_bias_inputs(
+            working_data,
+            response_col=response_col,
+            reward_col=reward_col,
+            length_col=length_col,
+        )
+    except Exception as exc:
+        typer.echo(f"Unable to prepare length bias inputs: {exc}", err=True)
+        raise typer.Exit(1)
+
     try:
         result = evaluate_length_bias(
-            run_data,
+            working_data,
             response_col=response_col,
             reward_col=reward_col,
             length_col=length_col,
             threshold=threshold,
-            sample_size=sample_size,
+            sample_size=None,
             seed=seed,
             tokenizer=tokenizer,
         )
@@ -1586,7 +1674,32 @@ def reward_length_bias(
     typer.echo(json_summary)
 
     report_path: Optional[Path] = None
-    card_path: Optional[Path] = None
+    card_data: Optional[Dict[str, Any]] = None
+    card_output_dir: Optional[Path] = None
+
+    if generate_card:
+        card_run_id = _infer_length_bias_run_id(working_data, run_path)
+        card_lengths = _resolve_card_lengths(responses, explicit_lengths, tokenizer)
+        try:
+            card_data, card_output_dir = generate_length_bias_card(
+                result,
+                responses=responses,
+                rewards=reward_values,
+                lengths=card_lengths,
+                run_id=card_run_id,
+                source=run_path,
+            )
+            typer.echo(
+                f"\nCard saved to: {card_output_dir / 'length_bias_card.json'}"
+            )
+            typer.echo(
+                f"Card image saved to: {card_output_dir / 'length_bias_card.png'}"
+            )
+        except Exception as exc:
+            typer.echo(f"Failed to generate trust card: {exc}", err=True)
+            card_data = None
+            card_output_dir = None
+
     if output_dir:
         output_path = Path(output_dir)
         output_path.mkdir(parents=True, exist_ok=True)
@@ -1594,36 +1707,20 @@ def reward_length_bias(
         write_json(result, report_path)
         typer.echo(f"\nReport saved to: {report_path}")
 
-        if generate_card:
-            card = {
-                "version": "1.0",
-                "generated_at": datetime.utcnow().isoformat(),
-                "source": run_path,
-                "passed": result.get("passed"),
-                "score": result.get("score"),
-                "severity": severity,
-                "threshold": result.get("threshold"),
-                "recommendations": recommendations,
-                "metrics": result.get("metrics"),
-            }
-            card_path = output_path / "length_bias_card.json"
-            write_json(card, card_path)
-            typer.echo(f"Card saved to: {card_path}")
-    elif generate_card:
-        card = {
-            "version": "1.0",
-            "generated_at": datetime.utcnow().isoformat(),
-            "source": run_path,
-            "passed": result.get("passed"),
-            "score": result.get("score"),
-            "severity": severity,
-            "threshold": result.get("threshold"),
-            "recommendations": recommendations,
-            "metrics": result.get("metrics"),
-        }
-        card_path = Path("length_bias_card.json")
-        write_json(card, card_path)
-        typer.echo(f"\nCard saved to: {card_path}")
+        if card_data and card_output_dir:
+            target_card_json = output_path / "length_bias_card.json"
+            target_card_png = output_path / "length_bias_card.png"
+            write_json(card_data, target_card_json)
+            typer.echo(f"Card copied to: {target_card_json}")
+
+            png_source = (
+                Path(card_data["artifacts"]["png"])
+                if isinstance(card_data.get("artifacts"), dict)
+                else None
+            )
+            if png_source and png_source.exists():
+                shutil.copy2(png_source, target_card_png)
+                typer.echo(f"Card image copied to: {target_card_png}")
 
 # Create a sub-app for reward-health commands
 reward_health_app = typer.Typer(name="reward-health", help="Reward health analysis commands")

--- a/tests/cli/test_reward_length_bias_cli.py
+++ b/tests/cli/test_reward_length_bias_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 
 import pandas as pd
@@ -21,6 +22,7 @@ def test_reward_length_bias_cli(tmp_path: Path, runner: CliRunner) -> None:
     data = pd.DataFrame(
         {
             "step": range(1, 21),
+            "run_id": ["cli-length" for _ in range(1, 21)],
             "reward_mean": [0.2 * idx for idx in range(1, 21)],
             "tokens_out": [idx * 5 for idx in range(1, 21)],
             "response_text": ["x" * (idx * 5) for idx in range(1, 21)],
@@ -70,3 +72,55 @@ def test_reward_length_bias_cli(tmp_path: Path, runner: CliRunner) -> None:
     assert report_path.exists()
     saved = json.loads(report_path.read_text())
     assert saved["metrics"]["bias_severity"] == parsed["metrics"]["bias_severity"]
+
+
+def test_reward_length_bias_cli_generates_card(tmp_path: Path, runner: CliRunner) -> None:
+    data = pd.DataFrame(
+        {
+            "step": range(1, 16),
+            "run_id": ["cli-card"] * 15,
+            "reward_mean": [0.1 * idx for idx in range(1, 16)],
+            "tokens_out": [idx * 4 for idx in range(1, 16)],
+            "response_text": ["y" * (idx * 4) for idx in range(1, 16)],
+        }
+    )
+    run_path = tmp_path / "metrics.jsonl"
+    with run_path.open("w", encoding="utf-8") as fp:
+        for record in data.to_dict(orient="records"):
+            fp.write(json.dumps(record) + "\n")
+
+    output_dir = tmp_path / "reports"
+
+    result = runner.invoke(
+        app,
+        [
+            "reward",
+            "length-bias",
+            "--run-path",
+            str(run_path),
+            "--response-col",
+            "response_text",
+            "--reward-col",
+            "reward_mean",
+            "--length-col",
+            "tokens_out",
+            "--generate-card",
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+
+    card_dir = Path("runs/cli-card/rldk_cards/length_bias")
+    try:
+        assert (card_dir / "length_bias_card.json").exists()
+        assert (card_dir / "length_bias_card.png").exists()
+
+        copied_json = output_dir / "length_bias_card.json"
+        copied_png = output_dir / "length_bias_card.png"
+        assert copied_json.exists()
+        assert copied_png.exists()
+    finally:
+        if card_dir.exists():
+            shutil.rmtree(card_dir.parent.parent, ignore_errors=True)


### PR DESCRIPTION
## Summary
- extend the reward card module with length bias plotting helpers and a `generate_length_bias_card` API that renders JSON and PNG artifacts
- update the CLI length-bias command to reuse the new generator, infer run identifiers, and copy artifacts alongside reports
- document the workflow with a dedicated length bias guide, README updates, mkdocs nav entry, and an executable example script

## Testing
- `pytest tests/cli/test_reward_length_bias_cli.py`
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68d17a8cbdfc832f997c66740d8de516