### PR TITLE
Add GRPO monitoring demo and preset docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for RL Debug Kit Reference Suite
 
-.PHONY: help init lint test cli-smoke docs-serve reference\:cpu_smoke reference\:bisect_demo reference\:setup clean profile profile-check profile-train profile-dashboard profile-clean test-trl test-trl-unit test-trl-integration test-trl-slow golden-master-test monitor-demo
+.PHONY: help init lint test cli-smoke docs-serve reference\:cpu_smoke reference\:bisect_demo reference\:setup clean profile profile-check profile-train profile-dashboard profile-clean test-trl test-trl-unit test-trl-integration test-trl-slow golden-master-test monitor-demo monitor-grpo
 
 help:
 	@echo "RL Debug Kit Development Commands"
@@ -11,7 +11,8 @@ help:
 	@echo "  test                   - Run all tests"
 	@echo "  cli-smoke              - Run CLI smoke tests"
 	@echo "  docs-serve             - Serve documentation locally"
-	@echo "  monitor-demo           - Run the live monitoring demo with auto-stop"
+        @echo "  monitor-demo           - Run the live monitoring demo with auto-stop"
+        @echo "  monitor-grpo           - Stream the GRPO loop with grpo_safe rules"
 	@echo ""
 	@echo "Reference Suite targets:"
 	@echo "  reference:setup        - Setup reference runs for testing"
@@ -113,10 +114,10 @@ docs-build:
 	RLDK_COMMIT_SHORT=$$(git rev-parse --short HEAD) mkdocs build
 
 monitor-demo:
-	@echo "Running live monitoring demo..."
-	@set -eu; \
-		export PYTHONPATH="src$${PYTHONPATH:+:$${PYTHONPATH}}"; \
-		artifacts_dir=artifacts; \
+        @echo "Running live monitoring demo..."
+        @set -eu; \
+                export PYTHONPATH="src$${PYTHONPATH:+:$${PYTHONPATH}}"; \
+                artifacts_dir=artifacts; \
 		mkdir -p $$artifacts_dir; \
 		rm -f $$artifacts_dir/run.jsonl $$artifacts_dir/alerts.jsonl $$artifacts_dir/report.json $$artifacts_dir/demo_loop.log $$artifacts_dir/monitor.log; \
 		python examples/minimal_streaming_loop.py > $$artifacts_dir/demo_loop.log 2>&1 & \
@@ -136,9 +137,42 @@ monitor-demo:
 		cat $$artifacts_dir/monitor.log; \
 		echo "Alerts written to $$artifacts_dir/alerts.jsonl"; \
 		tail -n 5 $$artifacts_dir/alerts.jsonl 2>/dev/null || echo "No alerts recorded yet."; \
