### PR TITLE
Guard manual network diagnostics and add focused regressions

### DIFF
--- a/tests/manual/conftest.py
+++ b/tests/manual/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytestmark = pytest.mark.skip(reason="manual diagnostic run")

--- a/tests/manual/test_network_thread_safety_fixed.py
+++ b/tests/manual/test_network_thread_safety_fixed.py
@@ -5,7 +5,9 @@ import sys
 import time
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Dict, Iterator
 from unittest.mock import MagicMock
 
 import pytest
@@ -13,6 +15,60 @@ import pytest
 import _path_setup  # noqa: F401
 
 SRC_PATH = (_path_setup.PROJECT_ROOT / "src").resolve()
+
+
+@contextmanager
+def manual_network_monitor_components() -> Iterator[Dict[str, object]]:
+    """Provide network monitor components for manual execution with sys.modules patches."""
+
+    original_modules: Dict[str, object] = {}
+
+    def _patch_module(name: str, value: object) -> None:
+        if name not in original_modules:
+            original_modules[name] = sys.modules.get(name)
+        if value is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = value
+
+    psutil_mock = MagicMock()
+    numpy_mock = MagicMock()
+    torch_mock = MagicMock()
+    torch_mock.__spec__ = importlib.util.spec_from_loader("torch", loader=None)
+    torch_distributed_mock = MagicMock()
+    torch_distributed_mock.__spec__ = importlib.util.spec_from_loader(
+        "torch.distributed", loader=None
+    )
+
+    _patch_module('psutil', psutil_mock)
+    _patch_module('numpy', numpy_mock)
+    _patch_module('torch', torch_mock)
+    _patch_module('torch.distributed', torch_distributed_mock)
+
+    module = _load_network_monitor_module()
+    _patch_module('network_monitor', module)
+
+    components = {
+        'psutil_mock': psutil_mock,
+        'numpy_mock': numpy_mock,
+        'torch_mock': torch_mock,
+        'torch_distributed_mock': torch_distributed_mock,
+        'NetworkDiagnostics': module.NetworkDiagnostics,
+        'NetworkInterfaceMonitor': module.NetworkInterfaceMonitor,
+        'NetworkLatencyMonitor': module.NetworkLatencyMonitor,
+        'NetworkBandwidthMonitor': module.NetworkBandwidthMonitor,
+        'DistributedNetworkMonitor': module.DistributedNetworkMonitor,
+        'RealNetworkMonitor': module.RealNetworkMonitor,
+    }
+
+    try:
+        yield components
+    finally:
+        for name, original in original_modules.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
 
 
 def _load_network_monitor_module() -> object:
@@ -508,33 +564,37 @@ def test_double_sampling_fix(network_monitor_components):
     print("✓ Double sampling frequency fix test passed")
 
 
-def main():
-    """Run all tests."""
+def main() -> int:
+    """Run all tests with manual sys.modules patches applied."""
+
     print("Running network monitoring thread safety tests...\n")
 
     try:
-        test_network_diagnostics_thread_safety()
-        test_network_interface_monitor_thread_safety()
-        test_network_latency_monitor_thread_safety()
-        test_network_bandwidth_monitor_thread_safety()
-        test_distributed_network_monitor_thread_safety()
-        test_real_network_monitor_thread_safety()
-        test_memory_bounds_enforcement()
-        test_sampling_frequency_control()
-        test_lock_uniqueness()
-        test_concurrent_read_write_operations()
-        test_double_sampling_fix()
+        with manual_network_monitor_components() as components:
+            test_mocked_torch_module_has_spec(components)
+            test_network_diagnostics_thread_safety(components)
+            test_network_interface_monitor_thread_safety(components)
+            test_network_latency_monitor_thread_safety(components)
+            test_network_bandwidth_monitor_thread_safety(components)
+            test_distributed_network_monitor_thread_safety(components)
+            test_real_network_monitor_thread_safety(components)
+            test_memory_bounds_enforcement(components)
+            test_sampling_frequency_control(components)
+            test_lock_uniqueness(components)
+            test_concurrent_read_write_operations(components)
+            test_double_sampling_fix(components)
 
         print("\n🎉 All tests passed! Network monitoring is thread-safe and memory-bounded.")
 
