### PR TITLE
Drop raw PPO text columns after tokenization

### DIFF
--- a/examples/run_ppo_tiny.py
+++ b/examples/run_ppo_tiny.py
@@ -197,8 +197,15 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
             text_column="prompt",
             padding=True,
             truncation=True,
+            keep_original=False,
             desc="Tokenizing PPO prompts",
         )
+        if hasattr(dataset, "remove_columns"):
+            if "response" in getattr(dataset, "column_names", []):
+                dataset = dataset.remove_columns(["response"])
+        else:  # pragma: no cover - exercised in unit tests with simple stubs
+            for record in dataset:
+                record.pop("response", None)
         trainer = create_ppo_trainer(
             model_name=model_name,
             ppo_config=settings.ppo_config,

--- a/examples/trl_integration/basic_ppo_integration.py
+++ b/examples/trl_integration/basic_ppo_integration.py
@@ -121,8 +121,15 @@ def test_basic_ppo_integration():
         text_column="prompt",
         padding=True,
         truncation=True,
+        keep_original=False,
         desc="Tokenizing basic PPO prompts",
     )
+    if hasattr(dataset, "remove_columns"):
+        if "response" in getattr(dataset, "column_names", []):
+            dataset = dataset.remove_columns(["response"])
+    else:  # pragma: no cover - exercised when stubbing datasets in tests
+        for record in dataset:
+            record.pop("response", None)
 
     # PPO configuration
     ppo_config = PPOConfig(

--- a/examples/trl_live_min.py
+++ b/examples/trl_live_min.py
@@ -80,9 +80,16 @@ def run_minimal_trl_loop():
         text_column="prompt",
         padding=True,
         truncation=True,
+        keep_original=False,
         desc="Tokenizing TRL live prompts",
     )
-    
+    if hasattr(dataset, "remove_columns"):
+        if "response" in getattr(dataset, "column_names", []):
+            dataset = dataset.remove_columns(["response"])
+    else:  # pragma: no cover - used when list-backed datasets are injected in tests
+        for record in dataset:
+            record.pop("response", None)
+
     # Initialize RLDK monitor with low thresholds to trigger alerts
     monitor = Monitor(
         output_dir=output_dir,

--- a/examples/trl_real_training.py
+++ b/examples/trl_real_training.py
@@ -131,9 +131,16 @@ def run_real_trl_training():
         text_column="prompt",
         padding=True,
         truncation=True,
+        keep_original=False,
         desc="Tokenizing TRL real training prompts",
     )
-    
+    if hasattr(dataset, "remove_columns"):
+        if "response" in getattr(dataset, "column_names", []):
+            dataset = dataset.remove_columns(["response"])
+    else:  # pragma: no cover - used in tests with lightweight dataset stubs
+        for record in dataset:
+            record.pop("response", None)
+
     # Initialize RLDK monitor with low thresholds to trigger alerts
     monitor = Monitor(
         output_dir=output_dir,

--- a/src/rldk/integrations/trl/utils.py
+++ b/src/rldk/integrations/trl/utils.py
@@ -591,12 +591,14 @@ def tokenize_text_column(
     truncation: Union[bool, str] = True,
     max_length: Optional[int] = None,
     add_special_tokens: bool = True,
+    keep_original: bool = False,
     desc: Optional[str] = None,
 ) -> "Dataset":
     """Add ``input_ids`` and ``attention_mask`` columns to a dataset.
 
-    The helper relies on :meth:`datasets.Dataset.map` to apply the tokenizer while keeping the
-    original text column intact so downstream components can still access the raw strings.
+    The helper relies on :meth:`datasets.Dataset.map` to apply the tokenizer and, by default,
+    removes the source text column so the resulting dataset only contains tensor-friendly fields.
+    Set ``keep_original=True`` to retain the raw strings alongside the tokenized payload.
 
     Args:
         dataset: The dataset whose records contain ``text_column`` entries.
@@ -606,6 +608,7 @@ def tokenize_text_column(
         truncation: Truncation strategy forwarded to the tokenizer.
         max_length: Optional maximum sequence length.
         add_special_tokens: Whether to include special tokens during tokenization.
+        keep_original: When ``True`` the raw ``text_column`` is retained in the mapped dataset.
         desc: Optional description forwarded to :meth:`datasets.Dataset.map`.
 
     Returns:
@@ -631,10 +634,14 @@ def tokenize_text_column(
         texts = batch[text_column]
         return tokenizer(texts, **tokenization_kwargs)
 
+    remove_columns: Optional[List[str]] = None
+    if not keep_original:
+        remove_columns = [text_column]
+
     return dataset.map(
         _tokenize,
         batched=True,
-        remove_columns=[],
+        remove_columns=remove_columns,
         desc=desc or f"Tokenizing '{text_column}' column",
     )
 

--- a/tests/unit/examples/test_tiny_scripts.py
+++ b/tests/unit/examples/test_tiny_scripts.py
@@ -95,10 +95,15 @@ def test_run_ppo_tiny_smoke(monkeypatch, tmp_path):
     monkeypatch.setattr(run_ppo_tiny, "load_tokenizer", lambda model_name: dummy_tokenizer)
 
     def fake_tokenize(dataset, tokenizer, **kwargs):
+        sanitized = []
         for record in dataset:
-            record.setdefault("input_ids", [101, 102])
-            record.setdefault("attention_mask", [1, 1])
-        return dataset
+            sanitized_record = dict(record)
+            sanitized_record.pop("prompt", None)
+            sanitized_record.pop("response", None)
+            sanitized_record.setdefault("input_ids", [101, 102])
+            sanitized_record.setdefault("attention_mask", [1, 1])
+            sanitized.append(sanitized_record)
+        return sanitized
 
     monkeypatch.setattr(run_ppo_tiny, "tokenize_text_column", fake_tokenize)
 
@@ -107,6 +112,8 @@ def test_run_ppo_tiny_smoke(monkeypatch, tmp_path):
 
         assert all("input_ids" in sample for sample in train_dataset)
         assert all("attention_mask" in sample for sample in train_dataset)
+        assert all("prompt" not in sample for sample in train_dataset)
+        assert all("response" not in sample for sample in train_dataset)
 
         class DummyTrainer:
             def __init__(self, log_path: Path) -> None:


### PR DESCRIPTION
## Summary
- drop raw text columns by default in `tokenize_text_column` with an opt-out flag
- ensure PPO example scripts strip non-tensor fields before calling `create_ppo_trainer`
- update tiny PPO script tests to reflect token-only datasets

## Testing
- pytest tests/unit/examples/test_tiny_scripts.py


------
https://chatgpt.com/codex/tasks/task_e_68deb20bdb04832fb1ef7d71a38c04f9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Default to removing raw text columns during tokenization and update PPO examples to strip non-tensor fields with corresponding test adjustments.
> 
> - **Utilities**:
>   - `tokenize_text_column` now defaults to dropping `text_column` via `remove_columns`; add `keep_original=False` flag to retain it if needed.
>   - Updated docstring accordingly.
> - **Examples (PPO)**:
>   - In `examples/run_ppo_tiny.py`, `examples/trl_integration/basic_ppo_integration.py`, `examples/trl_live_min.py`, `examples/trl_real_training.py`:
>     - Pass `keep_original=False` to `tokenize_text_column`.
>     - Remove `response` column after tokenization (supports both HF `Dataset.remove_columns` and list-backed datasets).
> - **Tests**:
>   - `tests/unit/examples/test_tiny_scripts.py`: adjust tokenization stub to drop `prompt` and `response`; add assertions ensuring only tensor fields remain.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03193502090bc43298eeab5a2a5e53c075db15e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->