### PR TITLE
Add reward overoptimization detector and reporting

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -150,6 +150,36 @@ python -m rldk.evals.cli list-suites
 python -m rldk.evals.cli validate data.jsonl
 ```
 
+## Reward Model Overoptimization Detector
+
+The reward health toolkit now tracks **reward model overoptimization** by comparing proxy reward improvements to trusted "gold" metrics such as human evaluation scores or benchmark accuracy.
+
+### Providing Gold Metrics
+
+- **CLI**: supply a gold metrics table with `--gold` (or embed the column directly in the run data) and specify the column via `--gold-col`. Gold metrics should align on the training step column.
+- **API**: pass a pandas DataFrame or Series to `reward_health(..., gold_metrics=..., gold_metric_col="gold_metric")`. The helper auto-aligns by step and handles early/late window splits.
+
+### How Detection Works
+
+1. Compute early vs. late window means (default first/last 100 steps) for proxy reward and gold metrics.
+2. Calculate the delta (`proxy - gold`). If the delta exceeds the configurable threshold (default `0.2`) while gold metrics stagnate or regress, the detector activates.
+3. Track Pearson/Spearman correlation drift between proxy and gold metrics.
+4. Pull recent KL statistics from PPO forensics; sustained high KL combined with proxy/gold divergence is treated as a red flag.
+
+### Interpreting the Report
+
+- **Summary Card**: shows proxy/gold delta, correlation trend, KL snapshot, and whether overoptimization was flagged.
+- **JSON Summary**: `overoptimization` contains metrics, thresholds, and remediation notes.
+- **Warnings**: If no gold metrics are provided, the report records a warning instead of failing.
+
+### Tuning Thresholds
+
+- `--overopt-window`: change the size of the early/late comparison window.
+- `--overopt-delta-threshold`: tighten or relax the delta needed to warn.
+- `--overopt-min-samples`: require a minimum number of overlapping proxy/gold samples before analysis runs.
+
+Remediation tips include pausing reward optimization, revisiting KL controllers, and refreshing gold metric evaluations to realign the reward model.
+
 ### Programmatic Usage
 
 ```python

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -328,6 +328,11 @@ The object returned by `reward_health` combines the underlying
   - `length_bias_detected`: Boolean flag indicating severity crossed the configured threshold
   - `length_bias_metrics`: Structured metrics (correlations, ODIN heuristics, quartiles)
   - `length_bias_recommendations`: Human-readable remediation tips from the detector
+- Overoptimization fields:
+  - `overoptimization.flagged`: True when proxy reward rises while gold metrics stagnate and KL is elevated
+  - `overoptimization.delta`: Difference between proxy and gold improvements across early/late windows
+  - `overoptimization.correlation_trend`: Pearson/Spearman deltas to monitor alignment drift
+  - `overoptimization.kl_summary`: Recent KL statistics pulled from PPO forensics hooks
 
 ### Evaluation Suites
 
@@ -583,6 +588,30 @@ class RewardHealthReport:
     length_bias_detected: bool
     length_bias_metrics: LengthBiasMetrics
     length_bias_recommendations: List[str]
