### PR TITLE
Use declarative configs for tiny PPO/GRPO runners

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -1,0 +1,20 @@
+# Tiny run configuration schema
+
+The example runners in `examples/run_ppo_tiny.py` and `examples/run_grpo_tiny.py` load
+YAML files from this directory to obtain both trainer arguments and metadata for
+logging. Each file shares a common structure:
+
+- `model` *(str)* – model identifier forwarded to the tokenizer and policy/value heads.
+- `dataset_seed` *(int)* – seed applied before constructing the toy dataset so the
+  sampling order is deterministic.
+- `steps` *(int)* – maximum number of optimisation steps; mapped to the trainer
+  configuration if it is not explicitly overridden.
+- `logging_interval` *(int)* – frequency (in steps) for emitting training metrics.
+- `log_path` *(str)* – JSONL path where the runners should write `EventWriter` output;
+  relative paths are resolved against the repository root so they mirror the CLI defaults.
+- `ppo_kwargs` / `grpo_kwargs` *(mapping)* – keyword arguments forwarded directly to
+  `trl.PPOConfig` or `trl.GRPOConfig` after the helper injects the step and logging
+  defaults listed above.
+
+This keeps the example scripts declarative while giving tests a single source of truth
+for verifying schema changes.

--- a/configs/grpo_tiny.yaml
+++ b/configs/grpo_tiny.yaml
@@ -1,14 +1,21 @@
-# Tiny GRPO configuration mirroring the PPO defaults for CPU-only smoke tests
-run_name: grpo_tiny
-learning_rate: 5.0e-5
-per_device_train_batch_size: 1
-gradient_accumulation_steps: 1
-num_train_epochs: 1
-num_generations: 1
-max_steps: 4
-logging_steps: 1
-save_steps: 0
-remove_unused_columns: false
-bf16: false
-fp16: false
-dataloader_num_workers: 0
+# Tiny GRPO configuration mirroring the PPO defaults for CPU-only smoke tests.
+#
+# The metadata fields align with the helper expected by ``examples/run_grpo_tiny.py``
+# so the runner can derive trainer configuration and logging paths from YAML alone.
+model: sshleifer/tiny-gpt2
+dataset_seed: 12
+steps: 4
+logging_interval: 1
+log_path: artifacts/grpo_tiny/run.jsonl
+grpo_kwargs:
+  run_name: grpo_tiny
+  learning_rate: 5.0e-5
+  per_device_train_batch_size: 1
+  gradient_accumulation_steps: 1
+  num_train_epochs: 1
+  num_generations: 1
+  save_steps: 0
+  remove_unused_columns: false
+  bf16: false
+  fp16: false
+  dataloader_num_workers: 0

--- a/configs/ppo_tiny.yaml
+++ b/configs/ppo_tiny.yaml
@@ -1,19 +1,26 @@
-# Tiny PPO configuration for CPU-friendly smoke runs
-run_name: ppo_tiny
-learning_rate: 5.0e-5
-per_device_train_batch_size: 1
-mini_batch_size: 1
-batch_size: 2
-gradient_accumulation_steps: 1
-num_ppo_epochs: 1
-max_steps: 4
-target_kl: 0.1
-clip_range: 0.2
-clip_range_value: 0.2
-logging_steps: 1
-save_steps: 0
-remove_unused_columns: false
-bf16: false
-fp16: false
-dataloader_num_workers: 0
-log_with: []
+# Tiny PPO configuration for CPU-friendly smoke runs.
+#
+# The top-level fields capture metadata that the example runner maps onto the
+# TRL ``PPOConfig`` constructor as well as helper settings like log locations.
+model: sshleifer/tiny-gpt2
+dataset_seed: 8
+steps: 4
+logging_interval: 1
+log_path: artifacts/ppo_tiny/run.jsonl
+ppo_kwargs:
+  run_name: ppo_tiny
+  learning_rate: 5.0e-5
+  per_device_train_batch_size: 1
+  mini_batch_size: 1
+  batch_size: 2
+  gradient_accumulation_steps: 1
+  num_ppo_epochs: 1
+  target_kl: 0.1
+  clip_range: 0.2
+  clip_range_value: 0.2
+  save_steps: 0
+  remove_unused_columns: false
+  bf16: false
+  fp16: false
+  dataloader_num_workers: 0
+  log_with: []