-		echo "Report available at $$artifacts_dir/report.json"; \
-		echo "Trainer stdout captured in $$artifacts_dir/demo_loop.log"; \
-		echo "✅ Monitor demo complete!"
+                echo "Report available at $$artifacts_dir/report.json"; \
+                echo "Trainer stdout captured in $$artifacts_dir/demo_loop.log"; \
+                echo "✅ Monitor demo complete!"
+
+monitor-grpo:
+        @echo "Running GRPO monitoring demo..."
+        @set -eu; \
+                export PYTHONPATH="src$${PYTHONPATH:+:$${PYTHONPATH}}"; \
+                artifacts_dir=artifacts; \
+                mkdir -p $$artifacts_dir; \
+                grpo_stream=$$artifacts_dir/grpo_run.jsonl; \
+                alerts_path=$$artifacts_dir/grpo_alerts.jsonl; \
+                report_path=$$artifacts_dir/grpo_report.json; \
+                loop_log=$$artifacts_dir/grpo_loop.log; \
+                monitor_log=$$artifacts_dir/grpo_monitor.log; \
+                rm -f $$grpo_stream $$alerts_path $$report_path $$loop_log $$monitor_log $$artifacts_dir/grpo_loop.pid; \
+                python examples/grpo_minimal_loop.py > $$loop_log 2>&1 & \
+                loop_pid=$$!; \
+                echo $$loop_pid > $$artifacts_dir/grpo_loop.pid; \
+                trap "kill -TERM $$loop_pid >/dev/null 2>&1 || true; wait $$loop_pid >/dev/null 2>&1 || true; rm -f $$artifacts_dir/grpo_loop.pid" EXIT; \
+                sleep 1; \
+                echo "Monitor attaching to PID $$loop_pid"; \
+                if command -v rldk >/dev/null 2>&1; then \
+                        timeout 20s rldk monitor --stream $$grpo_stream --rules grpo_safe --preset grpo --pid $$loop_pid --alerts $$alerts_path --report $$report_path > $$monitor_log 2>&1 || true; \
+                else \
+                        timeout 20s python -m rldk.cli monitor --stream $$grpo_stream --rules grpo_safe --preset grpo --pid $$loop_pid --alerts $$alerts_path --report $$report_path > $$monitor_log 2>&1 || true; \
+                fi; \
+                kill -TERM $$loop_pid >/dev/null 2>&1 || true; \
+                wait $$loop_pid >/dev/null 2>&1 || true; \
+                echo "Monitor output:"; \
+                cat $$monitor_log; \
+                echo "Alerts written to $$alerts_path"; \
+                tail -n 5 $$alerts_path 2>/dev/null || echo "No alerts recorded yet."; \
+                echo "Report available at $$report_path"; \
+                echo "Trainer stdout captured in $$loop_log"; \
+                echo "✅ GRPO monitor demo complete!"
 
 # Setup Reference Runs Target
 reference\:setup:

--- a/README.md
+++ b/README.md
@@ -133,12 +133,16 @@ with seed_context(123):
 
 ### **Live JSONL Monitoring (Framework-Agnostic)**
 Observe any trainer in real time by streaming JSONL metrics into the `rldk monitor` CLI. Built-in rule presets and field-map presets
-make it a zero-code add-on for PPO, TRL, Accelerate, and OpenRLHF workflows.
+make it a zero-code add-on for PPO/GRPO, TRL, Accelerate, and OpenRLHF workflows.
 
 ```bash
 # Stream the demo loop directly into the monitor (no files required)
 python examples/minimal_streaming_loop.py \
   | rldk monitor --rules ppo_safe --preset trl --alerts artifacts/alerts.jsonl
+
+# Stream the GRPO minimal loop with GRPO guardrails
+python examples/grpo_minimal_loop.py \
+  | rldk monitor --rules grpo_safe --preset grpo --alerts artifacts/grpo_alerts.jsonl
 
 # Or point the monitor at a directory of JSONL files (tails the newest)
 rldk monitor --stream artifacts --rules ppo_strict --preset accelerate --pid <trainer_pid>
@@ -174,6 +178,10 @@ f.write(__import__("json").dumps({
 f.flush()
 ```
 
