### PR TITLE
Handle monitor cooldown when steps reset

### DIFF
--- a/src/rldk/monitor/engine.py
+++ b/src/rldk/monitor/engine.py
@@ -782,9 +782,13 @@ class MonitorEngine:
                 continue
             if self._counts[rule.id][key] < max(rule.grace_steps, 0):
                 continue
-            last_step = self._cooldowns[rule.id].get(key)
-            if last_step is not None and event.step <= last_step + max(rule.cooldown_steps, 0):
-                continue
+            cooldown_map = self._cooldowns[rule.id]
+            last_step = cooldown_map.get(key)
+            if last_step is not None:
+                if event.step < last_step:
+                    cooldown_map.pop(key, None)
+                elif event.step <= last_step + max(rule.cooldown_steps, 0):
+                    continue
             window_snapshot = tuple(buffer)
             try:
                 evaluation = rule.condition.evaluate(

--- a/tests/test_monitor_grpo_presets.py
+++ b/tests/test_monitor_grpo_presets.py
@@ -116,3 +116,47 @@ def test_grpo_strict_preset_flags_strict_failures(
     assert "grpo_strict_kl_coef_stall" in fired
     assert "grpo_strict_reward_saturation" in fired
     assert expected_rule in fired
+
+
+def test_grpo_safe_kl_spike_triggers_after_step_reset() -> None:
+    preset = get_rule_preset("grpo_safe")
+    assert preset is not None
+    rules = load_rules(preset)
+    engine = MonitorEngine(rules, action_executor=_NoopExecutor())
+
+    def make_event(step: int, value: float) -> Event:
+        return Event(
+            time="2024-01-03T00:00:00Z",
+            step=step,
+            name="kl",
+            value=value,
+            run_id="step_reset",
+        )
+
+    fired_steps: list[int] = []
+
+    # Prime the rule to satisfy the configured grace period.
+    for step in range(1, 13):
+        engine.process_event(make_event(step, 0.1))
+
+    # First spike with monotonically increasing steps.
+    for step in (13, 14):
+        alerts = engine.process_event(make_event(step, 0.45))
+        fired_steps.extend(
+            alert.event.step
+            for alert in alerts
+            if alert.rule_id == "grpo_safe_kl_spike"
+        )
+
+    assert 14 in fired_steps
+
+    # Step counter resets; cooldown state should be cleared and allow a new alert.
+    for step, value in ((4, 0.1), (5, 0.5), (6, 0.55)):
+        alerts = engine.process_event(make_event(step, value))
+        fired_steps.extend(
+            alert.event.step
+            for alert in alerts
+            if alert.rule_id == "grpo_safe_kl_spike"
+        )
+
+    assert 6 in fired_steps


### PR DESCRIPTION
## Summary
- reset stored cooldown entries when the monitored step counter decreases
- guard the cooldown comparison so it only applies to non-decreasing steps
- add a regression test covering GRPO KL spikes after a step reset

## Testing
- pytest tests/test_monitor_grpo_presets.py

------
https://chatgpt.com/codex/tasks/task_e_68d1c93af18c832fb77b6035a539a101