### PR TITLE
Add PPO dataset tokenization helper

### DIFF
--- a/examples/run_ppo_tiny.py
+++ b/examples/run_ppo_tiny.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Iterable, Optional
 
 import yaml
 
-from rldk.integrations.trl import create_ppo_trainer
+from rldk.integrations.trl import create_ppo_trainer, tokenize_text_column
 
 DEFAULT_MODEL_NAME = "sshleifer/tiny-gpt2"
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -191,6 +191,14 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
 
         dataset = build_tiny_dataset()
         tokenizer = load_tokenizer(model_name)
+        dataset = tokenize_text_column(
+            dataset,
+            tokenizer,
+            text_column="prompt",
+            padding=True,
+            truncation=True,
+            desc="Tokenizing PPO prompts",
+        )
         trainer = create_ppo_trainer(
             model_name=model_name,
             ppo_config=settings.ppo_config,

--- a/examples/trl_integration/basic_ppo_integration.py
+++ b/examples/trl_integration/basic_ppo_integration.py
@@ -19,6 +19,7 @@ from rldk.integrations.trl import (
     RLDKCallback,
     check_trl_compatibility,
     create_ppo_trainer,
+    tokenize_text_column,
 )
 from rldk.utils.math_utils import safe_divide
 
@@ -106,8 +107,22 @@ def test_basic_ppo_integration():
         print("✅ Example structure validated without model download")
         return True
 
-    # Create sample dataset
+    # Create tokenizer and sample dataset
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    if getattr(tokenizer, "padding_side", None) != "right":
+        tokenizer.padding_side = "right"
+
     dataset = create_sample_dataset()
+    dataset = tokenize_text_column(
+        dataset,
+        tokenizer,
+        text_column="prompt",
+        padding=True,
+        truncation=True,
+        desc="Tokenizing basic PPO prompts",
+    )
 
     # PPO configuration
     ppo_config = PPOConfig(
@@ -135,6 +150,7 @@ def test_basic_ppo_integration():
         train_dataset=dataset,
         callbacks=[rldk_callback, ppo_monitor, checkpoint_monitor],
         event_log_path=event_log_path,
+        tokenizer=tokenizer,
     )
 
     print("✅ PPO Trainer created with RLDK callbacks")

--- a/examples/trl_live_min.py
+++ b/examples/trl_live_min.py
@@ -6,10 +6,10 @@ import time
 from pathlib import Path
 
 from datasets import Dataset
-from transformers import TrainingArguments
+from transformers import AutoTokenizer, TrainingArguments
 
 # Import RLDK utilities
-from rldk.integrations.trl import create_ppo_trainer
+from rldk.integrations.trl import create_ppo_trainer, tokenize_text_column
 from rldk.integrations.trl.monitors import PPOMonitor as Monitor
 
 try:
@@ -67,6 +67,21 @@ def run_minimal_trl_loop():
     # Create dataset
     dataset = create_tiny_dataset()
     print(f"📊 Dataset created with {len(dataset)} samples")
+
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    if getattr(tokenizer, "padding_side", None) != "right":
+        tokenizer.padding_side = "right"
+
+    dataset = tokenize_text_column(
+        dataset,
+        tokenizer,
+        text_column="prompt",
+        padding=True,
+        truncation=True,
+        desc="Tokenizing TRL live prompts",
+    )
     
     # Initialize RLDK monitor with low thresholds to trigger alerts
     monitor = Monitor(
@@ -108,6 +123,7 @@ def run_minimal_trl_loop():
             train_dataset=dataset,
             callbacks=[monitor],
             event_log_path=event_log_path,
+            tokenizer=tokenizer,
         )
         print("✅ PPO Trainer created with RLDK monitor callback")
     except Exception as e:

--- a/examples/trl_real_training.py
+++ b/examples/trl_real_training.py
@@ -15,7 +15,7 @@ from transformers import (
 )
 
 # Import RLDK utilities
-from rldk.integrations.trl import create_ppo_trainer
+from rldk.integrations.trl import create_ppo_trainer, tokenize_text_column
 from rldk.integrations.trl.monitors import PPOMonitor as Monitor
 
 try:
@@ -124,6 +124,15 @@ def run_real_trl_training():
     # Create dataset
     dataset = create_tiny_dataset()
     print(f"📊 Dataset created with {len(dataset)} samples")
+
+    dataset = tokenize_text_column(
+        dataset,
+        tokenizer,
+        text_column="prompt",
+        padding=True,
+        truncation=True,
+        desc="Tokenizing TRL real training prompts",
+    )
     
     # Initialize RLDK monitor with low thresholds to trigger alerts
     monitor = Monitor(

--- a/src/rldk/integrations/trl/__init__.py
+++ b/src/rldk/integrations/trl/__init__.py
@@ -9,6 +9,7 @@ from .utils import (
     create_ppo_trainer,
     fix_generation_config,
     prepare_models_for_ppo,
+    tokenize_text_column,
     validate_ppo_setup,
 )
 
@@ -26,6 +27,7 @@ __all__ = [
     "create_ppo_trainer",
     "fix_generation_config",
     "prepare_models_for_ppo",
+    "tokenize_text_column",
     "check_trl_compatibility",
     "validate_ppo_setup",
 ]

--- a/src/rldk/integrations/trl/utils.py
+++ b/src/rldk/integrations/trl/utils.py
@@ -580,3 +580,61 @@ def validate_ppo_setup(
             "Verify tokenizer has required token IDs",
         ] if issues else [],
     }
+
+
+def tokenize_text_column(
+    dataset: "Dataset",
+    tokenizer: AutoTokenizer,
+    *,
+    text_column: str,
+    padding: Union[bool, str] = True,
+    truncation: Union[bool, str] = True,
+    max_length: Optional[int] = None,
+    add_special_tokens: bool = True,
+    desc: Optional[str] = None,
+) -> "Dataset":
+    """Add ``input_ids`` and ``attention_mask`` columns to a dataset.
+
+    The helper relies on :meth:`datasets.Dataset.map` to apply the tokenizer while keeping the
+    original text column intact so downstream components can still access the raw strings.
+
+    Args:
+        dataset: The dataset whose records contain ``text_column`` entries.
+        tokenizer: Tokenizer used to encode the strings.
+        text_column: Name of the column that should be tokenized.
+        padding: Padding strategy forwarded to the tokenizer.
+        truncation: Truncation strategy forwarded to the tokenizer.
+        max_length: Optional maximum sequence length.
+        add_special_tokens: Whether to include special tokens during tokenization.
+        desc: Optional description forwarded to :meth:`datasets.Dataset.map`.
+
+    Returns:
+        A dataset instance that includes ``input_ids`` and ``attention_mask`` columns.
+
+    Raises:
+        KeyError: If ``text_column`` is missing from the dataset records.
+    """
+
+    tokenization_kwargs: Dict[str, Any] = {
+        "return_tensors": None,
+        "padding": padding,
+        "truncation": truncation,
+        "add_special_tokens": add_special_tokens,
+    }
+
+    if max_length is not None:
+        tokenization_kwargs["max_length"] = max_length
+
+    def _tokenize(batch: Dict[str, Any]) -> Dict[str, Any]:
+        if text_column not in batch:
+            raise KeyError(f"Column '{text_column}' not found in batch")
+        texts = batch[text_column]
+        return tokenizer(texts, **tokenization_kwargs)
+
+    return dataset.map(
+        _tokenize,
+        batched=True,
+        remove_columns=[],
+        desc=desc or f"Tokenizing '{text_column}' column",
+    )
+

--- a/tests/unit/examples/test_tiny_scripts.py
+++ b/tests/unit/examples/test_tiny_scripts.py
@@ -94,8 +94,19 @@ def test_run_ppo_tiny_smoke(monkeypatch, tmp_path):
     dummy_tokenizer = types.SimpleNamespace(pad_token="[PAD]", eos_token="[EOS]", padding_side="right")
     monkeypatch.setattr(run_ppo_tiny, "load_tokenizer", lambda model_name: dummy_tokenizer)
 
+    def fake_tokenize(dataset, tokenizer, **kwargs):
+        for record in dataset:
+            record.setdefault("input_ids", [101, 102])
+            record.setdefault("attention_mask", [1, 1])
+        return dataset
+
+    monkeypatch.setattr(run_ppo_tiny, "tokenize_text_column", fake_tokenize)
+
     def fake_create_ppo_trainer(model_name, ppo_config, train_dataset, **kwargs):
         event_log_path = Path(kwargs["event_log_path"])
+
+        assert all("input_ids" in sample for sample in train_dataset)
+        assert all("attention_mask" in sample for sample in train_dataset)
 
         class DummyTrainer:
             def __init__(self, log_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a reusable `tokenize_text_column` helper for TRL datasets that preserves raw text
- apply the helper across PPO example scripts so tokenized columns exist before trainer creation
- update tiny PPO smoke test stubs to cover the new helper and assert tokenized inputs reach the trainer

## Testing
- pytest tests/unit/examples/test_tiny_scripts.py -k ppo -q

------
https://chatgpt.com/codex/tasks/task_e_68dddba4b5d4832fa8995d025544a0ae