### PR TITLE
Add GRPO adapter ingestion support

### DIFF
--- a/src/rldk/adapters/__init__.py
+++ b/src/rldk/adapters/__init__.py
@@ -4,6 +4,7 @@ from .base import BaseAdapter
 from .custom_jsonl import CustomJSONLAdapter
 from .field_resolver import FieldResolver, SchemaError
 from .flexible import FlexibleDataAdapter, FlexibleJSONLAdapter
+from .grpo import GRPOAdapter
 from .openrlhf import OpenRLHFAdapter
 from .trl import TRLAdapter
 from .wandb import WandBAdapter
@@ -18,4 +19,5 @@ __all__ = [
     "FlexibleJSONLAdapter",
     "FieldResolver",
     "SchemaError",
+    "GRPOAdapter",
 ]

--- a/src/rldk/adapters/grpo.py
+++ b/src/rldk/adapters/grpo.py
@@ -1,0 +1,151 @@
+"""Adapter for GRPO training logs."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+import pandas as pd
+
+from .base import BaseAdapter
+
+
+class GRPOAdapter(BaseAdapter):
+    """Adapter for GRPO training logs produced by run.jsonl artifacts."""
+
+    _RUN_FILENAME = "run.jsonl"
+    _REQUIRED_KEYS = {"kl", "entropy", "advantage_mean", "grad_norm_policy", "reward_mean"}
+
+    def can_handle(self) -> bool:
+        """Return ``True`` when the source looks like a GRPO log directory."""
+        if not self.source.exists():
+            return False
+
+        if self.source.is_file():
+            return self._is_grpo_file(self.source)
+
+        if self.source.is_dir():
+            run_files = list(self._discover_run_files(self.source))
+            return any(self._is_grpo_file(path) for path in run_files)
+
+        return False
+
+    def load(self) -> pd.DataFrame:
+        """Load GRPO training metrics and map them to the canonical schema."""
+        if not self.can_handle():
+            raise ValueError(f"Cannot handle source: {self.source}")
+
+        run_files = list(self._discover_run_files(self.source))
+        if not run_files and self.source.is_file():
+            run_files = [self.source]
+
+        metrics: List[Dict[str, Any]] = []
+        for run_file in run_files:
+            metrics.extend(self._parse_run_file(run_file))
+
+        if not metrics:
+            raise ValueError(f"No GRPO metrics found in {self.source}")
+
+        df = pd.DataFrame(metrics)
+
+        if "phase" not in df.columns:
+            df["phase"] = "train"
+        else:
+            df["phase"] = df["phase"].fillna("train")
+
+        for column in ["reward_mean", "reward_std", "kl_mean", "entropy_mean"]:
+            if column not in df.columns:
+                df[column] = None
+
+        if "step" not in df.columns:
+            raise ValueError("GRPO logs must include a step field")
+
+        return df
+
+    def _discover_run_files(self, root: Path) -> Iterable[Path]:
+        if root.is_file():
+            if root.name == self._RUN_FILENAME:
+                yield root
+            return
+
+        for candidate in sorted(root.rglob(self._RUN_FILENAME)):
+            yield candidate
+
+    def _is_grpo_file(self, file_path: Path) -> bool:
+        if file_path.suffix != ".jsonl":
+            return False
+
+        try:
+            with open(file_path) as handle:
+                for line in handle:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    data = json.loads(line)
+                    if not isinstance(data, dict):
+                        continue
+                    return self._REQUIRED_KEYS.issubset(data)
+        except (OSError, json.JSONDecodeError):
+            return False
+        return False
+
+    def _parse_run_file(self, file_path: Path) -> List[Dict[str, Any]]:
+        metrics: List[Dict[str, Any]] = []
+        seed_hint = self._extract_seed(file_path)
+        run_id_hint = self._extract_run_id(file_path)
+
+        try:
+            with open(file_path) as handle:
+                for line_number, line in enumerate(handle, start=1):
+                    line = line.strip()
+                    if not line:
+                        continue
+
+                    data = json.loads(line)
+                    if not isinstance(data, dict):
+                        continue
+
+                    record: Dict[str, Any] = {
+                        "step": data.get("step", line_number - 1),
+                        "phase": data.get("phase") or "train",
+                        "reward_mean": data.get("reward_mean"),
+                        "reward_std": data.get("reward_std"),
+                        "kl_mean": data.get("kl"),
+                        "entropy_mean": data.get("entropy"),
+                    }
+
+                    seed_value = data.get("seed", seed_hint)
+                    if seed_value is not None:
+                        record["seed"] = seed_value
+
+                    run_id_value = data.get("run_id", run_id_hint)
+                    if run_id_value is not None:
+                        record["run_id"] = run_id_value
+
+                    for key, value in data.items():
+                        if key in {"step", "phase", "reward_mean", "reward_std", "kl", "entropy", "seed", "run_id"}:
+                            continue
+                        record[key] = value
+
+                    metrics.append(record)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RuntimeError(f"Failed to parse GRPO log {file_path}: {exc}") from exc
+
+        return metrics
+
+    def _extract_seed(self, file_path: Path) -> Any:
+        match = re.search(r"seed_(\d+)", str(file_path))
+        if match:
+            try:
+                return int(match.group(1))
+            except ValueError:
+                return match.group(1)
+        return None
+
+    def _extract_run_id(self, file_path: Path) -> str | None:
+        parent = file_path.parent
+        if parent.name and parent.name != ".":
+            return parent.name
+        return None

--- a/src/rldk/ingest/ingest.py
+++ b/src/rldk/ingest/ingest.py
@@ -9,6 +9,7 @@ import pandas as pd
 from ..adapters import (
     CustomJSONLAdapter,
     FlexibleDataAdapter,
+    GRPOAdapter,
     OpenRLHFAdapter,
     TRLAdapter,
     WandBAdapter,
@@ -39,7 +40,7 @@ def ingest_runs(
 
     Args:
         source: Path to logs directory, file, or wandb:// URI
-        adapter_hint: Optional hint for adapter type ('trl', 'openrlhf', 'wandb', 'custom_jsonl', 'flexible')
+        adapter_hint: Optional hint for adapter type ('trl', 'openrlhf', 'wandb', 'custom_jsonl', 'grpo', 'flexible')
         field_map: Optional explicit mapping from canonical to actual field names
         config_file: Optional path to YAML/JSON config file with field mapping
         validation_mode: Validation strictness - 'strict', 'flexible', or 'lenient'
@@ -98,7 +99,7 @@ def ingest_runs(
             ) from e
 
     # Validate adapter type
-    valid_adapters = ["trl", "openrlhf", "wandb", "custom_jsonl", "flexible"]
+    valid_adapters = ["trl", "openrlhf", "wandb", "custom_jsonl", "grpo", "flexible"]
     if adapter_hint not in valid_adapters:
         raise ValidationError(
             f"Invalid adapter type: {adapter_hint}",
@@ -116,6 +117,8 @@ def ingest_runs(
             adapter = WandBAdapter(source)
         elif adapter_hint == "custom_jsonl":
             adapter = CustomJSONLAdapter(source)
+        elif adapter_hint == "grpo":
+            adapter = GRPOAdapter(source)
         elif adapter_hint == "flexible":
             adapter = FlexibleDataAdapter(
                 source,
@@ -206,7 +209,7 @@ def ingest_runs_to_events(
 
     Args:
         source: Path to logs directory, file, or wandb:// URI
-        adapter_hint: Optional hint for adapter type ('trl', 'openrlhf', 'wandb', 'custom_jsonl', 'flexible')
+        adapter_hint: Optional hint for adapter type ('trl', 'openrlhf', 'wandb', 'custom_jsonl', 'grpo', 'flexible')
         field_map: Optional explicit mapping from canonical to actual field names
         config_file: Optional path to YAML/JSON config file with field mapping
         validation_mode: Validation strictness - 'strict', 'flexible', or 'lenient'
@@ -264,6 +267,11 @@ def _detect_adapter_type(source: Union[str, Path]) -> str:
     openrlhf_adapter = OpenRLHFAdapter(source_path)
     if openrlhf_adapter.can_handle():
         return "openrlhf"
+
+    # Check for GRPO-specific patterns before falling back to flexible adapter
+    grpo_adapter = GRPOAdapter(source_path)
+    if grpo_adapter.can_handle():
+        return "grpo"
 
     # Default to flexible adapter for better field resolution
     return "flexible"

--- a/tests/integration/test_grpo_ingestion.py
+++ b/tests/integration/test_grpo_ingestion.py
@@ -1,0 +1,66 @@
+"""Integration tests for the GRPO adapter ingestion path."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from rldk.ingest import ingest_runs
+
+
+FIXTURES = Path("test_artifacts/logs_grpo")
+
+
+def _assert_canonical_columns(df: pd.DataFrame) -> None:
+    canonical_columns = ["step", "reward_mean", "reward_std", "kl_mean", "entropy_mean"]
+    for column in canonical_columns:
+        assert column in df.columns, f"Missing canonical column {column}"
+        assert df[column].notna().any(), f"Canonical column {column} should contain values"
+
+
+def _assert_grpo_specific_columns(df: pd.DataFrame) -> None:
+    grpo_columns = [
+        "advantage_mean",
+        "advantage_std",
+        "grad_norm_policy",
+        "grad_norm_value",
+        "kl_coef",
+    ]
+    for column in grpo_columns:
+        assert column in df.columns, f"Missing GRPO specific column {column}"
+        assert df[column].notna().any(), f"Expected GRPO column {column} to contain values"
+
+
+def test_grpo_ingest_seed_directory() -> None:
+    """Each seeded run should ingest with canonical and GRPO-specific metrics."""
+    seed_path = FIXTURES / "seed_1"
+    df = ingest_runs(seed_path, adapter_hint="grpo")
+
+    assert not df.empty
+    _assert_canonical_columns(df)
+    _assert_grpo_specific_columns(df)
+    assert df["seed"].nunique() == 1
+    assert set(df["seed"].dropna()) == {1}
+
+
+def test_grpo_ingest_seed_run_file() -> None:
+    """Loading a specific run.jsonl file should preserve canonical and extra metrics."""
+    run_path = FIXTURES / "seed_2" / "run.jsonl"
+    df = ingest_runs(run_path, adapter_hint="grpo")
+
+    assert not df.empty
+    _assert_canonical_columns(df)
+    _assert_grpo_specific_columns(df)
+    assert df["run_id"].iloc[0] == "seed_2"
+
+
+def test_grpo_ingest_multiple_seeds() -> None:
+    """Aggregating the directory should keep seed-level metadata available."""
+    df = ingest_runs(FIXTURES, adapter_hint="grpo")
+
+    assert not df.empty
+    _assert_canonical_columns(df)
+    _assert_grpo_specific_columns(df)
+    assert df["seed"].nunique() == 3
+    assert set(df["run_id"].dropna()) == {"seed_1", "seed_2", "seed_3"}


### PR DESCRIPTION
## Summary
- add a GRPO adapter that reads run.jsonl logs and maps them onto the canonical training metrics schema while retaining GRPO-specific metrics
- expose the adapter through the ingest pipeline, including autodetection and adapter validation updates
- add integration tests that ingest the GRPO fixtures to ensure canonical columns and GRPO extras remain available

## Testing
- pytest tests/integration/test_grpo_ingestion.py

------
https://chatgpt.com/codex/tasks/task_e_68d1a6b5b94c832f90f97784816cce76