### PR TITLE
Expose deterministic command in CLI module

### DIFF
--- a/src/rldk/cli.py
+++ b/src/rldk/cli.py
@@ -74,6 +74,10 @@ from rldk.emit import EventWriter
 from rldk.replay import replay
 from rldk.reward import health
 
+__all__ = [
+    "run_deterministic_command",
+]
+
 # Import reward modules
 from rldk.reward.drift import compare_models, compare_score_lists
 from rldk.reward.health_analysis import health as reward_health_analysis

--- a/src/rldk/cli.py
+++ b/src/rldk/cli.py
@@ -24,6 +24,7 @@ from rldk.cards import (
 )
 from rldk.config import settings
 from rldk.determinism.check import check
+from rldk.determinism.runner import run_deterministic_command
 from rldk.diff import compare_training_metrics_tables
 from rldk.evals import run
 from rldk.evals.metrics import (


### PR DESCRIPTION
## Summary
- re-export `run_deterministic_command` from `rldk.cli` so the CLI module provides the determinism runner entrypoint

## Testing
- pytest tests/integration/test_cli_timeout_and_determinism.py::TestCLIIntegration::test_cli_determinism_integration

------
https://chatgpt.com/codex/tasks/task_e_68d5f90c3324832f9639dca1d5536c0a