### PR TITLE
Add GRPO monitor presets and coverage

### DIFF
--- a/rules/grpo_safe.yaml
+++ b/rules/grpo_safe.yaml
@@ -1,0 +1,69 @@
+rules:
+  - id: grpo_safe_kl_spike
+    where: name in ("kl", "kl_mean", "policy_kl", "grpo/kl_mean")
+    condition: value > 0.30
+    window:
+      size: 2
+      kind: consecutive
+    grace_steps: 12
+    cooldown_steps: 12
+    actions:
+      - warn:
+          msg: "GRPO KL spike {value:.3f} at step {step}"
+      - stop:
+          msg: "Halting due to GRPO KL {value:.3f}"
+  - id: grpo_safe_kl_coef_stall
+    where: name in ("kl_coef", "kl_coeff", "kl_coefficient", "beta")
+    condition: max(value) - min(value) < 0.003
+    window:
+      size: 20
+      kind: rolling
+    grace_steps: 25
+    cooldown_steps: 30
+    actions:
+      - warn:
+          msg: "KL coefficient stalled near {value:.4f}"
+  - id: grpo_safe_advantage_collapse
+    where: name in ("advantage_std", "adv_std", "advantage_stddev")
+    condition: mean(value) < 0.35
+    window:
+      size: 8
+      kind: rolling
+    grace_steps: 12
+    cooldown_steps: 18
+    actions:
+      - warn:
+          msg: "Advantage variance collapsing: std {value:.3f}"
+  - id: grpo_safe_acceptance_swings
+    where: name in ("acceptance_rate", "accept_rate", "acceptance")
+    condition: max(value) - min(value) > 0.4
+    window:
+      size: 12
+      kind: rolling
+    grace_steps: 12
+    cooldown_steps: 20
+    actions:
+      - warn:
+          msg: "Acceptance rate swing detected (latest {value:.2f})"
+  - id: grpo_safe_entropy_floor
+    where: name in ("entropy", "entropy_mean", "policy_entropy")
+    condition: mean(value) < 1.8
+    window:
+      size: 10
+      kind: rolling
+    grace_steps: 15
+    cooldown_steps: 20
+    actions:
+      - warn:
+          msg: "Entropy below floor: {value:.3f}"
+  - id: grpo_safe_reward_saturation
+    where: name in ("reward_mean", "reward", "group_reward_mean")
+    condition: max(value) - min(value) < 0.05
+    window:
+      size: 30
+      kind: rolling
+    grace_steps: 30
+    cooldown_steps: 30
+    actions:
+      - warn:
+          msg: "Reward trend saturated around {value:.3f}"