+Want a ready-made GRPO stream? `examples/grpo_minimal_loop.py` emits `kl`, `kl_coef`, `entropy`, `advantage_std`, and more via
+`EventWriter`. Pair it with `rldk monitor --stream artifacts/grpo_run.jsonl --rules grpo_safe --preset grpo` or simply run
+`make monitor-grpo` to launch the script, attach the monitor, and capture alerts plus a report automatically.
+
 Pair either snippet with the ready-to-run `rules.yaml` in the repository root:
 
 ```bash
@@ -184,17 +192,25 @@ rldk monitor --stream artifacts/run.jsonl --rules kl_drift
 
 Want the full walkthrough with alerts and auto-stop baked in? Run `make monitor-demo` to launch
 `examples/minimal_streaming_loop.py`, attach the monitor, and review the resulting `artifacts/alerts.jsonl` and
-`artifacts/report.json` files.
+`artifacts/report.json` files. Prefer GRPO metrics? `make monitor-grpo` runs the GRPO minimal loop, wires up `--preset grpo`
+with `--rules grpo_safe`, and records the alerts plus report under `artifacts/` for inspection.
 
 Key conveniences:
 
-- **Rule presets** – `ppo_safe`, `ppo_strict`, `kl_drift`, and `dpo_basic` cover common KL, drift, reward, and gradient gates so you can start without writing YAML.
-- **Field-map presets** – `--preset trl|accelerate|openrlhf` normalizes popular logging key conventions; combine with `--field-map` for custom tweaks.
+- **Rule presets** – `ppo_safe`, `ppo_strict`, `grpo_safe`, `grpo_strict`, `kl_drift`, and `dpo_basic` cover common KL, drift, reward, and gradient gates so you can start without writing YAML.
+- **Field-map presets** – `--preset grpo|trl|accelerate|openrlhf` normalizes popular logging key conventions; combine with `--field-map` for custom tweaks.
 - **Directory tailing** – Passing a directory to `--stream` automatically follows the newest `*.jsonl` file and handles rotation.
 - **Environment hook** – Set `RLDK_METRICS_PATH` to auto-tail a metrics file without specifying `--stream`; piping JSONL to stdin also just works.
 - **Ready-made emitter** – `examples/minimal_streaming_loop.py` shows how to emit canonical events and responds to monitor stop actions out of the box.
 - **Hosted run bridges** – `--from-wandb` and `--from-mlflow` follow remote projects with clear error messages and retry guards.
 - **Regex sniffing** – `--regex` (for example `--regex trl`) extracts metrics from stdout/stderr without changing your training loop.
+
+**Choosing a GRPO preset**
+
+- `grpo_safe` keeps wider guard bands and primarily warns unless the KL spike or variance collapse persists. Use it for established
+  runs where you want to observe drift but avoid premature stops.
+- `grpo_strict` lowers KL and entropy ceilings, adds stop actions to most rules, and reacts faster to unstable acceptance rates.
+  Reach for it when onboarding fresh policies or enforcing production guardrails.
 
 ### **Reward Model Health Analysis**
 Comprehensive reward model analysis and drift detection:

--- a/examples/grpo_minimal_loop.py
+++ b/examples/grpo_minimal_loop.py
@@ -1,0 +1,130 @@
+import json
+import math
+import os
+import random
+import signal
+import sys
+import time
+from pathlib import Path
+from typing import Iterable, Sequence, Tuple
+
+from rldk.emit import EventWriter
+
+
+_STOP_REQUESTED = False
+
+
+def _request_stop(signum: int, frame) -> None:  # type: ignore[unused-argument]
+    global _STOP_REQUESTED
+    _STOP_REQUESTED = True
+
+
+def _install_signal_handlers(signals: Iterable[int]) -> None:
+    for sig in signals:
+        try:
+            signal.signal(sig, _request_stop)
+        except (ValueError, OSError):  # pragma: no cover - platform specific
+            continue
+
+
+def _generate_metrics(
+    step: int,
+    rng: random.Random,
+    kl_coef_state: float,
+) -> Tuple[float, Sequence[Tuple[str, float]]]:
+    """Create synthetic but GRPO-like metrics for the monitoring demo."""
+
+    kl_value = 0.06 + 0.0018 * step + rng.uniform(-0.012, 0.012)
+    if step > 180:
+        kl_value += 0.14
+
+    if step < 160:
+        kl_coef = max(0.02, min(0.12, kl_coef_state + 0.0006 + rng.uniform(-0.0004, 0.0004)))
+    else:
+        kl_coef = 0.08 + rng.uniform(-0.0008, 0.0008)
+
+    entropy = max(1.45, 2.4 - 0.0038 * step + rng.uniform(-0.035, 0.035))
+    advantage_std = max(0.18, 1.05 - 0.0052 * step + rng.uniform(-0.04, 0.04))
+    advantage_mean = rng.uniform(-0.03, 0.03) * (1.0 - min(step / 300.0, 1.0))
+
+    acceptance_rate = 0.55 + 0.27 * math.sin(step / 6.5) + rng.uniform(-0.035, 0.035)
+    acceptance_rate = min(max(acceptance_rate, 0.05), 0.95)
+
+    if step > 210:
+        reward_mean = 0.63 + rng.uniform(-0.015, 0.015)
+    else:
+        reward_mean = 0.44 + 0.12 * (1 - math.exp(-step / 55.0)) + rng.uniform(-0.012, 0.012)
+    reward_std = 0.12 + 0.02 * math.cos(step / 8.5) + rng.uniform(-0.012, 0.012)
+
+    grad_norm_policy = 2.1 + 0.013 * step + rng.uniform(-0.35, 0.35)
+    grad_norm_value = 1.6 + 0.009 * step + rng.uniform(-0.25, 0.25)
+
+    metrics: Sequence[Tuple[str, float]] = (
+        ("kl", kl_value),
+        ("kl_coef", kl_coef),
+        ("entropy", entropy),
+        ("advantage_std", advantage_std),
+        ("advantage_mean", advantage_mean),
+        ("acceptance_rate", acceptance_rate),
+        ("reward_mean", reward_mean),
+        ("reward_std", reward_std),
+        ("grad_norm_policy", grad_norm_policy),
+        ("grad_norm_value", grad_norm_value),
+    )
+    return kl_coef, metrics
+
+
+def main() -> int:
+    """Stream GRPO-style metrics and respond to monitor stop actions."""
+
+    artifacts_dir = Path("artifacts")
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    log_path = artifacts_dir / "grpo_run.jsonl"
+
+    _install_signal_handlers([signal.SIGINT, signal.SIGTERM])
+
+    print(f"📡 Streaming GRPO metrics from PID {os.getpid()} -> {log_path}", flush=True)
+    print(
+        "Attach another terminal with 'rldk monitor --stream artifacts/grpo_run.jsonl "
+        "--rules grpo_safe --preset grpo --pid "
+        f"{os.getpid()}' to watch the built-in GRPO guards.",
+        flush=True,
+    )
+    print("Press Ctrl+C to stop or allow an RLDK monitor stop action to terminate the loop.", flush=True)
+
+    rng = random.Random(314)
+    max_steps = 320
+    start_time = time.time()
+    kl_coef = 0.03
+
+    with EventWriter(log_path) as writer:
+        for step in range(1, max_steps + 1):
+            if _STOP_REQUESTED:
+                break
+
+            kl_coef, metrics = _generate_metrics(step, rng, kl_coef)
+
+            for name, value in metrics:
+                event = writer.log(
+                    step=step,
+                    name=name,
+                    value=float(value),
+                    tags={"trainer": "grpo_demo"},
+                    meta={"source": "grpo_minimal_loop", "preset": "grpo"},
+                )
+                sys.stdout.write(json.dumps(event) + "\n")
+                sys.stdout.flush()
+
+            time.sleep(0.05)
+
+    duration = time.time() - start_time
+    print(f"✅ Loop finished after {duration:.2f}s and {step} steps", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        print("Interrupted by user", file=sys.stderr)
+        sys.exit(1)

--- a/src/rldk/cli.py
+++ b/src/rldk/cli.py
@@ -297,7 +297,7 @@ def monitor(
             "Field map preset to normalize common trainer keys"
             f" ({', '.join(sorted(FIELD_MAP_PRESETS))})"
             if FIELD_MAP_PRESETS
-            else "Field map preset name (e.g. trl)."
+            else "Field map preset name (e.g. trl, grpo)."
         ),
     ),
     field_map: Optional[str] = typer.Option(
@@ -985,7 +985,7 @@ def forensics_kl_drift(
     preset: Optional[str] = typer.Option(
         None,
         "--preset",
-        help="Field map preset for the metrics source (e.g. trl, accelerate)",
+        help="Field map preset for the metrics source (e.g. trl, grpo, accelerate)",
     ),
     field_map: Optional[str] = typer.Option(
         None,
@@ -1978,7 +1978,7 @@ def evaluate(
             "Field map preset to normalize training metrics "
             f"({', '.join(sorted(FIELD_MAP_PRESETS))})"
             if FIELD_MAP_PRESETS
-            else "Field map preset name (e.g. trl)."
+            else "Field map preset name (e.g. trl, grpo)."
         ),
     ),
     field_map: Optional[str] = typer.Option(
@@ -2582,7 +2582,7 @@ def diff(
             "Field map preset to normalize training metrics"
             f" ({', '.join(sorted(FIELD_MAP_PRESETS))})"
             if FIELD_MAP_PRESETS
-            else "Field map preset name (e.g. trl)."
+            else "Field map preset name (e.g. trl, grpo)."
         ),
     ),
     field_map: Optional[str] = typer.Option(
@@ -2852,7 +2852,7 @@ def reward_health(
             "Field map preset to normalize training metrics"
             f" ({', '.join(sorted(FIELD_MAP_PRESETS))})"
             if FIELD_MAP_PRESETS
-            else "Field map preset name (e.g. trl)."
+            else "Field map preset name (e.g. trl, grpo)."
         ),
     ),
     field_map: Optional[str] = typer.Option(
@@ -3689,7 +3689,7 @@ def card(
             "Field map preset to normalize training metrics"
             f" ({', '.join(sorted(FIELD_MAP_PRESETS))})"
             if FIELD_MAP_PRESETS
-            else "Field map preset name (e.g. trl)."
+            else "Field map preset name (e.g. trl, grpo)."
         ),
     ),
     field_map: Optional[str] = typer.Option(

--- a/src/rldk/monitor/engine.py
+++ b/src/rldk/monitor/engine.py
@@ -30,7 +30,7 @@ from typing import (
 
 import yaml
 
-from .presets import RULE_PRESETS, get_rule_preset
+from .presets import FIELD_MAP_PRESETS, RULE_PRESETS, get_field_map_preset, get_rule_preset
 from .regexes import create_line_parser
 
 logger = logging.getLogger(__name__)
@@ -38,6 +38,8 @@ logger = logging.getLogger(__name__)
 CANONICAL_FIELDS = {"time", "step", "name", "value", "run_id", "tags", "meta"}
 DEFAULT_WINDOW_KIND = "consecutive"
 AGGREGATOR_FUNCTIONS = {"mean", "max", "min", "any", "all", "sum", "count"}
+
+FieldMapSpec = Optional[Mapping[str, str] | str]
 
 DEFAULT_ACTION_MESSAGES: Dict[str, str] = {
     "warn": "{name} {value:.4f} at step {step} (rule {rule_id})",
@@ -405,7 +407,25 @@ def _canonical_time(value: Any) -> str:
     raise ValueError(f"Unsupported time value type: {type(value).__name__}")
 
 
-def _apply_field_map(event: Dict[str, Any], field_map: Optional[Dict[str, str]]) -> Dict[str, Any]:
+def _resolve_field_map(field_map: FieldMapSpec) -> Optional[Dict[str, str]]:
+    if field_map is None:
+        return None
+    if isinstance(field_map, dict):
+        return field_map
+    if isinstance(field_map, str):
+        preset = get_field_map_preset(field_map)
+        if preset is None:
+            available = ", ".join(sorted(FIELD_MAP_PRESETS))
+            raise ValueError(
+                f"Unknown field map preset '{field_map}'. Available presets: {available}"
+            )
+        return preset
+    if isinstance(field_map, Mapping):
+        return dict(field_map)
+    raise TypeError("field_map must be a mapping or preset name")
+
+
+def _apply_field_map(event: Dict[str, Any], field_map: Optional[Mapping[str, str]]) -> Dict[str, Any]:
     if not field_map:
         return dict(event)
     mapped: Dict[str, Any] = {}
@@ -415,8 +435,9 @@ def _apply_field_map(event: Dict[str, Any], field_map: Optional[Dict[str, str]])
     return mapped
 
 
-def canonicalize_event(payload: Dict[str, Any], field_map: Optional[Dict[str, str]] = None) -> Event:
-    mapped = _apply_field_map(payload, field_map)
+def canonicalize_event(payload: Dict[str, Any], field_map: FieldMapSpec = None) -> Event:
+    resolved_field_map = _resolve_field_map(field_map)
+    mapped = _apply_field_map(payload, resolved_field_map)
     missing = [field for field in ("time", "step", "name", "value") if field not in mapped]
     if missing:
         raise ValueError(f"Event missing required fields: {', '.join(missing)}")
@@ -450,7 +471,7 @@ def canonicalize_event(payload: Dict[str, Any], field_map: Optional[Dict[str, st
 
 def read_events_once(
     path: str | os.PathLike[str],
-    field_map: Optional[Dict[str, str]] = None,
+    field_map: FieldMapSpec = None,
     regex: Optional[str] = None,
 ) -> List[Event]:
     path_obj = Path(path)
@@ -474,6 +495,7 @@ def read_events_once(
 
         opener = _open_text
     parser = create_line_parser(regex) if regex else None
+    resolved_field_map = _resolve_field_map(field_map)
     events: List[Event] = []
     auto_step = 0
 
@@ -493,7 +515,7 @@ def read_events_once(
                 logger.warning("Failed to parse JSON event: %s", exc)
                 continue
             try:
-                events.append(canonicalize_event(payload, field_map))
+                events.append(canonicalize_event(payload, resolved_field_map))
             except ValueError as exc:
                 logger.warning("Skipping invalid event: %s", exc)
         else:
@@ -507,7 +529,7 @@ def read_events_once(
                 data.setdefault("time", _now_iso())
                 data.setdefault("step", _next_auto_step())
                 try:
-                    events.append(canonicalize_event(data, field_map))
+                    events.append(canonicalize_event(data, resolved_field_map))
                 except ValueError as exc:
                     logger.warning("Skipping invalid parsed event: %s", exc)
     return events
@@ -515,13 +537,14 @@ def read_events_once(
 
 def read_stream(
     path_or_stdin: str | os.PathLike[str],
-    field_map: Optional[Dict[str, str]] = None,
+    field_map: FieldMapSpec = None,
     regex: Optional[str] = None,
     poll_interval: float = 0.5,
 ) -> Iterator[Event]:
     """Yield canonical events from a stream, following file rotations."""
 
     parser = create_line_parser(regex) if regex else None
+    resolved_field_map = _resolve_field_map(field_map)
     auto_step = 0
 
     def _next_auto_step() -> int:
@@ -538,7 +561,7 @@ def read_stream(
                 logger.warning("Failed to parse JSON event: %s", exc)
                 return []
             try:
-                event = canonicalize_event(payload, field_map)
+                event = canonicalize_event(payload, resolved_field_map)
                 auto_step = max(auto_step, event.step)
                 return [event]
             except ValueError as exc:
@@ -555,7 +578,7 @@ def read_stream(
             data.setdefault("time", _now_iso())
             data.setdefault("step", _next_auto_step())
             try:
-                event = canonicalize_event(data, field_map)
+                event = canonicalize_event(data, resolved_field_map)
                 auto_step = max(auto_step, event.step)
                 events.append(event)
             except ValueError as exc:


### PR DESCRIPTION
## Summary
- include the `grpo` preset in CLI help strings and let the monitor resolve preset names when reading events or streaming
- add a GRPO minimal loop example plus a `make monitor-grpo` helper for running it with the safe rules
- document how to pick between `grpo_safe` and `grpo_strict` and reference the new script in the README

## Testing
- python -m compileall src/rldk/cli.py src/rldk/monitor/engine.py examples/grpo_minimal_loop.py


------
https://chatgpt.com/codex/tasks/task_e_68d1b16c1030832fb6afe46008b82b88