-    except Exception as e:
+    except Exception as e:  # pragma: no cover - manual diagnostics path
         print(f"\n❌ Test failed: {e}")
         import traceback
+
         traceback.print_exc()
         return 1
 
     return 0
 
 
-if __name__ == "__main__":
-    exit(main())
+if __name__ == "__main__":  # pragma: no cover - manual diagnostics entry point
+    sys.exit(main())

--- a/tests/manual/test_network_thread_safety_minimal.py
+++ b/tests/manual/test_network_thread_safety_minimal.py
@@ -7,6 +7,8 @@ import threading
 import time
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import contextmanager
+from typing import Dict, Iterator
 from unittest.mock import MagicMock
 
 import pytest
@@ -14,6 +16,60 @@ import pytest
 import _path_setup  # noqa: F401
 
 SRC_PATH = (_path_setup.PROJECT_ROOT / "src").resolve()
+
+
+@contextmanager
+def manual_network_monitor_components() -> Iterator[Dict[str, object]]:
+    """Provide network monitor components for manual execution with sys.modules patches."""
+
+    original_modules: Dict[str, object] = {}
+
+    def _patch_module(name: str, value: object) -> None:
+        if name not in original_modules:
+            original_modules[name] = sys.modules.get(name)
+        if value is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = value
+
+    psutil_mock = MagicMock()
+    numpy_mock = MagicMock()
+    torch_mock = MagicMock()
+    torch_mock.__spec__ = importlib.util.spec_from_loader("torch", loader=None)
+    torch_distributed_mock = MagicMock()
+    torch_distributed_mock.__spec__ = importlib.util.spec_from_loader(
+        "torch.distributed", loader=None
+    )
+
+    _patch_module('psutil', psutil_mock)
+    _patch_module('numpy', numpy_mock)
+    _patch_module('torch', torch_mock)
+    _patch_module('torch.distributed', torch_distributed_mock)
+
+    module = _load_network_monitor_module()
+    _patch_module('network_monitor', module)
+
+    components = {
+        'psutil_mock': psutil_mock,
+        'numpy_mock': numpy_mock,
+        'torch_mock': torch_mock,
+        'torch_distributed_mock': torch_distributed_mock,
+        'NetworkDiagnostics': module.NetworkDiagnostics,
+        'NetworkInterfaceMonitor': module.NetworkInterfaceMonitor,
+        'NetworkLatencyMonitor': module.NetworkLatencyMonitor,
+        'NetworkBandwidthMonitor': module.NetworkBandwidthMonitor,
+        'DistributedNetworkMonitor': module.DistributedNetworkMonitor,
+        'RealNetworkMonitor': module.RealNetworkMonitor,
+    }
+
+    try:
+        yield components
+    finally:
+        for name, original in original_modules.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
 
 
 def _load_network_monitor_module() -> object:
@@ -469,32 +525,36 @@ def test_concurrent_read_write_operations(network_monitor_components):
     print("✓ Concurrent read/write operations test passed")
 
 
-def main():
-    """Run all tests."""
+def main() -> int:
+    """Run all tests with manual sys.modules patches applied."""
+
     print("Running network monitoring thread safety tests...\n")
 
     try:
-        test_network_diagnostics_thread_safety()
-        test_network_interface_monitor_thread_safety()
-        test_network_latency_monitor_thread_safety()
-        test_network_bandwidth_monitor_thread_safety()
-        test_distributed_network_monitor_thread_safety()
-        test_real_network_monitor_thread_safety()
-        test_memory_bounds_enforcement()
-        test_sampling_frequency_control()
-        test_lock_uniqueness()
-        test_concurrent_read_write_operations()
+        with manual_network_monitor_components() as components:
+            test_torch_mock_sets_module_spec(components)
+            test_network_diagnostics_thread_safety(components)
+            test_network_interface_monitor_thread_safety(components)
+            test_network_latency_monitor_thread_safety(components)
+            test_network_bandwidth_monitor_thread_safety(components)
+            test_distributed_network_monitor_thread_safety(components)
+            test_real_network_monitor_thread_safety(components)
+            test_memory_bounds_enforcement(components)
+            test_sampling_frequency_control(components)
+            test_lock_uniqueness(components)
+            test_concurrent_read_write_operations(components)
 
         print("\n🎉 All tests passed! Network monitoring is thread-safe and memory-bounded.")
 