--- a/rules/grpo_strict.yaml
+++ b/rules/grpo_strict.yaml
@@ -1,0 +1,79 @@
+rules:
+  - id: grpo_strict_kl_spike
+    where: name in ("kl", "kl_mean", "policy_kl", "grpo/kl_mean")
+    condition: value > 0.22
+    window:
+      size: 2
+      kind: consecutive
+    grace_steps: 8
+    cooldown_steps: 10
+    actions:
+      - warn:
+          msg: "Strict GRPO KL guard tripped at {value:.3f}"
+      - stop:
+          msg: "Stopping due to GRPO KL {value:.3f}"
+  - id: grpo_strict_kl_coef_stall
+    where: name in ("kl_coef", "kl_coeff", "kl_coefficient", "beta")
+    condition: max(value) - min(value) < 0.002
+    window:
+      size: 15
+      kind: rolling
+    grace_steps: 18
+    cooldown_steps: 25
+    actions:
+      - warn:
+          msg: "KL coefficient flatlined near {value:.4f}"
+      - stop:
+          msg: "Strict KL coefficient stall detected"
+  - id: grpo_strict_advantage_collapse
+    where: name in ("advantage_std", "adv_std", "advantage_stddev")
+    condition: mean(value) < 0.6
+    window:
+      size: 6
+      kind: rolling
+    grace_steps: 8
+    cooldown_steps: 14
+    actions:
+      - warn:
+          msg: "Advantage std collapsed to {value:.3f}"
+      - stop:
+          msg: "Stopping due to advantage variance collapse"
+  - id: grpo_strict_acceptance_swings
+    where: name in ("acceptance_rate", "accept_rate", "acceptance")
+    condition: max(value) - min(value) > 0.3
+    window:
+      size: 10
+      kind: rolling
+    grace_steps: 10
+    cooldown_steps: 18
+    actions:
+      - warn:
+          msg: "Acceptance rate unstable (latest {value:.2f})"
+      - stop:
+          msg: "Stopping due to acceptance-rate instability"
+  - id: grpo_strict_entropy_floor
+    where: name in ("entropy", "entropy_mean", "policy_entropy")
+    condition: mean(value) < 1.95
+    window:
+      size: 8
+      kind: rolling
+    grace_steps: 10
+    cooldown_steps: 15
+    actions:
+      - warn:
+          msg: "Entropy breached strict floor at {value:.3f}"
+      - stop:
+          msg: "Stopping due to entropy collapse"
+  - id: grpo_strict_reward_saturation
+    where: name in ("reward_mean", "reward", "group_reward_mean")
+    condition: max(value) - min(value) < 0.02
+    window:
+      size: 25
+      kind: rolling
+    grace_steps: 25
+    cooldown_steps: 25
+    actions:
+      - warn:
+          msg: "Rewards saturated around {value:.3f}"
+      - stop:
+          msg: "Stopping due to saturated rewards"