--- a/examples/run_grpo_tiny.py
+++ b/examples/run_grpo_tiny.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import argparse
+import random
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Any, Dict, Iterable, Optional
 
 import yaml
 
@@ -14,7 +16,18 @@ from rldk.integrations.trl import EventWriterCallback, create_grpo_config
 
 DEFAULT_MODEL_NAME = "sshleifer/tiny-gpt2"
 DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[1] / "configs" / "grpo_tiny.yaml"
-DEFAULT_LOG_DIR = Path("artifacts/grpo_tiny")
+
+
+@dataclass
+class TinyGRPORunSettings:
+    """Container for metadata encoded in ``configs/grpo_tiny.yaml``."""
+
+    model: str
+    dataset_seed: int
+    steps: int
+    logging_interval: int
+    log_path: Path
+    grpo_config: "GRPOConfig"
 
 
 def build_tiny_dataset() -> "Dataset":
@@ -68,8 +81,8 @@ def load_tokenizer(model_name: str):
     return tokenizer
 
 
-def load_grpo_config(config_path: Path):
-    """Load a :class:`trl.GRPOConfig` using the helper that applies CPU defaults."""
+def load_grpo_config(config_path: Path) -> TinyGRPORunSettings:
+    """Load metadata and construct a :class:`trl.GRPOConfig` with safe defaults."""
 
     with config_path.open("r", encoding="utf-8") as stream:
         config_payload = yaml.safe_load(stream) or {}
@@ -77,7 +90,49 @@ def load_grpo_config(config_path: Path):
     if not isinstance(config_payload, dict):
         raise ValueError(f"Expected mapping in {config_path}, found {type(config_payload)!r}")
 
-    return create_grpo_config(**config_payload)
+    model_name = config_payload.get("model", DEFAULT_MODEL_NAME)
+    if not isinstance(model_name, str):
+        raise TypeError("The 'model' field must be a string in the GRPO config YAML")
+
+    dataset_seed = config_payload.get("dataset_seed", 0)
+    if not isinstance(dataset_seed, int):
+        raise TypeError("The 'dataset_seed' field must be an integer in the GRPO config YAML")
+
+    steps = config_payload.get("steps")
+    if not isinstance(steps, int):
+        raise TypeError("The 'steps' field must be provided as an integer in the GRPO config YAML")
+
+    logging_interval = config_payload.get("logging_interval", 1)
+    if not isinstance(logging_interval, int):
+        raise TypeError(
+            "The 'logging_interval' field must be provided as an integer in the GRPO config YAML"
+        )
+
+    log_path_field = config_payload.get("log_path")
+    if not isinstance(log_path_field, str):
+        raise TypeError("The 'log_path' field must be provided as a string in the GRPO config YAML")
+
+    log_path = Path(log_path_field)
+    if not log_path.is_absolute():
+        log_path = (config_path.parents[1] / log_path).resolve()
+
+    grpo_kwargs: Dict[str, Any] = dict(config_payload.get("grpo_kwargs", {}))
+    if not isinstance(grpo_kwargs, dict):  # pragma: no cover - validation guard
+        raise TypeError("The 'grpo_kwargs' section must be a mapping in the GRPO config YAML")
+
+    grpo_kwargs.setdefault("max_steps", steps)
+    grpo_kwargs.setdefault("logging_steps", logging_interval)
+
+    grpo_config = create_grpo_config(**grpo_kwargs)
+
+    return TinyGRPORunSettings(
+        model=model_name,
+        dataset_seed=dataset_seed,
+        steps=steps,
+        logging_interval=logging_interval,
+        log_path=log_path,
+        grpo_config=grpo_config,
+    )
 
 
 def build_grpo_trainer(
@@ -139,13 +194,13 @@ def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--log-dir",
         type=Path,
-        default=DEFAULT_LOG_DIR,
-        help="Directory where EventWriter JSONL logs should be stored.",
+        default=None,
+        help="Optional override for the directory where EventWriter JSONL logs should be stored.",
     )
     parser.add_argument(
         "--model-name",
-        default=DEFAULT_MODEL_NAME,
-        help="Model identifier to use for tokenizer and policy/value weights.",
+        default=None,
+        help="Optional override for the model identifier defined in the YAML configuration.",
     )
     return parser.parse_args(list(argv) if argv is not None else None)
 
