### PR TITLE
Separate policy and reward models in GRPO

### DIFF
--- a/examples/run_grpo_tiny.py
+++ b/examples/run_grpo_tiny.py
@@ -166,15 +166,21 @@ def build_grpo_trainer(
     except ImportError as exc:  # pragma: no cover - exercised in real runs
         raise ImportError("TRL is required for run_grpo_tiny. Install with: pip install trl") from exc
 
-    # For GRPO, we use the model as both policy and reward function
-    model = AutoModelForCausalLMWithValueHead.from_pretrained(model_name)
+    # Load separate models for proper TRL architecture:
+    # - policy_model: The model being optimized during training
+    # - ref_model: Frozen reference model for KL regularization
+    # - reward_model: Separate model for reward computation
+    policy_model = AutoModelForCausalLMWithValueHead.from_pretrained(model_name)
+    ref_model = AutoModelForCausalLMWithValueHead.from_pretrained(model_name)
+    reward_model = AutoModelForCausalLMWithValueHead.from_pretrained(model_name)
 
     callback = EventWriterCallback(event_log_path, run_id=getattr(grpo_config, "run_name", None))
 
     trainer = GRPOTrainer(
         args=grpo_config,
-        model=model,
-        reward_funcs=model,  # Use the same model as reward function
+        model=policy_model,  # Policy model being optimized
+        ref_model=ref_model,  # Reference model for KL regularization
+        reward_model=reward_model,  # Separate reward model
         processing_class=tokenizer,
         train_dataset=dataset,
         callbacks=[callback],


### PR DESCRIPTION
Separate policy, reference, and reward models for `GRPOTrainer` to fix `TypeError` and comply with TRL's architecture.

The previous implementation incorrectly passed the policy model instance to the `reward_funcs` parameter, which expects an iterable of callable functions. This caused a `TypeError` and violated TRL's design for GRPO, which requires distinct models for policy optimization, KL regularization (reference model), and reward computation. This change ensures proper architectural separation and functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-c757c20d-83da-4342-ae69-7aa1bd588c86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c757c20d-83da-4342-ae69-7aa1bd588c86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace single-model setup with distinct policy, reference, and reward models and pass them to `GRPOTrainer` via `model`, `ref_model`, and `reward_model`.
> 
> - **Examples**:
>   - `examples/run_grpo_tiny.py`:
>     - In `build_grpo_trainer`, instantiate separate `policy_model`, `ref_model`, and `reward_model` using `AutoModelForCausalLMWithValueHead.from_pretrained`.
>     - Update `GRPOTrainer` call to use `model`, `ref_model`, and `reward_model` instead of `reward_funcs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62e78a323bdb6f42e77f0d11babebff2a442c3f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->