--- a/src/rldk/monitor/presets.py
+++ b/src/rldk/monitor/presets.py
@@ -9,6 +9,177 @@ FieldMapPreset = Dict[str, str]
 
 
 RULE_PRESETS: Dict[str, RulePreset] = {
+    "grpo_safe": {
+        "rules": [
+            {
+                "id": "grpo_safe_kl_spike",
+                "where": "name in (\"kl\", \"kl_mean\", \"policy_kl\", \"grpo/kl_mean\")",
+                "condition": "value > 0.30",
+                "window": {"size": 2, "kind": "consecutive"},
+                "grace_steps": 12,
+                "cooldown_steps": 12,
+                "actions": [
+                    {"warn": {"msg": "GRPO KL spike {value:.3f} at step {step}"}},
+                    {"stop": {"msg": "Halting due to GRPO KL {value:.3f}"}},
+                ],
+            },
+            {
+                "id": "grpo_safe_kl_coef_stall",
+                "where": "name in (\"kl_coef\", \"kl_coeff\", \"kl_coefficient\", \"beta\")",
+                "condition": "max(value) - min(value) < 0.003",
+                "window": {"size": 20, "kind": "rolling"},
+                "grace_steps": 25,
+                "cooldown_steps": 30,
+                "actions": [
+                    {
+                        "warn": {
+                            "msg": "KL coefficient stalled near {value:.4f}"
+                        }
+                    }
+                ],
+            },
+            {
+                "id": "grpo_safe_advantage_collapse",
+                "where": "name in (\"advantage_std\", \"adv_std\", \"advantage_stddev\")",
+                "condition": "mean(value) < 0.35",
+                "window": {"size": 8, "kind": "rolling"},
+                "grace_steps": 12,
+                "cooldown_steps": 18,
+                "actions": [
+                    {
+                        "warn": {
+                            "msg": "Advantage variance collapsing: std {value:.3f}"
+                        }
+                    }
+                ],
+            },
+            {
+                "id": "grpo_safe_acceptance_swings",
+                "where": "name in (\"acceptance_rate\", \"accept_rate\", \"acceptance\")",
+                "condition": "max(value) - min(value) > 0.4",
+                "window": {"size": 12, "kind": "rolling"},
+                "grace_steps": 12,
+                "cooldown_steps": 20,
+                "actions": [
+                    {
+                        "warn": {
+                            "msg": "Acceptance rate swing detected (latest {value:.2f})"
+                        }
+                    }
+                ],
+            },
+            {
+                "id": "grpo_safe_entropy_floor",
+                "where": "name in (\"entropy\", \"entropy_mean\", \"policy_entropy\")",
+                "condition": "mean(value) < 1.8",
+                "window": {"size": 10, "kind": "rolling"},
+                "grace_steps": 15,
+                "cooldown_steps": 20,
+                "actions": [
+                    {"warn": {"msg": "Entropy below floor: {value:.3f}"}},
+                ],
+            },
+            {
+                "id": "grpo_safe_reward_saturation",
+                "where": "name in (\"reward_mean\", \"reward\", \"group_reward_mean\")",
+                "condition": "max(value) - min(value) < 0.05",
+                "window": {"size": 30, "kind": "rolling"},
+                "grace_steps": 30,
+                "cooldown_steps": 30,
+                "actions": [
+                    {
+                        "warn": {
+                            "msg": "Reward trend saturated around {value:.3f}"
+                        }
+                    }
+                ],
+            },
+        ]
+    },
+    "grpo_strict": {
+        "rules": [
+            {
+                "id": "grpo_strict_kl_spike",
+                "where": "name in (\"kl\", \"kl_mean\", \"policy_kl\", \"grpo/kl_mean\")",
+                "condition": "value > 0.22",
+                "window": {"size": 2, "kind": "consecutive"},
+                "grace_steps": 8,
+                "cooldown_steps": 10,
+                "actions": [
+                    {"warn": {"msg": "Strict GRPO KL guard tripped at {value:.3f}"}},
+                    {"stop": {"msg": "Stopping due to GRPO KL {value:.3f}"}},
+                ],
+            },
+            {
+                "id": "grpo_strict_kl_coef_stall",
+                "where": "name in (\"kl_coef\", \"kl_coeff\", \"kl_coefficient\", \"beta\")",
+                "condition": "max(value) - min(value) < 0.002",
+                "window": {"size": 15, "kind": "rolling"},
+                "grace_steps": 18,
+                "cooldown_steps": 25,
+                "actions": [
+                    {
+                        "warn": {
+                            "msg": "KL coefficient flatlined near {value:.4f}"
+                        }
+                    },
+                    {
+                        "stop": {
+                            "msg": "Strict KL coefficient stall detected"
+                        }
+                    },
+                ],
+            },
+            {
+                "id": "grpo_strict_advantage_collapse",
+                "where": "name in (\"advantage_std\", \"adv_std\", \"advantage_stddev\")",
+                "condition": "mean(value) < 0.6",
+                "window": {"size": 6, "kind": "rolling"},
+                "grace_steps": 8,
+                "cooldown_steps": 14,
+                "actions": [
+                    {"warn": {"msg": "Advantage std collapsed to {value:.3f}"}},
+                    {"stop": {"msg": "Stopping due to advantage variance collapse"}},
+                ],
+            },
+            {
+                "id": "grpo_strict_acceptance_swings",
+                "where": "name in (\"acceptance_rate\", \"accept_rate\", \"acceptance\")",
+                "condition": "max(value) - min(value) > 0.3",
+                "window": {"size": 10, "kind": "rolling"},
+                "grace_steps": 10,
+                "cooldown_steps": 18,
+                "actions": [
+                    {"warn": {"msg": "Acceptance rate unstable (latest {value:.2f})"}},
+                    {"stop": {"msg": "Stopping due to acceptance-rate instability"}},
+                ],
+            },
+            {
+                "id": "grpo_strict_entropy_floor",
+                "where": "name in (\"entropy\", \"entropy_mean\", \"policy_entropy\")",
+                "condition": "mean(value) < 1.95",
+                "window": {"size": 8, "kind": "rolling"},
+                "grace_steps": 10,
+                "cooldown_steps": 15,
+                "actions": [
+                    {"warn": {"msg": "Entropy breached strict floor at {value:.3f}"}},
+                    {"stop": {"msg": "Stopping due to entropy collapse"}},
+                ],
+            },
+            {
+                "id": "grpo_strict_reward_saturation",
+                "where": "name in (\"reward_mean\", \"reward\", \"group_reward_mean\")",
+                "condition": "max(value) - min(value) < 0.02",
+                "window": {"size": 25, "kind": "rolling"},
+                "grace_steps": 25,
+                "cooldown_steps": 25,
+                "actions": [
+                    {"warn": {"msg": "Rewards saturated around {value:.3f}"}},
+                    {"stop": {"msg": "Stopping due to saturated rewards"}},
+                ],
+            },
+        ]
+    },
     "ppo_safe": {
         "rules": [
             {
@@ -376,6 +547,64 @@ RULE_PRESETS: Dict[str, RulePreset] = {
 
 
 FIELD_MAP_PRESETS: Dict[str, FieldMapPreset] = {
+    "grpo": {
+        "timestamp": "time",
+        "time": "time",
+        "wall_time": "time",
+        "global_step": "step",
+        "trainer_step": "step",
+        "step": "step",
+        "iteration": "step",
+        "epoch_step": "step",
+        "reward": "reward_mean",
+        "reward_mean": "reward_mean",
+        "normalized_reward_mean": "reward_mean",
+        "group_reward_mean": "reward_mean",
+        "reward_avg": "reward_mean",
+        "reward_std": "reward_std",
+        "reward_stddev": "reward_std",
+        "group_reward_std": "reward_std",
+        "kl": "kl",
+        "kl_mean": "kl",
+        "policy_kl": "kl",
+        "kl_avg": "kl",
+        "kl_value": "kl",
+        "kl_divergence": "kl",
+        "kl_coef": "kl_coef",
+        "kl_coeff": "kl_coef",
+        "kl_coefficient": "kl_coef",
+        "kl_beta": "kl_coef",
+        "beta": "kl_coef",
+        "entropy": "entropy",
+        "entropy_mean": "entropy",
+        "policy_entropy": "entropy",
+        "advantage_mean": "advantage_mean",
+        "adv_mean": "advantage_mean",
+        "normalized_advantage_mean": "advantage_mean",
+        "advantage_std": "advantage_std",
+        "adv_std": "advantage_std",
+        "advantage_stddev": "advantage_std",
+        "policy_grad_norm": "grad_norm_policy",
+        "pi_grad_norm": "grad_norm_policy",
+        "actor_grad_norm": "grad_norm_policy",
+        "grad_norm_policy": "grad_norm_policy",
+        "value_grad_norm": "grad_norm_value",
+        "critic_grad_norm": "grad_norm_value",
+        "grad_norm_value": "grad_norm_value",
+        "acceptance_rate": "acceptance_rate",
+        "accept_rate": "acceptance_rate",
+        "acceptance": "acceptance_rate",
+        "policy_acceptance_rate": "acceptance_rate",
+        "run": "run_id",
+        "run_id": "run_id",
+        "seed": "seed",
+        "phase": "phase",
+        "training_phase": "phase",
+        "tags": "tags",
+        "metadata": "meta",
+        "meta": "meta",
+        "context": "meta",
+    },
     "trl": {
         "timestamp": "time",
         "time": "time",

--- a/tests/test_monitor_grpo_presets.py
+++ b/tests/test_monitor_grpo_presets.py
@@ -1,0 +1,118 @@
+"""Tests for GRPO monitor presets."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import pytest
+
+from rldk.monitor import Alert, ActionExecutor, Event, MonitorEngine, load_rules
+from rldk.monitor.presets import get_rule_preset
+
+_FIXTURE_PATH = Path("test_artifacts/logs_grpo/seed_1/run.jsonl")
+
+
+class _NoopExecutor(ActionExecutor):
+    """Capture alerts without side effects for testing."""
+
+    def execute(self, action, rule, event, window):  # type: ignore[override]
+        return Alert(
+            rule_id=rule.id,
+            action=action.kind,
+            event=event,
+            window_size=rule.window_size,
+            window_kind=rule.window_kind,
+            message=None,
+            status="success",
+        )
+
+
+def _iter_fixture_events(metric_names: Sequence[str]) -> Iterable[Event]:
+    with _FIXTURE_PATH.open() as handle:
+        for line in handle:
+            payload = json.loads(line)
+            step = int(payload["step"])
+            timestamp = "2024-01-01T00:00:00Z"
+            for metric in metric_names:
+                value = payload.get(metric)
+                if value is None:
+                    continue
+                yield Event(
+                    time=timestamp,
+                    step=step,
+                    name=metric,
+                    value=float(value),
+                    run_id="seed_1",
+                )
+
+
+def _drain_events(engine: MonitorEngine, events: Iterable[Event]) -> set[str]:
+    fired: set[str] = set()
+    for event in events:
+        for alert in engine.process_event(event):
+            fired.add(alert.rule_id)
+    return fired
+
+
+def test_grpo_safe_preset_triggers_on_fixture_anomalies() -> None:
+    preset = get_rule_preset("grpo_safe")
+    assert preset is not None
+    rules = load_rules(preset)
+    engine = MonitorEngine(rules, action_executor=_NoopExecutor())
+
+    metrics = ["kl", "kl_coef", "reward_mean"]
+    fired = _drain_events(engine, _iter_fixture_events(metrics))
+
+    assert "grpo_safe_kl_spike" in fired
+    assert "grpo_safe_kl_coef_stall" in fired
+    assert "grpo_safe_reward_saturation" in fired
+
+
+@pytest.mark.parametrize(
+    "metric, values, expected_rule",
+    [
+        (
+            "entropy",
+            [1.7] * 8,
+            "grpo_strict_entropy_floor",
+        ),
+        (
+            "advantage_std",
+            [0.3] * 6,
+            "grpo_strict_advantage_collapse",
+        ),
+        (
+            "acceptance_rate",
+            [0.5, 0.55, 0.58, 0.6, 0.62, 0.1, 0.85, 0.12, 0.8, 0.15],
+            "grpo_strict_acceptance_swings",
+        ),
+    ],
+)
+def test_grpo_strict_preset_flags_strict_failures(
+    metric: str, values: Sequence[float], expected_rule: str
+) -> None:
+    preset = get_rule_preset("grpo_strict")
+    assert preset is not None
+    rules = load_rules(preset)
+    engine = MonitorEngine(rules, action_executor=_NoopExecutor())
+
+    baseline_metrics = ["kl", "kl_coef", "reward_mean", "entropy", "advantage_std"]
+    fired = _drain_events(engine, _iter_fixture_events(baseline_metrics))
+
+    for offset, value in enumerate(values, start=1):
+        event = Event(
+            time="2024-01-02T00:00:00Z",
+            step=1500 + offset,
+            name=metric,
+            value=float(value),
+            run_id="seed_1",
+        )
+        for alert in engine.process_event(event):
+            fired.add(alert.rule_id)
+
+    assert "grpo_strict_kl_spike" in fired
+    assert "grpo_strict_kl_coef_stall" in fired
+    assert "grpo_strict_reward_saturation" in fired
+    assert expected_rule in fired


### PR DESCRIPTION
## Summary
- add GRPO-safe and GRPO-strict monitor presets covering key GRPO failure modes
- map common GRPO logger keys to canonical field names via a new field-map preset and YAML presets
- validate the presets against GRPO fixtures with focused monitor engine tests

## Testing
- `pytest tests/test_monitor_grpo_presets.py`


------
https://chatgpt.com/codex/tasks/task_e_68d1ac6a7fb0832fbbf212b8e79a2a5a