@@ -155,17 +210,24 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
 
     args = parse_args(argv)
     config_path = args.config.expanduser().resolve()
-    log_dir = args.log_dir.expanduser().resolve()
-    log_dir.mkdir(parents=True, exist_ok=True)
-    event_log_path = log_dir / "run.jsonl"
 
     try:
-        grpo_config = load_grpo_config(config_path)
+        settings = load_grpo_config(config_path)
+        model_name = args.model_name or settings.model
+
+        random.seed(settings.dataset_seed)
+
+        event_log_path = settings.log_path
+        if args.log_dir is not None:
+            event_log_path = args.log_dir.expanduser().resolve() / settings.log_path.name
+
+        event_log_path.parent.mkdir(parents=True, exist_ok=True)
+
         dataset = build_tiny_dataset()
-        tokenizer = load_tokenizer(args.model_name)
+        tokenizer = load_tokenizer(model_name)
         trainer = build_grpo_trainer(
-            model_name=args.model_name,
-            grpo_config=grpo_config,
+            model_name=model_name,
+            grpo_config=settings.grpo_config,
             dataset=dataset,
             tokenizer=tokenizer,
             event_log_path=event_log_path,

--- a/examples/run_grpo_tiny.py
+++ b/examples/run_grpo_tiny.py
@@ -15,7 +15,8 @@ from rldk.emit import EventWriter
 from rldk.integrations.trl import EventWriterCallback, create_grpo_config
 
 DEFAULT_MODEL_NAME = "sshleifer/tiny-gpt2"
-DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[1] / "configs" / "grpo_tiny.yaml"
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONFIG_PATH = PROJECT_ROOT / "configs" / "grpo_tiny.yaml"
 
 
 @dataclass
@@ -81,9 +82,26 @@ def load_tokenizer(model_name: str):
     return tokenizer
 
 
+def _resolve_log_path(log_path: Path, config_path: Path) -> Path:
+    """Resolve ``log_path`` against the repo root or config directory."""
+
+    if log_path.is_absolute():
+        return log_path
+
+    config_root = config_path.parent.resolve()
+    base_dir = PROJECT_ROOT
+    try:
+        config_path.resolve().relative_to(PROJECT_ROOT)
+    except ValueError:
+        base_dir = config_root
+
+    return (base_dir / log_path).resolve()
+
+
 def load_grpo_config(config_path: Path) -> TinyGRPORunSettings:
     """Load metadata and construct a :class:`trl.GRPOConfig` with safe defaults."""
 
+    config_path = config_path.resolve()
     with config_path.open("r", encoding="utf-8") as stream:
         config_payload = yaml.safe_load(stream) or {}
 
@@ -112,9 +130,7 @@ def load_grpo_config(config_path: Path) -> TinyGRPORunSettings:
     if not isinstance(log_path_field, str):
         raise TypeError("The 'log_path' field must be provided as a string in the GRPO config YAML")
 
-    log_path = Path(log_path_field)
-    if not log_path.is_absolute():
-        log_path = (config_path.parents[1] / log_path).resolve()
+    log_path = _resolve_log_path(Path(log_path_field), config_path)
 
     grpo_kwargs_field = config_payload.get("grpo_kwargs", {})
     if not isinstance(grpo_kwargs_field, dict):  # pragma: no cover - validation guard

--- a/examples/run_grpo_tiny.py
+++ b/examples/run_grpo_tiny.py
@@ -116,9 +116,10 @@ def load_grpo_config(config_path: Path) -> TinyGRPORunSettings:
     if not log_path.is_absolute():
         log_path = (config_path.parents[1] / log_path).resolve()
 
-    grpo_kwargs: Dict[str, Any] = dict(config_payload.get("grpo_kwargs", {}))
-    if not isinstance(grpo_kwargs, dict):  # pragma: no cover - validation guard
+    grpo_kwargs_field = config_payload.get("grpo_kwargs", {})
+    if not isinstance(grpo_kwargs_field, dict):  # pragma: no cover - validation guard
         raise TypeError("The 'grpo_kwargs' section must be a mapping in the GRPO config YAML")
+    grpo_kwargs: Dict[str, Any] = dict(grpo_kwargs_field)
 
     grpo_kwargs.setdefault("max_steps", steps)
     grpo_kwargs.setdefault("logging_steps", logging_interval)

--- a/examples/run_ppo_tiny.py
+++ b/examples/run_ppo_tiny.py
@@ -113,9 +113,10 @@ def load_ppo_config(config_path: Path) -> TinyPPORunSettings:
     if not log_path.is_absolute():
         log_path = (config_path.parents[1] / log_path).resolve()
 
-    ppo_kwargs: Dict[str, Any] = dict(config_payload.get("ppo_kwargs", {}))
-    if not isinstance(ppo_kwargs, dict):  # pragma: no cover - validation guard
+    ppo_kwargs_field = config_payload.get("ppo_kwargs", {})
+    if not isinstance(ppo_kwargs_field, dict):  # pragma: no cover - validation guard
         raise TypeError("The 'ppo_kwargs' section must be a mapping in the PPO config YAML")
+    ppo_kwargs: Dict[str, Any] = dict(ppo_kwargs_field)
 
     ppo_kwargs.setdefault("max_steps", steps)
     ppo_kwargs.setdefault("logging_steps", logging_interval)

--- a/examples/run_ppo_tiny.py
+++ b/examples/run_ppo_tiny.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import argparse
+import random
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Any, Dict, Iterable, Optional
 
 import yaml
 
@@ -13,7 +15,18 @@ from rldk.integrations.trl import create_ppo_trainer
 
 DEFAULT_MODEL_NAME = "sshleifer/tiny-gpt2"
 DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[1] / "configs" / "ppo_tiny.yaml"
-DEFAULT_LOG_DIR = Path("artifacts/ppo_tiny")
+
+
+@dataclass
+class TinyPPORunSettings:
+    """Container for the metadata encoded in ``configs/ppo_tiny.yaml``."""
+
+    model: str
+    dataset_seed: int
+    steps: int
+    logging_interval: int
+    log_path: Path
+    ppo_config: "PPOConfig"
 
 
 def build_tiny_dataset() -> "Dataset":
@@ -60,8 +73,8 @@ def load_tokenizer(model_name: str):
     return tokenizer
 
 
-def load_ppo_config(config_path: Path):
-    """Load a :class:`trl.PPOConfig` from YAML."""
+def load_ppo_config(config_path: Path) -> TinyPPORunSettings:
+    """Load metadata and create a :class:`trl.PPOConfig` from YAML."""
 
     with config_path.open("r", encoding="utf-8") as stream:
         config_payload = yaml.safe_load(stream) or {}
@@ -74,7 +87,49 @@ def load_ppo_config(config_path: Path):
     except ImportError as exc:  # pragma: no cover - exercised in real runs
         raise ImportError("TRL is required for run_ppo_tiny. Install with: pip install trl") from exc
 
-    return PPOConfig(**config_payload)
+    model_name = config_payload.get("model", DEFAULT_MODEL_NAME)
+    if not isinstance(model_name, str):
+        raise TypeError("The 'model' field must be a string in the PPO config YAML")
+
+    dataset_seed = config_payload.get("dataset_seed", 0)
+    if not isinstance(dataset_seed, int):
+        raise TypeError("The 'dataset_seed' field must be an integer in the PPO config YAML")
+
+    steps = config_payload.get("steps")
+    if not isinstance(steps, int):
+        raise TypeError("The 'steps' field must be provided as an integer in the PPO config YAML")
+
+    logging_interval = config_payload.get("logging_interval", 1)
+    if not isinstance(logging_interval, int):
+        raise TypeError(
+            "The 'logging_interval' field must be provided as an integer in the PPO config YAML"
+        )
+
+    log_path_field = config_payload.get("log_path")
+    if not isinstance(log_path_field, str):
+        raise TypeError("The 'log_path' field must be provided as a string in the PPO config YAML")
+
+    log_path = Path(log_path_field)
+    if not log_path.is_absolute():
+        log_path = (config_path.parents[1] / log_path).resolve()
+
+    ppo_kwargs: Dict[str, Any] = dict(config_payload.get("ppo_kwargs", {}))
+    if not isinstance(ppo_kwargs, dict):  # pragma: no cover - validation guard
+        raise TypeError("The 'ppo_kwargs' section must be a mapping in the PPO config YAML")
+
+    ppo_kwargs.setdefault("max_steps", steps)
+    ppo_kwargs.setdefault("logging_steps", logging_interval)
+
+    ppo_config = PPOConfig(**ppo_kwargs)
+
+    return TinyPPORunSettings(
+        model=model_name,
+        dataset_seed=dataset_seed,
+        steps=steps,
+        logging_interval=logging_interval,
+        log_path=log_path,
+        ppo_config=ppo_config,
+    )
 
 
 def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
@@ -88,13 +143,13 @@ def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--log-dir",
         type=Path,
-        default=DEFAULT_LOG_DIR,
-        help="Directory where EventWriter JSONL logs should be stored.",
+        default=None,
+        help="Optional override for the directory where JSONL logs should be stored.",
     )
     parser.add_argument(
         "--model-name",
-        default=DEFAULT_MODEL_NAME,
-        help="Model identifier to use for tokenizer and policy/value weights.",
+        default=None,
+        help="Optional override for the model identifier defined in the YAML configuration.",
     )
     return parser.parse_args(list(argv) if argv is not None else None)
 
