### PR TITLE
Add TRL EventWriter callback and JSONL logging support

### DIFF
--- a/docs/TRL_INTEGRATION_GUIDE.md
+++ b/docs/TRL_INTEGRATION_GUIDE.md
@@ -52,6 +52,36 @@ trainer = PPOTrainer(
 trainer.train()
 ```
 
+### 3. Lightweight Event Logging
+
+For minimal setups that only need raw scalar metrics, RLDK ships a dedicated
+`EventWriterCallback`. It mirrors TRL's log payloads into the canonical
+`EventWriter` JSONL format using RLDK's field presets, so downstream tooling can
+ingest KL, reward, and gradient metrics without the heavier monitoring stack.
+
+```python
+from pathlib import Path
+
+from rldk.integrations.trl import EventWriterCallback, create_ppo_trainer
+from trl import PPOConfig
+
+event_log_path = Path("./artifacts/my_run/events.jsonl")
+
+trainer = create_ppo_trainer(
+    model_name="sshleifer/tiny-gpt2",
+    ppo_config=ppo_config,
+    train_dataset=train_dataset,
+    callbacks=[],
+    event_log_path=event_log_path,
+)
+
+trainer.train()
+```
+
+When ``event_log_path`` is provided, :func:`create_ppo_trainer` automatically
+attaches the callback (unless one is already supplied) and appends events to the
+specified JSONL file.
+
 ## JSONL Event Logging
 
 RLDK automatically logs training events in a standardized JSONL format that includes:
@@ -185,9 +215,10 @@ plt.show()
 RLDK generates several output files in the specified directory:
 
 ### JSONL Events File
-- **Format**: `{run_id}_events.jsonl`
-- **Content**: Per-step training events in standardized format
-- **Usage**: Primary data source for analysis
+- **Format**: `{run_id}_events.jsonl` or the path passed to ``event_log_path``
+- **Content**: Per-step training events in standardized format with canonical
+  metric names (``kl``, ``reward_mean``, ``grad_norm_policy`` and more)
+- **Usage**: Primary data source for analysis or ingestion tools
 
 ### Metrics CSV File
 - **Format**: `{run_id}_metrics.csv`

--- a/examples/trl_integration/basic_ppo_integration.py
+++ b/examples/trl_integration/basic_ppo_integration.py
@@ -126,12 +126,15 @@ def test_basic_ppo_integration():
         fp16=False,  # Disable fp16 for compatibility
     )
 
+    event_log_path = os.path.join(output_dir, "test_ppo_run_events.jsonl")
+
     # Create PPO trainer with automatic compatibility handling
     trainer = create_ppo_trainer(
         model_name=model_name,
         ppo_config=ppo_config,
         train_dataset=dataset,
         callbacks=[rldk_callback, ppo_monitor, checkpoint_monitor],
+        event_log_path=event_log_path,
     )
 
     print("✅ PPO Trainer created with RLDK callbacks")

--- a/examples/trl_live_min.py
+++ b/examples/trl_live_min.py
@@ -56,6 +56,8 @@ def run_minimal_trl_loop():
     # Create output directory
     output_dir = "./artifacts/trl_live"
     os.makedirs(output_dir, exist_ok=True)
+
+    event_log_path = os.path.join(output_dir, "trl_live_min_events.jsonl")
     
     # Use tiny model to keep downloads fast
     model_name = "sshleifer/tiny-gpt2"  # Very small model
@@ -105,6 +107,7 @@ def run_minimal_trl_loop():
             ppo_config=ppo_config,
             train_dataset=dataset,
             callbacks=[monitor],
+            event_log_path=event_log_path,
         )
         print("✅ PPO Trainer created with RLDK monitor callback")
     except Exception as e:

--- a/examples/trl_real_training.py
+++ b/examples/trl_real_training.py
@@ -87,6 +87,7 @@ def run_real_trl_training():
     # Create output directory
     output_dir = "./artifacts/trl_real"
     os.makedirs(output_dir, exist_ok=True)
+    event_log_path = os.path.join(output_dir, "trl_real_training_events.jsonl")
     
     # Use tiny model to keep downloads fast
     model_name = "sshleifer/tiny-gpt2"  # Very small model
@@ -171,6 +172,7 @@ def run_real_trl_training():
             ref_model=ref_model,
             reward_model=reward_model,
             value_model=value_model,
+            event_log_path=event_log_path,
         )
         print("✅ PPO Trainer created with RLDK monitor callback")
     except Exception as e:

--- a/src/rldk/integrations/trl/__init__.py
+++ b/src/rldk/integrations/trl/__init__.py
@@ -1,6 +1,6 @@
 """TRL integration for RLDK."""
 
-from .callbacks import RLDKCallback, RLDKMetrics, RLDKMonitor
+from .callbacks import EventWriterCallback, RLDKCallback, RLDKMetrics, RLDKMonitor
 from .dashboard import RLDKDashboard
 from .monitors import CheckpointMetrics, CheckpointMonitor, PPOMetrics, PPOMonitor
 from .utils import (
@@ -13,6 +13,7 @@ from .utils import (
 )
 
 __all__ = [
+    "EventWriterCallback",
     "RLDKCallback",
     "RLDKMonitor",
     "RLDKMetrics",

--- a/src/rldk/integrations/trl/callbacks.py
+++ b/src/rldk/integrations/trl/callbacks.py
@@ -4,8 +4,9 @@ import json
 import time
 import warnings
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -54,6 +55,9 @@ except ImportError:
     PPOTrainerClass = None
 
 # Import Event schema for proper JSONL emission
+from ...emit import EventWriter
+from ...monitor.presets import FIELD_MAP_PRESETS
+
 try:
     from ...io.event_schema import Event, create_event_from_row
     EVENT_SCHEMA_AVAILABLE = True
@@ -61,6 +65,167 @@ except ImportError:
     EVENT_SCHEMA_AVAILABLE = False
     Event = None
     create_event_from_row = None
+
+
+class EventWriterCallback(TrainerCallback):
+    """Lightweight callback that mirrors TRL logs into ``EventWriter`` JSONL files."""
+
+    _SOURCE = "trl"
+
+    def __init__(
+        self,
+        event_log_path: Union[str, Path],
+        *,
+        run_id: Optional[str] = None,
+        tags: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        if not TRAINER_API_AVAILABLE:
+            raise ImportError(
+                "Transformers trainer callbacks are required for EventWriterCallback. "
+                "Install with: pip install 'transformers[torch]'"
+            )
+
+        self.event_log_path = Path(event_log_path)
+        self.event_log_path.parent.mkdir(parents=True, exist_ok=True)
+        self.run_id = run_id
+        self._provided_tags = dict(tags) if tags else None
+        self._writer: Optional[EventWriter] = None
+        self._trl_field_map: Dict[str, str] = dict(FIELD_MAP_PRESETS.get("trl", {}))
+        self._metric_field_map: Dict[str, str] = dict(FIELD_MAP_PRESETS.get("grpo", {}))
+        self._token_normalizer = {
+            "rewards": "reward",
+            "advantages": "advantage",
+            "vals": "value",
+            "val": "value",
+            "values": "value",
+            "kl_divergence": "kl",
+            "clipfrac": "clip_frac",
+        }
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _ensure_writer(self) -> EventWriter:
+        if self._writer is None:
+            self._writer = EventWriter(self.event_log_path)
+        return self._writer
+
+    def _normalise_token(self, token: str) -> str:
+        token = token.replace("-", "_")
+        return self._token_normalizer.get(token, token)
+
+    def _candidate_metric_keys(self, key: str) -> List[str]:
+        sanitized = key.strip().replace("-", "_")
+        parts = [part for part in sanitized.split("/") if part]
+        candidates: List[str] = []
+
+        for start in range(len(parts)):
+            suffix = parts[start:]
+            direct = "_".join(suffix)
+            if direct and direct not in candidates:
+                candidates.append(direct)
+
+            normalized_suffix = [self._normalise_token(part) for part in suffix]
+            normalized = "_".join(normalized_suffix)
+            if normalized and normalized not in candidates:
+                candidates.append(normalized)
+
+        if sanitized and sanitized not in candidates:
+            candidates.append(sanitized)
+
+        return candidates
+
+    def _canonical_metric_name(self, key: str) -> str:
+        for candidate in self._candidate_metric_keys(key):
+            mapped = self._metric_field_map.get(candidate)
+            if mapped:
+                return mapped
+        return key.replace("/", "_")
+
+    # ------------------------------------------------------------------
+    # Trainer callback hooks
+    # ------------------------------------------------------------------
+    def on_train_begin(self, args, state, control, **kwargs):  # type: ignore[override]
+        self._ensure_writer()
+        if self.run_id is None:
+            self.run_id = getattr(args, "run_name", None)
+        return control
+
+    def on_train_end(self, args, state, control, **kwargs):  # type: ignore[override]
+        if self._writer is not None:
+            self._writer.close()
+            self._writer = None
+        return control
+
+    def on_log(self, args, state, control, logs=None, **kwargs):  # type: ignore[override]
+        if not logs:
+            return control
+
+        writer = self._ensure_writer()
+        step = getattr(state, "global_step", 0) or 0
+        timestamp = time.time()
+
+        context_tags: Dict[str, Any] = {}
+        context_meta: Dict[str, Any] = {}
+        context_run_id: Optional[str] = None
+        context_step: Optional[int] = None
+        context_time: Optional[Any] = None
+
+        for raw_key, raw_value in list(logs.items()):
+            mapped_field = self._trl_field_map.get(raw_key)
+            if mapped_field == "step":
+                try:
+                    context_step = int(raw_value)  # type: ignore[arg-type]
+                except Exception:
+                    continue
+            elif mapped_field == "time":
+                context_time = raw_value
+            elif mapped_field == "run_id":
+                context_run_id = str(raw_value)
+            elif mapped_field == "tags" and isinstance(raw_value, dict):
+                context_tags.update(raw_value)
+            elif mapped_field == "meta" and isinstance(raw_value, dict):
+                context_meta.update(raw_value)
+
+        if context_step is not None:
+            step = context_step
+        event_time = context_time if context_time is not None else timestamp
+        if isinstance(event_time, (int, float)):
+            event_time = datetime.fromtimestamp(event_time, tz=timezone.utc)
+        run_identifier = context_run_id or self.run_id
+
+        base_tags = dict(self._provided_tags) if self._provided_tags else {}
+        if context_tags:
+            base_tags.update(context_tags)
+
+        for raw_key, raw_value in logs.items():
+            if self._trl_field_map.get(raw_key) in {"step", "time", "run_id", "tags", "meta"}:
+                continue
+
+            if isinstance(raw_value, (int, float)):
+                numeric_value = float(raw_value)
+            else:
+                try:
+                    numeric_value = float(raw_value)
+                except (TypeError, ValueError):
+                    continue
+
+            canonical_name = self._canonical_metric_name(str(raw_key))
+            meta_payload = {"source": self._SOURCE, "raw_name": raw_key}
+            if context_meta:
+                meta_payload.update(context_meta)
+
+            writer.log(
+                step=step,
+                name=canonical_name,
+                value=numeric_value,
+                time=event_time,
+                run_id=run_identifier,
+                tags=base_tags or None,
+                meta=meta_payload,
+            )
+
+        return control
 
 
 @dataclass

--- a/src/rldk/integrations/trl/utils.py
+++ b/src/rldk/integrations/trl/utils.py
@@ -1,12 +1,15 @@
 """Utility functions for TRL integration."""
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import warnings
 
 from packaging import version
 from packaging.version import InvalidVersion
 from transformers import AutoTokenizer, GenerationConfig
+
+from .callbacks import EventWriterCallback
 
 try:  # pragma: no cover - torch is an optional dependency for some integrations
     import torch
@@ -316,6 +319,7 @@ def create_ppo_trainer(
     reward_model: Optional[Any] = None,
     value_model: Optional["AutoModelForCausalLMWithValueHead"] = None,
     validate_setup: bool = True,
+    event_log_path: Optional[Union[str, Path]] = None,
     **ppo_kwargs: Any,
 ) -> "PPOTrainer":
     """Create a :class:`trl.PPOTrainer` with version-aware defaults."""
@@ -402,6 +406,18 @@ def create_ppo_trainer(
         if not validation["valid"]:
             issues = "; ".join(validation["issues"])
             raise ValueError(f"Invalid PPO setup detected: {issues}")
+
+    if event_log_path is not None:
+        already_has_writer = any(
+            isinstance(cb, EventWriterCallback) for cb in callbacks_list
+        )
+        if not already_has_writer:
+            callbacks_list.append(
+                EventWriterCallback(
+                    event_log_path,
+                    run_id=getattr(ppo_config, "run_name", None),
+                )
+            )
 
     trainer_kwargs: Dict[str, Any] = {
         "args": ppo_config,

--- a/tests/unit/integrations/trl/test_event_writer_callback.py
+++ b/tests/unit/integrations/trl/test_event_writer_callback.py
@@ -1,0 +1,58 @@
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("numpy")
+pytest.importorskip("pandas")
+
+from rldk.integrations.trl.callbacks import EventWriterCallback, TRAINER_API_AVAILABLE
+
+pytestmark = pytest.mark.skipif(
+    not TRAINER_API_AVAILABLE,
+    reason="Transformers Trainer APIs are required for the TRL event writer callback",
+)
+
+
+def test_event_writer_callback_emits_expected_metrics(tmp_path: Path) -> None:
+    event_log_path = tmp_path / "events.jsonl"
+
+    callback = EventWriterCallback(
+        event_log_path,
+        run_id="unit-test",
+        tags={"suite": "unit"},
+    )
+
+    from transformers import TrainerControl, TrainerState, TrainingArguments
+
+    args = TrainingArguments(output_dir=str(tmp_path))
+    state = TrainerState()
+    control = TrainerControl()
+
+    callback.on_train_begin(args, state, control)
+
+    state.global_step = 5
+    logs = {
+        "step": 5,
+        "ppo/policy/kl_mean": 0.15,
+        "ppo/rewards/mean": 1.25,
+        "ppo/policy/grad_norm": 2.5,
+    }
+
+    callback.on_log(args, state, control, logs)
+    callback.on_train_end(args, state, control)
+
+    contents = event_log_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(contents) == 3
+
+    events = [json.loads(line) for line in contents]
+    names = {event["name"] for event in events}
+
+    assert {"kl", "reward_mean", "grad_norm_policy"}.issubset(names)
+    for event in events:
+        assert event["run_id"] == "unit-test"
+        assert event["meta"]["raw_name"] in logs
+        assert event["meta"]["source"] == "trl"
+        assert event["step"] == 5
+        assert event["tags"]["suite"] == "unit"
+


### PR DESCRIPTION
## Summary
- add an EventWriterCallback that mirrors TRL on_log payloads into canonical EventWriter JSONL events
- allow create_ppo_trainer and example scripts to accept an event_log_path and wire the callback automatically
- document the workflow and add a regression test that validates the emitted metrics
- ensure EventWriterCallback emits ISO8601 timestamps when mirroring TRL metrics into EventWriter JSONL streams

## Testing
- pytest tests/unit/integrations/trl/test_event_writer_callback.py

------
https://chatgpt.com/codex/tasks/task_e_68d6e560145c832fb471b666bdf30b34