### PR TITLE
Ensure TRL detection is prioritized over custom JSONL

### DIFF
--- a/src/rldk/adapters/custom_jsonl.py
+++ b/src/rldk/adapters/custom_jsonl.py
@@ -25,9 +25,11 @@ class CustomJSONLAdapter(BaseAdapter):
         if self.source.is_file():
             return self._is_custom_jsonl_file(self.source)
         elif self.source.is_dir():
-            # Check for our custom JSONL log files
-            jsonl_files = list(self.source.glob("*.jsonl"))
-            return len(jsonl_files) > 0
+            # Check directory contents for at least one file with the custom schema
+            for jsonl_file in self.source.glob("*.jsonl"):
+                if self._is_custom_jsonl_file(jsonl_file):
+                    return True
+            return False
 
         return False
 

--- a/src/rldk/ingest/ingest.py
+++ b/src/rldk/ingest/ingest.py
@@ -283,13 +283,6 @@ def _detect_adapter_type(source: Union[str, Path]) -> str:
     if not source_path.exists():
         return "flexible"  # Default to flexible adapter
 
-    # Check for our custom JSONL format first
-    from ..adapters.custom_jsonl import CustomJSONLAdapter
-
-    custom_adapter = CustomJSONLAdapter(source_path)
-    if custom_adapter.can_handle():
-        return "custom_jsonl"
-
     # Check for TRL-specific patterns
     from ..adapters.trl import TRLAdapter
 
@@ -310,6 +303,13 @@ def _detect_adapter_type(source: Union[str, Path]) -> str:
     grpo_adapter = GRPOAdapter(source_path)
     if grpo_adapter.can_handle():
         return "grpo"
+
+    # Check for our custom JSONL format after known formats
+    from ..adapters.custom_jsonl import CustomJSONLAdapter
+
+    custom_adapter = CustomJSONLAdapter(source_path)
+    if custom_adapter.can_handle():
+        return "custom_jsonl"
 
     # Default to flexible adapter for better field resolution
     return "flexible"

--- a/tests/integration/test_ingestion.py
+++ b/tests/integration/test_ingestion.py
@@ -358,6 +358,29 @@ class TestJSONLIngestion:
         finally:
             os.unlink(f.name)
 
+    def test_trl_directory_ingestion_prefers_trl_adapter(self, tmp_path):
+        """Regression test to ensure TRL exports aren't blocked by the custom adapter."""
+
+        trl_dir = tmp_path / "trl_export"
+        trl_dir.mkdir()
+
+        trl_file = trl_dir / "metrics.jsonl"
+        trl_payload = {
+            "step": 0,
+            "phase": "train",
+            "reward_mean": 1.0,
+            "kl_mean": 0.05,
+            "entropy_mean": 0.9,
+            "clip_frac": 0.01,
+        }
+        trl_file.write_text(json.dumps(trl_payload) + "\n", encoding="utf-8")
+
+        # Should ingest without raising the custom adapter error
+        df = ingest_runs(trl_dir)
+
+        assert not df.empty
+        assert df["phase"].iloc[0] == "train"
+
         # Test 3: Full standard schema - should NOT be detected as custom
         with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
             json.dump({


### PR DESCRIPTION
## Summary
- tighten the CustomJSONLAdapter directory detection to inspect file contents before accepting a path
- prioritize TRL, OpenRLHF, and GRPO adapters ahead of the custom JSONL adapter during auto-detection
- add a regression test that ingests a TRL export directory to ensure the custom adapter no longer blocks ingestion

## Testing
- pytest tests/integration/test_ingestion.py::TestJSONLIngestion::test_trl_directory_ingestion_prefers_trl_adapter *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68d99fec8bd0832fbbb17f81803d2579

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorders adapter auto-detection to prefer TRL/OpenRLHF/GRPO before CustomJSONL and updates CustomJSONL directory handling to validate file contents; adds a regression test for TRL directories.
> 
> - **Ingest**:
>   - Reorder `_detect_adapter_type` to check `TRL`, `OpenRLHF`, and `GRPO` before `custom_jsonl`; keep `flexible` as fallback.
> - **Adapters**:
>   - `CustomJSONLAdapter.can_handle` for directories now inspects `*.jsonl` contents via `_is_custom_jsonl_file` instead of presence-only.
> - **Tests**:
>   - Add regression `test_trl_directory_ingestion_prefers_trl_adapter` ensuring TRL export directories ingest with the TRL adapter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54421f56fcee798959bad017c1d7cb9244da0056. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->