-    except Exception as e:
+    except Exception as e:  # pragma: no cover - manual diagnostics path
         print(f"\n❌ Test failed: {e}")
         import traceback
+
         traceback.print_exc()
         return 1
 
     return 0
 
 
-if __name__ == "__main__":
-    exit(main())
+if __name__ == "__main__":  # pragma: no cover - manual diagnostics entry point
+    sys.exit(main())

--- a/tests/unit/test_network_monitor_regressions.py
+++ b/tests/unit/test_network_monitor_regressions.py
@@ -1,0 +1,194 @@
+"""Targeted regression tests extracted from manual network diagnostics."""
+
+from itertools import count
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from rldk.integrations.openrlhf import network_monitor
+
+
+@pytest.fixture
+def stub_psutil(monkeypatch):
+    """Provide deterministic psutil responses for network monitor tests."""
+
+    data_sequence = [
+        {
+            'bytes_recv': 1_000,
+            'bytes_sent': 500,
+            'packets_recv': 10,
+            'packets_sent': 5,
+            'dropin': 0,
+            'dropout': 0,
+            'errin': 0,
+            'errout': 0,
+        },
+        {
+            'bytes_recv': 1_600,
+            'bytes_sent': 800,
+            'packets_recv': 16,
+            'packets_sent': 9,
+            'dropin': 0,
+            'dropout': 0,
+            'errin': 0,
+            'errout': 0,
+        },
+        {
+            'bytes_recv': 2_200,
+            'bytes_sent': 1_100,
+            'packets_recv': 22,
+            'packets_sent': 13,
+            'dropin': 0,
+            'dropout': 0,
+            'errin': 0,
+            'errout': 0,
+        },
+    ]
+    call_index = {'value': 0}
+
+    def fake_net_if_stats():
+        return {'eth0': SimpleNamespace(isup=True)}
+
+    def fake_net_io_counters(pernic=True):
+        idx = call_index['value']
+        if idx >= len(data_sequence):
+            idx = len(data_sequence) - 1
+        call_index['value'] += 1
+        return {'eth0': SimpleNamespace(**data_sequence[idx])}
+
+    monkeypatch.setattr(network_monitor.psutil, 'net_if_stats', fake_net_if_stats)
+    monkeypatch.setattr(network_monitor.psutil, 'net_io_counters', fake_net_io_counters)
+    monkeypatch.setattr(network_monitor.psutil, 'net_connections', lambda: [])
+
+    yield
+
+
+@pytest.fixture
+def fake_time(monkeypatch):
+    """Provide a deterministic clock so rate calculations are stable."""
+
+    clock = count()
+    monkeypatch.setattr(network_monitor.time, 'time', lambda: next(clock))
+    yield
+
+
+def test_interface_monitor_sampling_frequency(stub_psutil, fake_time):
+    """NetworkInterfaceMonitor should respect sampling frequency and produce rates."""
+
+    monitor = network_monitor.NetworkInterfaceMonitor(sampling_frequency=3)
+    empty_stats = monitor._empty_stats()
+
+    results = [monitor.get_interface_stats() for _ in range(6)]
+    empty_count = sum(1 for result in results if result == empty_stats)
+
+    assert empty_count == 5  # First five calls skip due to sampling/baseline setup
+
+    final_result = results[-1]
+    assert final_result != empty_stats
+    assert final_result['bytes_in_per_sec'] > 0
+    assert final_result['bytes_out_per_sec'] > 0
+    assert final_result['packets_in_per_sec'] > 0
+    assert final_result['packets_out_per_sec'] > 0
+    assert monitor._invocation_count == 6
+
+
+def test_latency_monitor_history_bounds():
+    """Latency history deques should enforce configured bounds."""
+
+    monitor = network_monitor.NetworkLatencyMonitor()
+
+    for i in range(150):
+        with monitor._lock:
+            for history in monitor.latency_history.values():
+                history.append(float(i))
+
+    for history in monitor.latency_history.values():
+        assert len(history) == monitor.max_history_size
+        assert history.maxlen == monitor.max_history_size
+
+
+def test_distributed_monitor_history_bounds(stub_psutil):
+    """Distributed monitor histories must remain bounded."""
+
+    monitor = network_monitor.DistributedNetworkMonitor()
+
+    with monitor._distributed_lock:
+        for i in range(150):
+            monitor.allreduce_times.append(i)
+            monitor.broadcast_times.append(i)
+            monitor.gather_times.append(i)
+            monitor.scatter_times.append(i)
+
+        for i in range(1_100):
+            monitor.performance_history.append(i)
+
+    assert len(monitor.allreduce_times) == 100
+    assert monitor.allreduce_times.maxlen == 100
+    assert len(monitor.broadcast_times) == 100
+    assert monitor.broadcast_times.maxlen == 100
+    assert len(monitor.gather_times) == 100
+    assert monitor.gather_times.maxlen == 100
+    assert len(monitor.scatter_times) == 100
+    assert monitor.scatter_times.maxlen == 100
+    assert len(monitor.performance_history) == 1_000
+    assert monitor.performance_history.maxlen == 1_000
+
+
+def test_real_monitor_history_bounds(stub_psutil):
+    """RealNetworkMonitor should bound historical measurements."""
+
+    monitor = network_monitor.RealNetworkMonitor(enable_distributed_monitoring=False)
+
+    with monitor._history_lock:
+        for i in range(150):
+            monitor.bandwidth_history.append(float(i))
+            monitor.latency_history.append(float(i))
+
+    assert len(monitor.bandwidth_history) == 100
+    assert monitor.bandwidth_history.maxlen == 100
+    assert len(monitor.latency_history) == 100
+    assert monitor.latency_history.maxlen == 100
+
+
+def test_distributed_monitor_sampling_invokes_submonitors(stub_psutil, fake_time, monkeypatch):
+    """Distributed monitor should sample sub-monitors when allowed by frequency."""
+
+    monitor = network_monitor.DistributedNetworkMonitor(sampling_frequency=3)
+
+    interface_stats = {
+        'bytes_in_per_sec': 0.5,
+        'bytes_out_per_sec': 0.75,
+        'packets_in_per_sec': 1.0,
+        'packets_out_per_sec': 1.5,
+        'bytes_in_mbps': 1.0,
+        'bytes_out_mbps': 1.5,
+        'total_bytes_recv': 0.0,
+        'total_bytes_sent': 0.0,
+        'total_packets_recv': 0.0,
+        'total_packets_sent': 0.0,
+        'dropin': 0.0,
+        'dropout': 0.0,
+        'errin': 0.0,
+        'errout': 0.0,
+    }
+
+    monitor.interface_monitor.get_interface_stats = MagicMock(return_value=interface_stats)
+    monitor.latency_monitor.measure_latency = MagicMock(return_value={'example': 1.2})
+    monitor.latency_monitor.get_average_latency = MagicMock(return_value=12.5)
+    monitor.bandwidth_monitor.measure_bandwidth = MagicMock(return_value=42.0)
+
+    monkeypatch.setattr(network_monitor.psutil, 'net_connections', lambda: [])
+
+    for _ in range(10):
+        monitor.measure_distributed_metrics()
+
+    assert monitor._invocation_count == 10
+    assert monitor.interface_monitor.get_interface_stats.call_count == 3
+    assert monitor.latency_monitor.measure_latency.call_count == 3
+    assert monitor.latency_monitor.get_average_latency.call_count == 3
+    assert monitor.bandwidth_monitor.measure_bandwidth.call_count == 3
+    assert len(monitor.performance_history) == 3
+    assert monitor.performance_history.maxlen == 1_000
+    assert monitor.performance_history[-1].bandwidth_mbps == 42.0
+    assert monitor.performance_history[-1].latency_ms == 12.5


### PR DESCRIPTION
## Summary
- gate manual network thread-safety scripts behind a context manager that patches `sys.modules` only for direct execution
- skip the long-running manual diagnostics during pytest discovery
- add targeted unit tests that mock psutil to verify sampling and history bounds for network monitors

## Testing
- pytest tests/unit/test_network_monitor_regressions.py

------
https://chatgpt.com/codex/tasks/task_e_68d5cea4bed4832f907b632ff4eb7285