@@ -104,17 +159,24 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
 
     args = parse_args(argv)
     config_path = args.config.expanduser().resolve()
-    log_dir = args.log_dir.expanduser().resolve()
-    log_dir.mkdir(parents=True, exist_ok=True)
-    event_log_path = log_dir / "run.jsonl"
 
     try:
-        ppo_config = load_ppo_config(config_path)
+        settings = load_ppo_config(config_path)
+        model_name = args.model_name or settings.model
+
+        random.seed(settings.dataset_seed)
+
+        event_log_path = settings.log_path
+        if args.log_dir is not None:
+            event_log_path = args.log_dir.expanduser().resolve() / settings.log_path.name
+
+        event_log_path.parent.mkdir(parents=True, exist_ok=True)
+
         dataset = build_tiny_dataset()
-        tokenizer = load_tokenizer(args.model_name)
+        tokenizer = load_tokenizer(model_name)
         trainer = create_ppo_trainer(
-            model_name=args.model_name,
-            ppo_config=ppo_config,
+            model_name=model_name,
+            ppo_config=settings.ppo_config,
             train_dataset=dataset,
             tokenizer=tokenizer,
             event_log_path=event_log_path,

--- a/examples/run_ppo_tiny.py
+++ b/examples/run_ppo_tiny.py
@@ -14,7 +14,8 @@ import yaml
 from rldk.integrations.trl import create_ppo_trainer
 
 DEFAULT_MODEL_NAME = "sshleifer/tiny-gpt2"
-DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[1] / "configs" / "ppo_tiny.yaml"
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONFIG_PATH = PROJECT_ROOT / "configs" / "ppo_tiny.yaml"
 
 
 @dataclass
@@ -73,9 +74,26 @@ def load_tokenizer(model_name: str):
     return tokenizer
 
 
+def _resolve_log_path(log_path: Path, config_path: Path) -> Path:
+    """Resolve ``log_path`` against the repo root or config directory."""
+
+    if log_path.is_absolute():
+        return log_path
+
+    config_root = config_path.parent.resolve()
+    base_dir = PROJECT_ROOT
+    try:
+        config_path.resolve().relative_to(PROJECT_ROOT)
+    except ValueError:
+        base_dir = config_root
+
+    return (base_dir / log_path).resolve()
+
+
 def load_ppo_config(config_path: Path) -> TinyPPORunSettings:
     """Load metadata and create a :class:`trl.PPOConfig` from YAML."""
 
+    config_path = config_path.resolve()
     with config_path.open("r", encoding="utf-8") as stream:
         config_payload = yaml.safe_load(stream) or {}
 
@@ -109,9 +127,7 @@ def load_ppo_config(config_path: Path) -> TinyPPORunSettings:
     if not isinstance(log_path_field, str):
         raise TypeError("The 'log_path' field must be provided as a string in the PPO config YAML")
 
-    log_path = Path(log_path_field)
-    if not log_path.is_absolute():
-        log_path = (config_path.parents[1] / log_path).resolve()
+    log_path = _resolve_log_path(Path(log_path_field), config_path)
 
     ppo_kwargs_field = config_payload.get("ppo_kwargs", {})
     if not isinstance(ppo_kwargs_field, dict):  # pragma: no cover - validation guard

--- a/tests/unit/configs/test_tiny_yaml_configs.py
+++ b/tests/unit/configs/test_tiny_yaml_configs.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+import types
+
+import yaml
+
+CONFIG_DIR = Path(__file__).resolve().parents[3] / "configs"
+
+if "numpy" not in sys.modules:  # pragma: no cover - lightweight stub for optional dependency
+    numpy_stub = types.ModuleType("numpy")
+    random_stub = types.ModuleType("numpy.random")
+    random_stub._state = ("stub", 0, None)
+
+    def _seed(value: int) -> None:
+        random_stub._state = ("stub", int(value), None)
+
+    def _get_state():
+        return random_stub._state
+
+    def _set_state(state) -> None:
+        random_stub._state = state
+
+    random_stub.seed = _seed  # type: ignore[assignment]
+    random_stub.get_state = _get_state  # type: ignore[assignment]
+    random_stub.set_state = _set_state  # type: ignore[assignment]
+
+    numpy_stub.random = random_stub  # type: ignore[attr-defined]
+    numpy_stub.bool_ = bool  # type: ignore[attr-defined]
+    numpy_stub.ndarray = object  # type: ignore[attr-defined]
+
+    sys.modules["numpy"] = numpy_stub
+    sys.modules["numpy.random"] = random_stub
+
+if "pandas" not in sys.modules:  # pragma: no cover - lightweight stub for optional dependency
+    pandas_stub = types.ModuleType("pandas")
+    pandas_stub.DataFrame = lambda *args, **kwargs: None  # type: ignore[attr-defined]
+    pandas_stub.Series = lambda *args, **kwargs: None  # type: ignore[attr-defined]
+    sys.modules["pandas"] = pandas_stub
+
+
+def _load_config(name: str) -> dict:
+    path = CONFIG_DIR / name
+    with path.open("r", encoding="utf-8") as handle:
+        payload = yaml.safe_load(handle) or {}
+    assert isinstance(payload, dict), f"Expected mapping at {path}, found {type(payload)!r}"
+    return payload
+
+
+def test_ppo_config_schema() -> None:
+    payload = _load_config("ppo_tiny.yaml")
+
+    assert isinstance(payload.get("model"), str)
+    assert isinstance(payload.get("steps"), int) and payload["steps"] > 0
+    assert isinstance(payload.get("log_path"), str)
+    assert payload["log_path"].endswith(".jsonl")
+    assert isinstance(payload.get("dataset_seed"), int)
+    assert isinstance(payload.get("logging_interval"), int)
+    assert isinstance(payload.get("ppo_kwargs"), dict)
+
+
+def test_grpo_config_schema() -> None:
+    payload = _load_config("grpo_tiny.yaml")
+
+    assert isinstance(payload.get("model"), str)
+    assert isinstance(payload.get("steps"), int) and payload["steps"] > 0
+    assert isinstance(payload.get("log_path"), str)
+    assert payload["log_path"].endswith(".jsonl")
+    assert isinstance(payload.get("dataset_seed"), int)
+    assert isinstance(payload.get("logging_interval"), int)
+    assert isinstance(payload.get("grpo_kwargs"), dict)

--- a/tests/unit/examples/test_tiny_scripts.py
+++ b/tests/unit/examples/test_tiny_scripts.py
@@ -66,8 +66,15 @@ from rldk.emit import EventWriter
 def test_run_ppo_tiny_smoke(monkeypatch, tmp_path):
     import examples.run_ppo_tiny as run_ppo_tiny
 
-    dummy_config = types.SimpleNamespace(run_name="ppo-test")
-    monkeypatch.setattr(run_ppo_tiny, "load_ppo_config", lambda path: dummy_config)
+    dummy_settings = run_ppo_tiny.TinyPPORunSettings(
+        model="dummy-ppo",
+        dataset_seed=0,
+        steps=4,
+        logging_interval=1,
+        log_path=Path("artifacts/ppo_tiny/run.jsonl"),
+        ppo_config=types.SimpleNamespace(run_name="ppo-test"),
+    )
+    monkeypatch.setattr(run_ppo_tiny, "load_ppo_config", lambda path: dummy_settings)
 
     dummy_dataset = [{"prompt": "hi", "response": "hello"}]
     monkeypatch.setattr(run_ppo_tiny, "build_tiny_dataset", lambda: dummy_dataset)
@@ -108,8 +115,15 @@ def test_run_ppo_tiny_smoke(monkeypatch, tmp_path):
 def test_run_grpo_tiny_smoke(monkeypatch, tmp_path):
     import examples.run_grpo_tiny as run_grpo_tiny
 
-    dummy_config = types.SimpleNamespace(run_name="grpo-test")
-    monkeypatch.setattr(run_grpo_tiny, "load_grpo_config", lambda path: dummy_config)
+    dummy_settings = run_grpo_tiny.TinyGRPORunSettings(
+        model="dummy-grpo",
+        dataset_seed=0,
+        steps=4,
+        logging_interval=1,
+        log_path=Path("artifacts/grpo_tiny/run.jsonl"),
+        grpo_config=types.SimpleNamespace(run_name="grpo-test"),
+    )
+    monkeypatch.setattr(run_grpo_tiny, "load_grpo_config", lambda path: dummy_settings)
 
     dummy_dataset = [
         {"accepted": True},

--- a/tests/unit/examples/test_tiny_scripts.py
+++ b/tests/unit/examples/test_tiny_scripts.py
@@ -62,6 +62,18 @@ if "transformers" not in sys.modules:  # pragma: no cover - test bootstrap helpe
 from rldk.emit import EventWriter
 
 
+def _install_trl_stub(monkeypatch):
+    trl_stub = types.ModuleType("trl")
+
+    class _DummyPPOConfig:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    trl_stub.PPOConfig = _DummyPPOConfig  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "trl", trl_stub)
+    return trl_stub
+
+
 @pytest.mark.xfail(reason="Tiny PPO script smoke test is experimental", strict=False)
 def test_run_ppo_tiny_smoke(monkeypatch, tmp_path):
     import examples.run_ppo_tiny as run_ppo_tiny
@@ -109,6 +121,48 @@ def test_run_ppo_tiny_smoke(monkeypatch, tmp_path):
     entries = [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
     names = {entry["name"] for entry in entries}
     assert {"reward", "kl"} <= names
+
+
+def test_load_ppo_config_resolves_repo_relative_log_path(monkeypatch):
+    import examples.run_ppo_tiny as run_ppo_tiny
+
+    _install_trl_stub(monkeypatch)
+
+    settings = run_ppo_tiny.load_ppo_config(run_ppo_tiny.DEFAULT_CONFIG_PATH)
+
+    expected = (
+        run_ppo_tiny.DEFAULT_CONFIG_PATH.parents[1]
+        / "artifacts"
+        / "ppo_tiny"
+        / "run.jsonl"
+    ).resolve()
+    assert settings.log_path == expected
+
+
+def test_load_ppo_config_resolves_external_relative_log_path(monkeypatch, tmp_path):
+    import examples.run_ppo_tiny as run_ppo_tiny
+
+    _install_trl_stub(monkeypatch)
+
+    config_path = tmp_path / "ppo_custom.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "model: custom/model",
+                "dataset_seed: 1",
+                "steps: 2",
+                "logging_interval: 1",
+                "log_path: logs/run.jsonl",
+                "ppo_kwargs: {}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    settings = run_ppo_tiny.load_ppo_config(config_path)
+
+    expected = (tmp_path / "logs" / "run.jsonl").resolve()
+    assert settings.log_path == expected
 
 
 @pytest.mark.xfail(reason="Tiny GRPO script smoke test is experimental", strict=False)
@@ -160,3 +214,53 @@ def test_run_grpo_tiny_smoke(monkeypatch, tmp_path):
     entries = [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
     names = {entry["name"] for entry in entries}
     assert {"reward", "kl"} <= names  # acceptance_rate logged separately in real script
+
+
+def test_load_grpo_config_resolves_repo_relative_log_path(monkeypatch):
+    import examples.run_grpo_tiny as run_grpo_tiny
+
+    monkeypatch.setattr(
+        run_grpo_tiny,
+        "create_grpo_config",
+        lambda **kwargs: types.SimpleNamespace(**kwargs),
+    )
+
+    settings = run_grpo_tiny.load_grpo_config(run_grpo_tiny.DEFAULT_CONFIG_PATH)
+
+    expected = (
+        run_grpo_tiny.DEFAULT_CONFIG_PATH.parents[1]
+        / "artifacts"
+        / "grpo_tiny"
+        / "run.jsonl"
+    ).resolve()
+    assert settings.log_path == expected
+
+
+def test_load_grpo_config_resolves_external_relative_log_path(monkeypatch, tmp_path):
+    import examples.run_grpo_tiny as run_grpo_tiny
+
+    monkeypatch.setattr(
+        run_grpo_tiny,
+        "create_grpo_config",
+        lambda **kwargs: types.SimpleNamespace(**kwargs),
+    )
+
+    config_path = tmp_path / "grpo_custom.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "model: custom/model",
+                "dataset_seed: 2",
+                "steps: 3",
+                "logging_interval: 1",
+                "log_path: logs/run.jsonl",
+                "grpo_kwargs: {}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    settings = run_grpo_tiny.load_grpo_config(config_path)
+
+    expected = (tmp_path / "logs" / "run.jsonl").resolve()
+    assert settings.log_path == expected


### PR DESCRIPTION
## Summary
- document the tiny run YAML schema and enrich the PPO/GRPO configs with model, log path, and trainer metadata
- teach the tiny PPO and GRPO runner scripts to load the YAML via safe_load, map fields onto TRL config objects, and honour the configured log path
- add unit coverage that validates the config schema and update the tiny runner smoke tests to work with the richer settings objects

## Testing
- pytest tests/unit/configs/test_tiny_yaml_configs.py

------
https://chatgpt.com/codex/tasks/task_e_68d700769740832f888fabe74352ccb7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch tiny PPO/GRPO runners to structured YAML configs (with model/logging metadata and path resolution) and add tests/docs to validate the schema and behavior.
> 
> - **Configs**:
>   - Introduce declarative YAML schema with metadata: `model`, `dataset_seed`, `steps`, `logging_interval`, `log_path`, and algorithm kwargs under `ppo_kwargs`/`grpo_kwargs` in `configs/{ppo,grpo}_tiny.yaml`.
> - **Examples**:
>   - Refactor `examples/run_ppo_tiny.py` and `examples/run_grpo_tiny.py` to:
>     - Load YAML via `safe_load` and map to TRL configs; add `TinyPPORunSettings`/`TinyGRPORunSettings` dataclasses.
>     - Resolve `log_path` relative to repo or config dir; respect optional `--log-dir` and `--model-name` overrides.
>     - Seed randomness from `dataset_seed` and ensure log directory creation; reuse derived config fields (e.g., `max_steps`, `logging_steps`).
> - **Tests**:
>   - Add `tests/unit/configs/test_tiny_yaml_configs.py` to validate YAML schema and `.jsonl` log path.
>   - Extend `tests/unit/examples/test_tiny_scripts.py` with stubs and assertions for path resolution and updated settings; add TRL stub helper.
> - **Docs**:
>   - New `configs/README.md` documenting the tiny run configuration schema.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1032f9f6d473445da5f62e5170ce326b28231caf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->