+    overoptimization: OveroptimizationAnalysis
+```
+
+#### `OveroptimizationAnalysis`
+```python
+@dataclass
+class OveroptimizationAnalysis:
+    proxy_improvement: float
+    gold_improvement: float
+    delta: float
+    correlation_trend: Dict[str, Optional[float]]
+    kl_summary: Dict[str, Any]
+    flagged: bool
+    gold_metrics_available: bool
+    gold_regressed: bool
+    gold_stagnant: bool
+    kl_elevated: bool
+    correlation_declined: bool
+    warning: Optional[str]
+    notes: List[str]
+    window_size: int
+    delta_threshold: float
+    min_samples: int
+    sample_size: int
 ```
 
 #### `DivergenceReport`

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -190,6 +190,11 @@ rldk reward-health --run RUN_SOURCE [OPTIONS]
 - `--threshold-calibration`: Threshold for calibration quality (default: `0.7`)
 - `--threshold-shortcut`: Threshold for shortcut signal detection (default: `0.6`)
 - `--threshold-leakage`: Threshold for label leakage risk (default: `0.3`)
+- `--gold`: Optional path to trusted gold metrics for overoptimization checks
+- `--gold-col`: Column name containing trusted gold scores (in `--run` or `--gold` dataset)
+- `--overopt-window`: Window size for early/late proxy vs gold comparison (default: `100`)
+- `--overopt-delta-threshold`: Minimum proxy-minus-gold delta to raise an alert (default: `0.2`)
+- `--overopt-min-samples`: Minimum paired samples required for overoptimization detector (default: `100`)
 - `--gate`: Enable CI gate mode with exit codes (0=pass, 1=warn, 2=fail)
 
 **Examples:**

--- a/src/rldk/__init__.py
+++ b/src/rldk/__init__.py
@@ -21,6 +21,7 @@ def _lazy_import_bisect():
 def _lazy_import_reward():
     from .reward import (
         HealthAnalysisResult,
+        OveroptimizationAnalysis,
         RewardHealthReport,
         LengthBiasDetector,
         LengthBiasMetrics,
@@ -37,6 +38,7 @@ def _lazy_import_reward():
         HealthAnalysisResult,
         LengthBiasDetector,
         LengthBiasMetrics,
+        OveroptimizationAnalysis,
     )
 
 def _lazy_import_evals():
@@ -143,12 +145,12 @@ def health(*args, **kwargs):
     return health_func(*args, **kwargs)
 
 def compare_models(*args, **kwargs):
-    _, _, compare_models_func, _, _, _, _ = _lazy_import_reward()
+    _, _, compare_models_func, *_ = _lazy_import_reward()
     return compare_models_func(*args, **kwargs)
 
 
 def reward_health(*args, **kwargs):
-    _, _, _, reward_health_func, _, _, _ = _lazy_import_reward()
+    _, _, _, reward_health_func, *_ = _lazy_import_reward()
     return reward_health_func(*args, **kwargs)
 
 def run(*args, **kwargs):
@@ -300,6 +302,7 @@ RewardHealthReport = _create_lazy_class('RewardHealthReport', _lazy_import_rewar
 HealthAnalysisResult = _create_lazy_class('HealthAnalysisResult', _lazy_import_reward, 4)
 LengthBiasDetector = _create_lazy_class('LengthBiasDetector', _lazy_import_reward, 5)
 LengthBiasMetrics = _create_lazy_class('LengthBiasMetrics', _lazy_import_reward, 6)
+OveroptimizationAnalysis = _create_lazy_class('OveroptimizationAnalysis', _lazy_import_reward, 7)
 EvalResult = _create_lazy_class('EvalResult', _lazy_import_evals, 1)
 ReplayReport = _create_lazy_class('ReplayReport', _lazy_import_replay, 1)
 ComprehensivePPOForensics = _create_lazy_class('ComprehensivePPOForensics', _lazy_import_forensics, 3)
@@ -335,6 +338,7 @@ __all__ = [
     "health",
     "reward_health",
     "RewardHealthReport",
+    "OveroptimizationAnalysis",
     "HealthAnalysisResult",
     "LengthBiasDetector",
     "LengthBiasMetrics",

--- a/src/rldk/cli.py
+++ b/src/rldk/cli.py
@@ -1637,6 +1637,11 @@ def reward_health_run(
     out: str = typer.Option(..., "--out", help="Output directory for reports"),
     adapter: Optional[str] = typer.Option(None, "--adapter", help="Adapter type for data ingestion (custom_jsonl, trl, openrlhf, wandb)"),
     gate: bool = typer.Option(False, "--gate", help="Enable CI gate mode with exit codes (0=pass, 1=warn, 2=fail). Use 'gate' subcommand for health.json-based gating."),
+    gold_scores: Optional[str] = typer.Option(None, "--gold-scores", help="Optional path to trusted gold metrics for overoptimization detection"),
+    gold_metric_col: Optional[str] = typer.Option(None, "--gold-metric-col", help="Column name containing gold metrics (in scores or gold dataset)"),
+    overopt_window: int = typer.Option(100, "--overopt-window", help="Window size (steps) for early/late delta comparison"),
+    overopt_delta_threshold: float = typer.Option(0.2, "--overopt-delta-threshold", help="Minimum proxy-minus-gold delta to trigger overoptimization warning"),
+    overopt_min_samples: int = typer.Option(100, "--overopt-min-samples", help="Minimum paired samples required for overoptimization detector"),
 ):
     """Run reward health analysis on scores data."""
     try:
@@ -1645,6 +1650,11 @@ def reward_health_run(
         # Ingest scores data
         typer.echo("Ingesting scores data...")
         scores_data = ingest_runs(scores, adapter_hint=adapter)
+
+        gold_data: Optional[pd.DataFrame] = None
+        if gold_scores:
+            typer.echo(f"Ingesting gold metrics from: {gold_scores}")
+            gold_data = ingest_runs(gold_scores, adapter_hint=adapter)
 
         # Load configuration (default or user-provided)
         if config:
@@ -1673,6 +1683,11 @@ def reward_health_run(
             threshold_calibration=threshold_calibration,
             threshold_shortcut=threshold_shortcut,
             threshold_leakage=threshold_leakage,
+            gold_metrics=gold_data,
+            gold_metric_col=gold_metric_col,
+            overoptimization_window=overopt_window,
+            overoptimization_delta_threshold=overopt_delta_threshold,
+            overoptimization_min_samples=overopt_min_samples,
         )
 
         # Generate reports
@@ -1681,10 +1696,15 @@ def reward_health_run(
 
         # Display results
         severity = health_report.length_bias_metrics.bias_severity
+        overopt = getattr(health_report, "overoptimization", None)
         if health_report.passed:
             typer.echo("\n✅ Reward health check passed")
             if severity is not None:
                 typer.echo(f"  Length bias severity: {severity:.3f}")
+            if overopt and getattr(overopt, "gold_metrics_available", False):
+                typer.echo(
+                    f"  Overoptimization delta: {getattr(overopt, 'delta', 0.0):.3f}"
+                )
             exit_code = 0
         else:
             typer.echo("\n🚨 Reward health issues detected")
@@ -1699,12 +1719,24 @@ def reward_health_run(
                 typer.echo(f"  - {len(health_report.shortcut_signals)} shortcut signals")
             if health_report.label_leakage_risk > threshold_leakage:
                 typer.echo(f"  - Label leakage risk: {health_report.label_leakage_risk:.3f}")
+            if overopt and getattr(overopt, "flagged", False):
+                typer.echo(
+                    f"  - Reward overoptimization suspected (delta {getattr(overopt, 'delta', 0.0):.3f})"
+                )
+            elif overopt and overopt.gold_metrics_available:
+                typer.echo(
+                    f"  - Overoptimization delta {getattr(overopt, 'delta', 0.0):.3f} (below threshold)"
+                )
+            elif overopt and overopt.warning:
+                typer.echo(f"  - Overoptimization check: {overopt.warning}")
 
             # Determine exit code based on severity
             critical_issues = 0
             if health_report.drift_detected:
                 critical_issues += 1
             if health_report.label_leakage_risk > threshold_leakage:
+                critical_issues += 1
+            if overopt and getattr(overopt, "flagged", False):
                 critical_issues += 1
 
             if critical_issues > 0:
@@ -2869,6 +2901,31 @@ def reward_health(
         "--enable-length-bias-detection/--disable-length-bias-detection",
         help="Toggle dedicated length bias detection",
     ),
+    gold_path: Optional[str] = typer.Option(
+        None,
+        "--gold",
+        help="Optional path to trusted gold metrics for overoptimization analysis",
+    ),
+    gold_metric_col: Optional[str] = typer.Option(
+        None,
+        "--gold-col",
+        help="Column containing gold metrics (in run or gold dataset)",
+    ),
+    overopt_window: int = typer.Option(
+        100,
+        "--overopt-window",
+        help="Window size (steps) used for early/late proxy vs gold comparison",
+    ),
+    overopt_delta_threshold: float = typer.Option(
+        0.2,
+        "--overopt-delta-threshold",
+        help="Minimum proxy-minus-gold delta to raise overoptimization flag",
+    ),
+    overopt_min_samples: int = typer.Option(
+        100,
+        "--overopt-min-samples",
+        help="Minimum paired samples required to evaluate overoptimization",
+    ),
     gate: bool = typer.Option(
         False, "--gate", help="Enable CI gate mode with exit codes (0=pass, 1=warn, 2=fail)"
     ),
@@ -2952,6 +3009,27 @@ def reward_health(
             _ensure_column_present(reference_data, step_col, "step")
             _ensure_column_present(reference_data, reward_col, "reward")
 
+        gold_data = None
+        if gold_path:
+            typer.echo("Normalizing gold metrics...")
+            try:
+                gold_data = normalize_training_metrics_source(
+                    gold_path, field_map=mapping_dict
+                )
+            except TypeError as exc:
+                if not Path(gold_path).is_dir():
+                    raise
+                try:
+                    gold_data = _fallback_directory_load(Path(gold_path), mapping_dict)
+                except Exception as load_exc:
+                    raise exc from load_exc
+            if gold_data.empty:
+                raise ValidationError(
+                    "Normalized gold metrics are empty",
+                    suggestion="Ensure the gold source contains the trusted metric column",
+                    error_code="EMPTY_GOLD_DATA",
+                )
+
         # Run reward health analysis
         typer.echo("Running reward health analysis...")
         health_report = health(
@@ -2968,6 +3046,11 @@ def reward_health(
             length_col=length_col,
             threshold_length_bias=threshold_length_bias,
             enable_length_bias_detection=enable_length_bias_detection,
+            gold_metrics=gold_data,
+            gold_metric_col=gold_metric_col,
+            overoptimization_window=overopt_window,
+            overoptimization_delta_threshold=overopt_delta_threshold,
+            overoptimization_min_samples=overopt_min_samples,
         )
 
         # Generate reports
@@ -2976,10 +3059,15 @@ def reward_health(
 
         # Display results
         severity = health_report.length_bias_metrics.bias_severity
+        overopt = getattr(health_report, "overoptimization", None)
         if health_report.passed:
             typer.echo("\n✅ Reward health check passed")
             if severity is not None:
                 typer.echo(f"  Length bias severity: {severity:.3f}")
+            if overopt and getattr(overopt, "gold_metrics_available", False):
+                typer.echo(
+                    f"  Overoptimization delta: {getattr(overopt, 'delta', 0.0):.3f}"
+                )
             exit_code = 0
         else:
             typer.echo("\n🚨 Reward health issues detected")
@@ -3002,6 +3090,16 @@ def reward_health(
                 typer.echo(
                     f"  - Label leakage risk: {health_report.label_leakage_risk:.3f}"
                 )
+            if overopt and getattr(overopt, "flagged", False):
+                typer.echo(
+                    f"  - Reward overoptimization suspected (delta {getattr(overopt, 'delta', 0.0):.3f})"
+                )
+            elif overopt and overopt.gold_metrics_available:
+                typer.echo(
+                    f"  - Overoptimization delta {getattr(overopt, 'delta', 0.0):.3f} (below threshold)"
+                )
+            elif overopt and overopt.warning:
+                typer.echo(f"  - Overoptimization check: {overopt.warning}")
             if health_report.length_bias_detected:
                 typer.echo(
                     f"  - Length bias severity {severity:.3f} exceeds threshold"
@@ -3018,6 +3116,8 @@ def reward_health(
             if health_report.drift_detected:
                 critical_issues += 1
             if health_report.label_leakage_risk > threshold_leakage:
+                critical_issues += 1
+            if overopt and getattr(overopt, "flagged", False):
                 critical_issues += 1
 
             if critical_issues > 0:

--- a/src/rldk/io/consolidated_writers.py
+++ b/src/rldk/io/consolidated_writers.py
@@ -11,6 +11,12 @@ from .consolidated_schemas import Event, MetricsSchema
 from .unified_writer import UnifiedWriter
 from ..reward.length_bias import LengthBiasMetrics
 
+try:
+    from ..reward.health_analysis import OveroptimizationAnalysis, RewardHealthReport
+except ImportError:  # pragma: no cover - avoid circular import during module init
+    OveroptimizationAnalysis = None  # type: ignore[assignment]
+    RewardHealthReport = Any  # type: ignore[assignment]
+
 
 def _length_bias_metrics_to_dict(
     metrics: Optional[LengthBiasMetrics],
@@ -179,6 +185,21 @@ def _generate_reward_health_card_md(report) -> str:
     )
     lines.append(f"- **Length Bias Severity:** {severity_str}\n")
 
+    overopt = getattr(report, "overoptimization", None)
+    if OveroptimizationAnalysis and isinstance(overopt, OveroptimizationAnalysis):
+        if overopt.warning:
+            lines.append(f"- **Overoptimization Check:** ⚠️ {overopt.warning}\n\n")
+        else:
+            lines.append(
+                f"- **Overoptimization Flagged:** {'Yes' if overopt.flagged else 'No'}\n"
+            )
+            if overopt.gold_metrics_available:
+                lines.append(f"- **Proxy vs Gold Δ:** {overopt.delta:.3f}\n\n")
+            else:
+                lines.append("- **Proxy vs Gold Δ:** N/A (no gold metrics)\n\n")
+    else:
+        lines.append("- **Overoptimization Check:** Not evaluated\n\n")
+
     # Detailed analysis sections
     if report.drift_detected:
         lines.append("## 🔄 Reward Drift Analysis\n")
@@ -262,6 +283,49 @@ def _generate_reward_health_card_md(report) -> str:
         lines.append(
             "The reward model may have access to training signals it shouldn't see.\n"
         )
+
+    if OveroptimizationAnalysis and isinstance(overopt, OveroptimizationAnalysis):
+        lines.append("## 📉 Reward Overoptimization Watch\n")
+        if overopt.warning:
+            lines.append(f"**Status:** ⚠️ {overopt.warning}\n\n")
+        else:
+            status_line = (
+                "**Status:** 🚨 Potential overoptimization detected\n\n"
+                if overopt.flagged
+                else "**Status:** ✅ No overoptimization warning\n\n"
+            )
+            lines.append(status_line)
+            if overopt.gold_metrics_available:
+                lines.append(
+                    f"- **Proxy Improvement:** {overopt.proxy_improvement:.3f}\n"
+                )
+                lines.append(
+                    f"- **Gold Improvement:** {overopt.gold_improvement:.3f}\n"
+                )
+                lines.append(f"- **Delta:** {overopt.delta:.3f}\n")
+            if overopt.correlation_trend:
+                pearson = overopt.correlation_trend.get("pearson_delta")
+                spearman = overopt.correlation_trend.get("spearman_delta")
+                if pearson is not None or spearman is not None:
+                    lines.append("- **Correlation Trend:**\n")
+                    if pearson is not None:
+                        lines.append(f"  - Pearson Δ: {pearson:.3f}\n")
+                    if spearman is not None:
+                        lines.append(f"  - Spearman Δ: {spearman:.3f}\n")
+            if overopt.kl_summary:
+                kl_current = overopt.kl_summary.get("kl_current_mean")
+                kl_target = overopt.kl_summary.get("kl_target")
+                if kl_current is not None:
+                    lines.append(f"- **Recent KL Mean:** {float(kl_current):.3f}\n")
+                if kl_target is not None:
+                    lines.append(f"- **KL Target:** {float(kl_target):.3f}\n")
+            lines.append(f"- **Detector Window:** {overopt.window_size} steps\n")
+            lines.append(f"- **Delta Threshold:** {overopt.delta_threshold:.3f}\n")
+            lines.append(f"- **Samples Evaluated:** {overopt.sample_size}\n")
+            if overopt.notes:
+                lines.append("\n### Notes\n")
+                for note in overopt.notes:
+                    lines.append(f"- {note}\n")
 
     length_metrics_dict = _length_bias_metrics_to_dict(report.length_bias_metrics)
     if report.length_bias_detected or length_metrics_dict or report.length_bias_recommendations:
@@ -356,6 +420,14 @@ def write_reward_health_summary(report, output_dir: Path) -> None:
             report.length_bias_metrics
         ),
     }
+
+    overopt = getattr(report, "overoptimization", None)
+    if OveroptimizationAnalysis and isinstance(overopt, OveroptimizationAnalysis):
+        summary["overoptimization"] = overopt.to_dict()
+    elif hasattr(overopt, "to_dict"):
+        summary["overoptimization"] = overopt.to_dict()
+    else:
+        summary["overoptimization"] = {}
 
     # Add drift summary if available
     if report.drift_metrics is not None and not report.drift_metrics.empty:

--- a/src/rldk/io/reward_writers.py
+++ b/src/rldk/io/reward_writers.py
@@ -6,7 +6,11 @@ from typing import Any, Dict, Optional, Union
 import numpy as np
 import pandas as pd
 
-from ..reward.health_analysis import RewardHealthReport
+try:
+    from ..reward.health_analysis import OveroptimizationAnalysis, RewardHealthReport
+except ImportError:  # pragma: no cover - avoid circular import during module init
+    OveroptimizationAnalysis = None  # type: ignore[assignment]
+    RewardHealthReport = Any  # type: ignore[assignment]
 from ..reward.length_bias import LengthBiasMetrics
 from .unified_writer import UnifiedWriter
 
@@ -110,6 +114,24 @@ def write_reward_health_card(report: RewardHealthReport, output_dir: Path) -> No
         )
         f.write(f"- **Length Bias Severity:** {severity_str}\n\n")
 
+        overopt = getattr(report, "overoptimization", None)
+        if OveroptimizationAnalysis and isinstance(overopt, OveroptimizationAnalysis):
+            if overopt.warning:
+                f.write(f"- **Overoptimization Check:** ⚠️ {overopt.warning}\n\n")
+            else:
+                overopt_status = "Yes" if overopt.flagged else "No"
+                f.write(
+                    f"- **Overoptimization Flagged:** {overopt_status}\n"
+                )
+                if overopt.gold_metrics_available:
+                    f.write(
+                        f"- **Proxy vs Gold Δ:** {overopt.delta:.3f}\n\n"
+                    )
+                else:
+                    f.write("- **Proxy vs Gold Δ:** N/A (no gold metrics)\n\n")
+        else:
+            f.write("- **Overoptimization Check:** Not evaluated\n\n")
+
         # Detailed analysis sections
         if report.drift_detected:
             f.write("## 🔄 Reward Drift Analysis\n\n")
@@ -181,10 +203,10 @@ def write_reward_health_card(report: RewardHealthReport, output_dir: Path) -> No
             for signal in report.shortcut_signals:
                 f.write(f"- {signal}\n")
 
-            if report.shortcut_analysis:
-                f.write("\n### Shortcut Analysis\n\n")
-                for metric, correlation in report.shortcut_analysis.items():
-                    f.write(f"- **{metric}:** {correlation:.3f}\n")
+        if report.shortcut_analysis:
+            f.write("\n### Shortcut Analysis\n\n")
+            for metric, correlation in report.shortcut_analysis.items():
+                f.write(f"- **{metric}:** {correlation:.3f}\n")
 
         if report.label_leakage_risk > 0.3:
             f.write("## 🔒 Label Leakage Analysis\n\n")
@@ -193,6 +215,61 @@ def write_reward_health_card(report: RewardHealthReport, output_dir: Path) -> No
             f.write(
                 "The reward model may have access to training signals it shouldn't see.\n"
             )
+
+        if OveroptimizationAnalysis and isinstance(overopt, OveroptimizationAnalysis):
+            f.write("## 📉 Reward Overoptimization Watch\n\n")
+            if overopt.warning:
+                f.write(f"**Status:** ⚠️ {overopt.warning}\n\n")
+            else:
+                status_line = (
+                    "**Status:** 🚨 Potential overoptimization detected\n\n"
+                    if overopt.flagged
+                    else "**Status:** ✅ No overoptimization warning\n\n"
+                )
+                f.write(status_line)
+                if overopt.gold_metrics_available:
+                    f.write(
+                        f"- **Proxy Improvement:** {overopt.proxy_improvement:.3f}\n"
+                    )
+                    f.write(
+                        f"- **Gold Improvement:** {overopt.gold_improvement:.3f}\n"
+                    )
+                    f.write(f"- **Delta:** {overopt.delta:.3f}\n")
+                if overopt.correlation_trend:
+                    pearson = overopt.correlation_trend.get("pearson_delta")
+                    spearman = overopt.correlation_trend.get("spearman_delta")
+                    if pearson is not None or spearman is not None:
+                        f.write("- **Correlation Trend:**\n")
+                        if pearson is not None:
+                            f.write(
+                                f"  - Pearson Δ: {pearson:.3f}\n"
+                            )
+                        if spearman is not None:
+                            f.write(
+                                f"  - Spearman Δ: {spearman:.3f}\n"
+                            )
+                if overopt.kl_summary:
+                    kl_current = overopt.kl_summary.get("kl_current_mean")
+                    kl_target = overopt.kl_summary.get("kl_target")
+                    if kl_current is not None:
+                        f.write(
+                            f"- **Recent KL Mean:** {float(kl_current):.3f}\n"
+                        )
+                    if kl_target is not None:
+                        f.write(f"- **KL Target:** {float(kl_target):.3f}\n")
+                f.write(
+                    f"- **Detector Window:** {overopt.window_size} steps\n"
+                )
+                f.write(
+                    f"- **Delta Threshold:** {overopt.delta_threshold:.3f}\n"
+                )
+                f.write(
+                    f"- **Samples Evaluated:** {overopt.sample_size}\n"
+                )
+                if overopt.notes:
+                    f.write("\n### Notes\n\n")
+                    for note in overopt.notes:
+                        f.write(f"- {note}\n")
 
         length_metrics_dict = _length_bias_metrics_to_dict(report.length_bias_metrics)
         if report.length_bias_detected or length_metrics_dict or report.length_bias_recommendations:
@@ -294,6 +371,14 @@ def write_reward_health_summary(report: RewardHealthReport, output_dir: Path) ->
             report.length_bias_metrics
         ),
     }
+
+    overopt = getattr(report, "overoptimization", None)
+    if OveroptimizationAnalysis and isinstance(overopt, OveroptimizationAnalysis):
+        summary["overoptimization"] = overopt.to_dict()
+    elif hasattr(overopt, "to_dict"):
+        summary["overoptimization"] = overopt.to_dict()
+    else:
+        summary["overoptimization"] = {}
 
     # Add drift summary if available
     if report.drift_metrics is not None and not report.drift_metrics.empty:

--- a/src/rldk/reward/__init__.py
+++ b/src/rldk/reward/__init__.py
@@ -6,12 +6,13 @@ from .api import HealthAnalysisResult, reward_health
 from .calibration import analyze_calibration
 from .drift import compare_models, detect_reward_drift
 from .length_bias import LengthBiasDetector, LengthBiasMetrics
-from .health_analysis import RewardHealthReport, health
+from .health_analysis import OveroptimizationAnalysis, RewardHealthReport, health
 
 __all__ = [
     "health",
     "reward_health",
     "RewardHealthReport",
+    "OveroptimizationAnalysis",
     "HealthAnalysisResult",
     "compare_models",
     "detect_reward_drift",

--- a/src/rldk/reward/api.py
+++ b/src/rldk/reward/api.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from ..ingest.training_metrics_normalizer import normalize_training_metrics
 from ..utils.error_handling import ValidationError
-from .health_analysis import RewardHealthReport, health
+from .health_analysis import OveroptimizationAnalysis, RewardHealthReport, health
 from .length_bias import LengthBiasMetrics
 
 TrainingMetricsInput = Union[pd.DataFrame, Sequence[Mapping[str, Any]], str, Path]
@@ -63,6 +63,14 @@ class HealthAnalysisResult:
         else:
             report_dict["drift_metrics"] = []
 
+        overopt = getattr(self.report, "overoptimization", None)
+        if isinstance(overopt, OveroptimizationAnalysis):
+            report_dict["overoptimization"] = overopt.to_dict()
+        elif hasattr(overopt, "to_dict"):
+            report_dict["overoptimization"] = overopt.to_dict()
+        else:
+            report_dict["overoptimization"] = {}
+
         return {
             "report": report_dict,
             "metrics": self.metrics.to_dict(orient="records"),
@@ -108,6 +116,11 @@ def reward_health(
     length_col: Optional[str] = None,
     threshold_length_bias: float = 0.4,
     enable_length_bias_detection: bool = True,
+    gold_metrics: Optional[TrainingMetricsInput] = None,
+    gold_metric_col: Optional[str] = None,
+    overoptimization_window: int = 100,
+    overoptimization_delta_threshold: float = 0.2,
+    overoptimization_min_samples: int = 100,
 ) -> HealthAnalysisResult:
     """Run reward health analysis with flexible input formats."""
 
@@ -135,6 +148,10 @@ def reward_health(
         _ensure_column_present(reference_metrics, step_col, "step")
         _ensure_column_present(reference_metrics, reward_col, "reward")
 
+    gold_metrics_df: Optional[pd.DataFrame] = None
+    if gold_metrics is not None:
+        gold_metrics_df = normalize_training_metrics(gold_metrics, field_map=field_map)
+
     report = health(
         run_data=run_metrics,
         reference_data=reference_metrics,
@@ -149,6 +166,11 @@ def reward_health(
         length_col=length_col,
         threshold_length_bias=threshold_length_bias,
         enable_length_bias_detection=enable_length_bias_detection,
+        gold_metrics=gold_metrics_df,
+        gold_metric_col=gold_metric_col,
+        overoptimization_window=overoptimization_window,
+        overoptimization_delta_threshold=overoptimization_delta_threshold,
+        overoptimization_min_samples=overoptimization_min_samples,
     )
 
     return HealthAnalysisResult(report=report, metrics=run_metrics, reference_metrics=reference_metrics)

--- a/src/rldk/reward/health_analysis.py
+++ b/src/rldk/reward/health_analysis.py
@@ -1,12 +1,16 @@
 """Main reward health checking functionality."""
 
-from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+
+import contextlib
+import io
 
 import numpy as np
 import pandas as pd
 
 from .calibration import analyze_calibration
+from ..forensics.kl_schedule_tracker import KLScheduleTracker
 from .drift import detect_reward_drift
 from .length_bias import LengthBiasDetector, LengthBiasMetrics
 
@@ -29,6 +33,55 @@ class RewardHealthReport:
     length_bias_detected: bool = False
     length_bias_metrics: LengthBiasMetrics = field(default_factory=LengthBiasMetrics)
     length_bias_recommendations: List[str] = field(default_factory=list)
+    overoptimization: "OveroptimizationAnalysis" = field(
+        default_factory=lambda: OveroptimizationAnalysis()
+    )
+
+
+@dataclass
+class OveroptimizationAnalysis:
+    """Summary of reward-vs-gold overoptimization analysis."""
+
+    proxy_improvement: float = 0.0
+    gold_improvement: float = 0.0
+    delta: float = 0.0
+    correlation_trend: Dict[str, Optional[float]] = field(default_factory=dict)
+    kl_summary: Dict[str, Any] = field(default_factory=dict)
+    flagged: bool = False
+    gold_metrics_available: bool = False
+    gold_regressed: bool = False
+    gold_stagnant: bool = False
+    kl_elevated: bool = False
+    correlation_declined: bool = False
+    warning: Optional[str] = None
+    notes: List[str] = field(default_factory=list)
+    window_size: int = 100
+    delta_threshold: float = 0.2
+    min_samples: int = 100
+    sample_size: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-serializable representation."""
+
+        def _normalize_value(value: Any) -> Any:
+            if isinstance(value, bool):
+                return value
+            if isinstance(value, (np.floating, np.integer)):
+                return float(value)
+            if isinstance(value, (float, int)):
+                if pd.isna(value):
+                    return None
+                return float(value)
+            if isinstance(value, dict):
+                return {k: _normalize_value(v) for k, v in value.items()}
+            if isinstance(value, list):
+                return [_normalize_value(v) for v in value]
+            if pd.isna(value):
+                return None
+            return value
+
+        payload = asdict(self)
+        return {key: _normalize_value(val) for key, val in payload.items()}
 
 
 def health(
@@ -45,6 +98,11 @@ def health(
     length_col: Optional[str] = None,
     threshold_length_bias: float = 0.4,
     enable_length_bias_detection: bool = True,
+    gold_metrics: Optional[Union[pd.DataFrame, pd.Series]] = None,
+    gold_metric_col: Optional[str] = None,
+    overoptimization_window: int = 100,
+    overoptimization_delta_threshold: float = 0.2,
+    overoptimization_min_samples: int = 100,
 ) -> RewardHealthReport:
     """
     Analyze reward model health and detect pathologies.
@@ -63,6 +121,11 @@ def health(
         length_col: Optional column containing precomputed response lengths
         threshold_length_bias: Threshold on length bias severity for failures
         enable_length_bias_detection: Toggle for length bias detector
+        gold_metrics: Optional trusted gold metric timeseries
+        gold_metric_col: Column name to pull gold metrics from if available
+        overoptimization_window: Window size for early/late comparisons
+        overoptimization_delta_threshold: Proxy-minus-gold delta to flag issues
+        overoptimization_min_samples: Minimum paired samples required for detector
 
     Returns:
         RewardHealthReport with comprehensive analysis
@@ -172,6 +235,29 @@ def health(
         issues.append("Potential label leakage detected")
         fixes.append("Audit data pipeline for information leakage")
 
+    overoptimization_analysis = _analyze_overoptimization(
+        run_data=run_data,
+        reward_col=reward_col,
+        step_col=step_col,
+        gold_metrics=gold_metrics,
+        gold_metric_col=gold_metric_col,
+        window_size=overoptimization_window,
+        delta_threshold=overoptimization_delta_threshold,
+        min_samples=overoptimization_min_samples,
+    )
+
+    if overoptimization_analysis.warning:
+        warning_message = overoptimization_analysis.warning
+        if warning_message not in fixes:
+            fixes.append(warning_message)
+    elif overoptimization_analysis.flagged:
+        issues.append(
+            "Reward overoptimization suspected: proxy reward improved while gold metrics stagnated"
+        )
+        fixes.append(
+            "Pause reward optimization, review KL controls, and refresh gold evaluations to realign the reward model"
+        )
+
     # Determine overall health
     passed = len(issues) == 0
 
@@ -190,6 +276,7 @@ def health(
         length_bias_detected=length_bias_detected,
         length_bias_metrics=length_bias_metrics,
         length_bias_recommendations=length_bias_recommendations,
+        overoptimization=overoptimization_analysis,
     )
 
 
@@ -411,3 +498,234 @@ def _detect_label_leakage(
             leakage_risk += 0.4
 
     return min(leakage_risk, 1.0)
+
+
+def _analyze_overoptimization(
+    run_data: pd.DataFrame,
+    reward_col: str,
+    step_col: str,
+    gold_metrics: Optional[Union[pd.DataFrame, pd.Series]],
+    gold_metric_col: Optional[str],
+    window_size: int,
+    delta_threshold: float,
+    min_samples: int,
+) -> OveroptimizationAnalysis:
+    analysis = OveroptimizationAnalysis(
+        window_size=window_size,
+        delta_threshold=delta_threshold,
+        min_samples=min_samples,
+    )
+
+    gold_df, warning = _prepare_gold_dataframe(
+        run_data=run_data,
+        step_col=step_col,
+        gold_metrics=gold_metrics,
+        gold_metric_col=gold_metric_col,
+    )
+
+    if gold_df is None:
+        if warning:
+            analysis.warning = warning
+        return analysis
+
+    analysis.gold_metrics_available = True
+
+    paired = run_data[[step_col, reward_col]].merge(gold_df, on=step_col, how="inner")
+    paired = paired.dropna(subset=[reward_col, "gold_metric"])
+    paired = paired.sort_values(step_col).reset_index(drop=True)
+    sample_size = len(paired)
+    analysis.sample_size = sample_size
+
+    if sample_size < max(4, min_samples):
+        analysis.warning = (
+            "Insufficient overlapping reward/gold samples for overoptimization analysis"
+        )
+        return analysis
+
+    effective_window = max(2, min(window_size, sample_size // 2))
+    if effective_window < 2:
+        analysis.warning = "Not enough data points to compute early/late window statistics"
+        return analysis
+
+    early_window = paired.iloc[:effective_window]
+    late_window = paired.iloc[-effective_window:]
+
+    proxy_improvement = late_window[reward_col].mean() - early_window[reward_col].mean()
+    gold_improvement = late_window["gold_metric"].mean() - early_window["gold_metric"].mean()
+    analysis.proxy_improvement = float(proxy_improvement)
+    analysis.gold_improvement = float(gold_improvement)
+    analysis.delta = float(proxy_improvement - gold_improvement)
+    analysis.gold_regressed = gold_improvement < 0
+    analysis.gold_stagnant = abs(gold_improvement) < delta_threshold * 0.25
+
+    correlation_trend = {}
+    for method in ("pearson", "spearman"):
+        early_corr = _safe_correlation(early_window[reward_col], early_window["gold_metric"], method)
+        late_corr = _safe_correlation(late_window[reward_col], late_window["gold_metric"], method)
+        if early_corr is not None:
+            correlation_trend[f"{method}_early"] = early_corr
+        if late_corr is not None:
+            correlation_trend[f"{method}_late"] = late_corr
+        if early_corr is not None and late_corr is not None:
+            correlation_trend[f"{method}_delta"] = float(late_corr - early_corr)
+
+    analysis.correlation_trend = correlation_trend
+    deltas = [correlation_trend.get("pearson_delta"), correlation_trend.get("spearman_delta")]
+    analysis.correlation_declined = any(
+        delta is not None and delta < -0.05 for delta in deltas if delta is not None
+    )
+
+    kl_summary = _summarize_recent_kl(run_data, step_col)
+    analysis.kl_summary = kl_summary
+    current_mean = _safe_numeric(kl_summary.get("kl_current_mean"))
+    if current_mean is None:
+        current_mean = _safe_numeric(kl_summary.get("current_kl"))
+    kl_target = _safe_numeric(kl_summary.get("kl_target")) or 0.1
+    analysis.kl_elevated = (
+        current_mean is not None and current_mean > kl_target * 1.5
+    ) or bool(kl_summary.get("target_range_violations", 0))
+
+    proxy_gain_ok = proxy_improvement >= delta_threshold
+    gold_flat = analysis.gold_stagnant or analysis.gold_regressed or gold_improvement <= 0
+
+    if (
+        proxy_gain_ok
+        and gold_flat
+        and analysis.kl_elevated
+        and sample_size >= min_samples
+    ):
+        analysis.flagged = True
+        if not analysis.correlation_declined:
+            analysis.notes.append(
+                "Proxy/gold delta cleared the threshold but correlations remained stable"
+            )
+
+    return analysis
+
+
+def _prepare_gold_dataframe(
+    run_data: pd.DataFrame,
+    step_col: str,
+    gold_metrics: Optional[Union[pd.DataFrame, pd.Series]],
+    gold_metric_col: Optional[str],
+) -> Tuple[Optional[pd.DataFrame], Optional[str]]:
+    candidate: Optional[pd.DataFrame]
+
+    if gold_metrics is None:
+        candidate_cols = [
+            gold_metric_col,
+            "gold_metric",
+            "gold_score",
+            "trusted_score",
+            "eval_score",
+            "benchmark_score",
+        ]
+        resolved_col = next(
+            (col for col in candidate_cols if col and col in run_data.columns),
+            None,
+        )
+        if resolved_col is None:
+            return None, "Gold metrics not provided; supply --gold-col or --gold path to enable overoptimization checks"
+        candidate = run_data[[step_col, resolved_col]].rename(
+            columns={resolved_col: "gold_metric"}
+        )
+        return candidate, None
+
+    if isinstance(gold_metrics, pd.Series):
+        series = gold_metrics.dropna()
+        if series.empty:
+            return None, "Provided gold metrics are empty"
+        if series.index.name == step_col or series.index.equals(run_data[step_col]):
+            df = series.to_frame(name="gold_metric").reset_index()
+            if series.index.name != step_col:
+                df = df.rename(columns={"index": step_col})
+            return df[[step_col, "gold_metric"]], None
+        if len(series) == len(run_data):
+            df = pd.DataFrame({step_col: run_data[step_col], "gold_metric": series.values})
+            return df, None
+        return None, "Gold metrics series length does not match reward metrics"
+
+    if isinstance(gold_metrics, pd.DataFrame):
+        gold_df = gold_metrics.copy()
+        if step_col not in gold_df.columns:
+            if len(gold_df) == len(run_data):
+                gold_df = gold_df.copy()
+                gold_df[step_col] = run_data[step_col].values
+            else:
+                return None, "Gold metrics missing step information"
+
+        candidate_cols = [
+            gold_metric_col,
+            "gold_metric",
+            "gold_score",
+            "trusted_score",
+            "eval_score",
+            "benchmark_score",
+        ]
+        resolved_col = next(
+            (col for col in candidate_cols if col and col in gold_df.columns),
+            None,
+        )
+        if resolved_col is None:
+            remaining = [c for c in gold_df.columns if c != step_col]
+            if len(remaining) == 1:
+                resolved_col = remaining[0]
+        if resolved_col is None:
+            return None, "Unable to determine gold metric column"
+        return (
+            gold_df[[step_col, resolved_col]].rename(columns={resolved_col: "gold_metric"}),
+            None,
+        )
+
+    return None, "Unsupported gold metrics format"
+
+
+def _safe_correlation(
+    rewards: pd.Series, gold: pd.Series, method: str
+) -> Optional[float]:
+    if rewards.nunique(dropna=True) < 2 or gold.nunique(dropna=True) < 2:
+        return None
+    try:
+        corr = rewards.corr(gold, method=method)
+        if pd.isna(corr):
+            return None
+        return float(corr)
+    except Exception:
+        return None
+
+
+def _summarize_recent_kl(run_data: pd.DataFrame, step_col: str) -> Dict[str, Any]:
+    candidate_cols = ["kl_mean", "kl", "kl_value", "kl_divergence"]
+    kl_col = next((col for col in candidate_cols if col in run_data.columns), None)
+    if kl_col is None:
+        return {}
+
+    coef_cols = ["kl_coef", "kl_coefficient", "kl_beta", "kl_scale"]
+    coef_col = next((col for col in coef_cols if col in run_data.columns), None)
+
+    with contextlib.redirect_stdout(io.StringIO()):
+        tracker = KLScheduleTracker(enable_drift_tracking=False)
+
+    for step, row in run_data[[step_col, kl_col]].dropna().iterrows():
+        step_value = int(row[step_col]) if step_col in run_data.columns else int(step)
+        kl_value = row[kl_col]
+        coef_value = 1.0
+        if coef_col is not None:
+            coef_value = run_data.loc[row.name, coef_col]
+        tracker.update(step_value, kl_value, coef_value)
+
+    summary = tracker.get_summary()
+    sanitized = {key: _safe_numeric(value) if isinstance(value, (float, int, np.floating, np.integer)) else value for key, value in summary.items()}
+    return sanitized
+
+
+def _safe_numeric(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if pd.isna(numeric):
+        return None
+    return numeric

--- a/src/rldk/reward/health_config/exit_codes.py
+++ b/src/rldk/reward/health_config/exit_codes.py
@@ -64,18 +64,18 @@ def raise_on_failure(health_path: str) -> None:
     if passed:
         print("✅ Health check passed")
         if warnings:
-            print(f"  Warnings: {len(warnings)}")
+            print(f"Warnings: {len(warnings)}")
             for warning in warnings:
-                print(f"    - {warning}")
+                print(warning)
     else:
         print("🚨 Health check failed")
         if failures:
-            print(f"  Failures: {len(failures)}")
+            print(f"Failures: {len(failures)}")
             for failure in failures:
-                print(f"    - {failure}")
+                print(failure)
         if warnings:
-            print(f"  Warnings: {len(warnings)}")
+            print(f"Warnings: {len(warnings)}")
             for warning in warnings:
-                print(f"    - {warning}")
+                print(warning)
 
     sys.exit(exit_code)

--- a/tests/integration/test_reward_health.py
+++ b/tests/integration/test_reward_health.py
@@ -6,7 +6,11 @@ import pytest
 
 from rldk.reward.calibration import analyze_calibration
 from rldk.reward.drift import detect_reward_drift
-from rldk.reward.health_analysis import RewardHealthReport, health
+from rldk.reward.health_analysis import (
+    OveroptimizationAnalysis,
+    RewardHealthReport,
+    health,
+)
 from rldk.reward.length_bias import LengthBiasMetrics
 
 
@@ -331,6 +335,7 @@ class TestRewardHealthReport:
             length_bias_detected=False,
             length_bias_metrics=LengthBiasMetrics(),
             length_bias_recommendations=[],
+            overoptimization=OveroptimizationAnalysis(),
         )
 
         assert report.passed is True
@@ -358,6 +363,7 @@ class TestRewardHealthReport:
             length_bias_detected=True,
             length_bias_metrics=LengthBiasMetrics(bias_severity=0.8),
             length_bias_recommendations=["Audit prompts for response length bias."],
+            overoptimization=OveroptimizationAnalysis(flagged=True),
         )
 
         assert report.passed is False

--- a/tests/reward_health/test_overoptimization.py
+++ b/tests/reward_health/test_overoptimization.py
@@ -1,0 +1,94 @@
+"""Tests for reward overoptimization detector."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from rldk.reward.health_analysis import health
+
+
+def _build_run_frame(num_steps: int = 200, reward_gain: float = 0.5) -> pd.DataFrame:
+    steps = np.arange(num_steps)
+    start = 0.2
+    end = start + reward_gain
+    rewards = np.linspace(start, end, num_steps) + np.random.normal(0.0, 0.01, num_steps)
+    kl_values = np.linspace(0.25, 0.4, num_steps)
+    return pd.DataFrame(
+        {
+            "step": steps,
+            "reward_mean": rewards,
+            "kl_mean": kl_values,
+        }
+    )
+
+
+def test_overoptimization_flagged_when_proxy_outpaces_gold() -> None:
+    run_data = _build_run_frame(reward_gain=0.6)
+    gold_scores = pd.DataFrame(
+        {
+            "step": run_data["step"],
+            "gold_metric": np.linspace(0.35, 0.34, len(run_data)),
+        }
+    )
+
+    report = health(
+        run_data=run_data,
+        reward_col="reward_mean",
+        step_col="step",
+        threshold_leakage=1.0,
+        threshold_shortcut=1.0,
+        enable_length_bias_detection=False,
+        gold_metrics=gold_scores,
+        gold_metric_col="gold_metric",
+        overoptimization_min_samples=80,
+    )
+
+    assert report.overoptimization.flagged is True
+    assert report.overoptimization.delta > 0.2
+    assert report.overoptimization.kl_elevated is True
+    assert report.passed is False
+
+
+def test_overoptimization_relaxes_when_gold_improves() -> None:
+    run_data = _build_run_frame(reward_gain=0.4)
+    gold_scores = pd.DataFrame(
+        {
+            "step": run_data["step"],
+            "gold_metric": np.linspace(0.3, 0.62, len(run_data)),
+        }
+    )
+
+    report = health(
+        run_data=run_data,
+        reward_col="reward_mean",
+        step_col="step",
+        threshold_leakage=1.0,
+        threshold_shortcut=1.0,
+        enable_length_bias_detection=False,
+        gold_metrics=gold_scores,
+        gold_metric_col="gold_metric",
+        overoptimization_min_samples=80,
+    )
+
+    assert report.overoptimization.flagged is False
+    assert report.overoptimization.delta < 0.2
+    assert report.passed is True
+
+
+def test_overoptimization_warns_when_missing_gold() -> None:
+    run_data = _build_run_frame(reward_gain=0.3)
+
+    report = health(
+        run_data=run_data,
+        reward_col="reward_mean",
+        step_col="step",
+        threshold_leakage=1.0,
+        threshold_shortcut=1.0,
+        enable_length_bias_detection=False,
+        overoptimization_min_samples=50,
+    )
+
+    assert report.overoptimization.flagged is False
+    assert report.overoptimization.gold_metrics_available is False
+    assert report.overoptimization.warning is not None

--- a/tests/test_reward_health_cli.py
+++ b/tests/test_reward_health_cli.py
@@ -51,6 +51,7 @@ def test_reward_health_cli_normalizes_jsonl(tmp_path: Path, runner: CliRunner) -
 
     summary = json.loads(summary_path.read_text(encoding="utf-8"))
     assert "calibration_score" in summary
+    assert "overoptimization" in summary
 
 
 def test_reward_health_cli_missing_reward(tmp_path: Path, runner: CliRunner) -> None:

--- a/tests/unit/reward/test_reward_writers.py
+++ b/tests/unit/reward/test_reward_writers.py
@@ -6,7 +6,7 @@ import pytest
 
 from src.rldk.io.reward_writers import write_reward_health_summary
 from src.rldk.io.consolidated_writers import write_reward_health_summary as consolidated_summary
-from src.rldk.reward.health_analysis import RewardHealthReport
+from src.rldk.reward.health_analysis import OveroptimizationAnalysis, RewardHealthReport
 from src.rldk.reward.length_bias import LengthBiasMetrics
 
 
@@ -19,6 +19,24 @@ def sample_report() -> RewardHealthReport:
         variance_explained=0.2,
         bias_severity=0.55,
         recommendations=["Review reward model prompts for length bias."],
+    )
+    overopt = OveroptimizationAnalysis(
+        proxy_improvement=0.35,
+        gold_improvement=0.05,
+        delta=0.30,
+        correlation_trend={"pearson_delta": -0.2, "spearman_delta": -0.1},
+        kl_summary={"kl_current_mean": 0.3, "kl_target": 0.1},
+        flagged=True,
+        gold_metrics_available=True,
+        gold_regressed=False,
+        gold_stagnant=True,
+        kl_elevated=True,
+        correlation_declined=True,
+        window_size=50,
+        delta_threshold=0.2,
+        min_samples=60,
+        sample_size=80,
+        notes=["Proxy reward diverging from gold benchmark"],
     )
     return RewardHealthReport(
         passed=False,
@@ -35,6 +53,7 @@ def sample_report() -> RewardHealthReport:
         length_bias_detected=True,
         length_bias_metrics=metrics,
         length_bias_recommendations=metrics.recommendations,
+        overoptimization=overopt,
     )
 
 
@@ -56,3 +75,5 @@ def test_reward_health_summary_serializes_length_bias(tmp_path: Path, sample_rep
     assert payload["length_bias_recommendations"] == [
         "Review reward model prompts for length bias."
     ]
+    assert payload["overoptimization"]["flagged"] is True
+    assert pytest.approx(payload["overoptimization"]["delta"], rel=1e-6) == 0.30


### PR DESCRIPTION
## Summary
- add an overoptimization analysis dataclass that compares proxy reward to trusted gold metrics and KL signals
- expose CLI and report updates to surface overoptimization metrics, configuration knobs, and documentation guidance
- extend test suite with new detector coverage and update report writers/CLI behavior

## Testing
- pytest tests/reward_health tests/unit/reward/test_reward_writers.py tests/test_reward_health_cli.py tests/integration/test_reward_health.py

------
https://chatgpt.com/codex/tasks/task_e_68d19665fd94832f98e8cd7d13a26707