### PR TITLE
Adjust TRL PPO wrapping logic and add tests

### DIFF
--- a/src/rldk/integrations/trl/utils.py
+++ b/src/rldk/integrations/trl/utils.py
@@ -7,7 +7,7 @@ import warnings
 
 from packaging import version
 from packaging.version import InvalidVersion
-from transformers import AutoTokenizer, GenerationConfig
+from transformers import AutoModelForCausalLM, AutoTokenizer, GenerationConfig, PreTrainedModel
 
 from .callbacks import EventWriterCallback
 
@@ -155,6 +155,26 @@ def create_grpo_config(**config_kwargs: Any) -> "GRPOConfig":
     return GRPOConfig(**safe_kwargs)
 
 
+def _build_generation_config(
+    tokenizer: AutoTokenizer,
+    generation_config: Optional[GenerationConfig],
+) -> GenerationConfig:
+    """Return a usable :class:`~transformers.GenerationConfig` instance."""
+
+    if generation_config is not None:
+        return generation_config
+
+    return GenerationConfig(
+        eos_token_id=tokenizer.eos_token_id,
+        pad_token_id=tokenizer.pad_token_id,
+        bos_token_id=getattr(tokenizer, "bos_token_id", None),
+        max_length=512,
+        do_sample=True,
+        temperature=1.0,
+        top_p=1.0,
+    )
+
+
 def fix_generation_config(
     model: "AutoModelForCausalLMWithValueHead",
     tokenizer: AutoTokenizer,
@@ -181,20 +201,17 @@ def fix_generation_config(
     if not TRL_AVAILABLE:
         raise ImportError("TRL is required for this function. Install with: pip install trl")
 
+    if AutoModelForCausalLMWithValueHead is None:
+        raise ImportError(
+            "AutoModelForCausalLMWithValueHead is unavailable despite TRL being installed."
+            " Upgrade TRL to a version that provides value head models."
+        )
+
     if not isinstance(model, AutoModelForCausalLMWithValueHead):
         raise AttributeError("Model must be an AutoModelForCausalLMWithValueHead instance")
 
     # Create generation config if not provided
-    if generation_config is None:
-        generation_config = GenerationConfig(
-            eos_token_id=tokenizer.eos_token_id,
-            pad_token_id=tokenizer.pad_token_id,
-            bos_token_id=getattr(tokenizer, 'bos_token_id', None),
-            max_length=512,  # Default max length
-            do_sample=True,  # Enable sampling for generation
-            temperature=1.0,  # Default temperature
-            top_p=1.0,  # Default top_p
-        )
+    generation_config = _build_generation_config(tokenizer, generation_config)
 
     # Set the generation_config attribute
     model.generation_config = generation_config
@@ -238,8 +255,8 @@ def prepare_models_for_ppo(
     tokenizer: Optional[AutoTokenizer] = None,
     generation_config: Optional[GenerationConfig] = None
 ) -> Tuple[
-    "AutoModelForCausalLMWithValueHead",
-    "AutoModelForCausalLMWithValueHead",
+    PreTrainedModel,
+    PreTrainedModel,
     "AutoModelForCausalLMWithValueHead",
     AutoTokenizer,
 ]:
@@ -263,14 +280,18 @@ def prepare_models_for_ppo(
         if tokenizer.pad_token is None:
             tokenizer.pad_token = tokenizer.eos_token
 
-    # Create models - use same model for policy and reward heads
-    model = AutoModelForCausalLMWithValueHead.from_pretrained(model_name)
-    ref_model = AutoModelForCausalLMWithValueHead.from_pretrained(model_name)
+    # Create models - load policy/reference as base causal LMs to preserve weights
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+    ref_model = AutoModelForCausalLM.from_pretrained(model_name)
     reward_model = AutoModelForCausalLMWithValueHead.from_pretrained(model_name)
 
-    # Fix generation_config for all models
-    model = fix_generation_config(model, tokenizer, generation_config)
-    ref_model = fix_generation_config(ref_model, tokenizer, generation_config)
+    # Ensure policy/ref models expose a usable generation_config
+    shared_generation_config = _build_generation_config(tokenizer, generation_config)
+    for candidate in (model, ref_model):
+        if getattr(candidate, "generation_config", None) is None:
+            candidate.generation_config = shared_generation_config
+
+    # Fix generation_config for TRL models
     reward_model = fix_generation_config(reward_model, tokenizer, generation_config)
 
     return model, ref_model, reward_model, tokenizer
@@ -304,6 +325,31 @@ def _ensure_generation_config(
         )
 
     return fix_generation_config(candidate, tokenizer, generation_config)
+
+
+def _wrap_policy_for_legacy_trl(
+    candidate: Optional[Union[PreTrainedModel, "AutoModelForCausalLMWithValueHead"]],
+    *,
+    model_name: str,
+    tokenizer: AutoTokenizer,
+    generation_config: Optional[GenerationConfig],
+) -> "AutoModelForCausalLMWithValueHead":
+    """Wrap policy models with TRL value heads without losing pretrained weights."""
+
+    if AutoModelForCausalLMWithValueHead is None:
+        raise ImportError(
+            "AutoModelForCausalLMWithValueHead is unavailable. Upgrade TRL to wrap policy models."
+        )
+
+    if isinstance(candidate, AutoModelForCausalLMWithValueHead):
+        return fix_generation_config(candidate, tokenizer, generation_config)
+
+    if candidate is not None:
+        wrapped = AutoModelForCausalLMWithValueHead.from_pretrained(pretrained_model=candidate)
+    else:
+        wrapped = AutoModelForCausalLMWithValueHead.from_pretrained(model_name)
+
+    return fix_generation_config(wrapped, tokenizer, generation_config)
 
 
 def create_ppo_trainer(
@@ -387,6 +433,20 @@ def create_ppo_trainer(
     if tokenizer is None:
         raise ValueError("Tokenizer could not be prepared for PPO training")
 
+    if not use_new_api:
+        model = _wrap_policy_for_legacy_trl(
+            model,
+            model_name=model_name,
+            tokenizer=tokenizer,
+            generation_config=generation_config,
+        )
+        ref_model = _wrap_policy_for_legacy_trl(
+            ref_model,
+            model_name=model_name,
+            tokenizer=tokenizer,
+            generation_config=generation_config,
+        )
+
     if use_new_api and value_model is None:
         value_model = _prepare_value_model(
             model_name,
@@ -402,6 +462,7 @@ def create_ppo_trainer(
             value_model,
             tokenizer,
             require_value_model=use_new_api,
+            allow_base_models=use_new_api,
         )
         if not validation["valid"]:
             issues = "; ".join(validation["issues"])
@@ -523,6 +584,7 @@ def validate_ppo_setup(
     tokenizer: Optional[AutoTokenizer],
     *,
     require_value_model: bool = True,
+    allow_base_models: bool = False,
 ) -> Dict[str, Any]:
     """Validate PPO setup for common issues."""
 
@@ -530,7 +592,13 @@ def validate_ppo_setup(
     warnings: List[str] = []
 
     # Helper to validate TRL value-head models
-    def _check_value_head(name: str, model_obj: Optional[Any], required: bool = True) -> None:
+    def _check_value_head(
+        name: str,
+        model_obj: Optional[Any],
+        *,
+        required: bool = True,
+        allow_plain: bool = False,
+    ) -> None:
         if model_obj is None:
             message = f"{name} is missing"
             if required:
@@ -540,6 +608,11 @@ def validate_ppo_setup(
             return
 
         if not isinstance(model_obj, AutoModelForCausalLMWithValueHead):
+            if allow_plain and name in {"model", "ref_model"}:
+                if hasattr(model_obj, "forward"):
+                    if getattr(model_obj, "generation_config", None) is None:
+                        warnings.append(f"{name} missing generation_config attribute")
+                    return
             issues.append(f"{name} is not an AutoModelForCausalLMWithValueHead instance")
             return
 
@@ -548,8 +621,8 @@ def validate_ppo_setup(
         elif model_obj.generation_config is None:
             warnings.append(f"{name} has None generation_config")
 
-    _check_value_head("model", model)
-    _check_value_head("ref_model", ref_model)
+    _check_value_head("model", model, allow_plain=allow_base_models)
+    _check_value_head("ref_model", ref_model, allow_plain=allow_base_models)
     _check_value_head("value_model", value_model, required=require_value_model)
 
     if reward_model is None:

--- a/tests/integration/test_trl_policy_wrapping.py
+++ b/tests/integration/test_trl_policy_wrapping.py
@@ -1,0 +1,274 @@
+"""Integration tests for TRL policy wrapping helpers."""
+
+import sys
+import types
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+import pytest
+
+if "numpy" not in sys.modules:
+    class _RandomArray(list):
+        def tolist(self) -> List[float]:  # pragma: no cover - simple helper
+            return list(self)
+
+    class _RandomStub:
+        def __init__(self) -> None:
+            self._state: Any = (0,)
+
+        def get_state(self) -> Any:
+            return self._state
+
+        def set_state(self, state: Any) -> None:
+            self._state = state
+
+        def seed(self, seed: Any = None) -> None:  # pragma: no cover - deterministic stub
+            self._state = (seed,)
+
+        def random(self, size: Any = None) -> Any:
+            if size is None:
+                return 0.0
+            if isinstance(size, int):
+                return _RandomArray([0.0] * size)
+            if isinstance(size, tuple):
+                total = 1
+                for dim in size:
+                    total *= dim or 1
+                return _RandomArray([0.0] * total)
+            return _RandomArray([0.0])
+
+    numpy_stub = types.ModuleType("numpy")
+    numpy_stub.std = lambda *args, **kwargs: 0.0  # type: ignore[assignment]
+    numpy_stub.polyfit = lambda *args, **kwargs: [0.0]  # type: ignore[assignment]
+    numpy_stub.mean = lambda *args, **kwargs: 0.0  # type: ignore[assignment]
+    numpy_stub.random = _RandomStub()  # type: ignore[assignment]
+    numpy_stub.ndarray = list  # type: ignore[assignment]
+    sys.modules["numpy"] = numpy_stub
+
+if "pandas" not in sys.modules:
+    pandas_stub = types.ModuleType("pandas")
+    pandas_stub.DataFrame = lambda *args, **kwargs: None  # type: ignore[assignment]
+    sys.modules["pandas"] = pandas_stub
+
+if "transformers" not in sys.modules:
+    transformers_stub = types.ModuleType("transformers")
+
+    class _PreTrainedModel:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - simple stub
+            pass
+
+    class _GenerationConfig:
+        def __init__(self, **kwargs: Any) -> None:  # pragma: no cover - simple stub
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    class _AutoCausalLM(_PreTrainedModel):
+        def __init__(self) -> None:
+            super().__init__()
+            self.name_or_path = "stub"
+            self.base_model_prefix = "transformer"
+            self.transformer = object()
+            self.is_gradient_checkpointing = False
+            self.generation_config = None
+
+        def forward(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:  # pragma: no cover - unused
+            return {}
+
+    class _AutoModelForCausalLM:
+        @staticmethod
+        def from_pretrained(*_args: Any, **_kwargs: Any) -> _AutoCausalLM:
+            return _AutoCausalLM()
+
+    class _AutoTokenizer:
+        def __init__(self) -> None:
+            self.pad_token = "<pad>"
+            self.eos_token = "<eos>"
+            self.pad_token_id = 0
+            self.eos_token_id = 1
+            self.bos_token_id = 0
+
+        @classmethod
+        def from_pretrained(cls, *_args: Any, **_kwargs: Any) -> "_AutoTokenizer":
+            return cls()
+
+    transformers_stub.PreTrainedModel = _PreTrainedModel  # type: ignore[assignment]
+    transformers_stub.GenerationConfig = _GenerationConfig  # type: ignore[assignment]
+    transformers_stub.AutoModelForCausalLM = _AutoModelForCausalLM  # type: ignore[assignment]
+    transformers_stub.AutoTokenizer = _AutoTokenizer  # type: ignore[assignment]
+    sys.modules["transformers"] = transformers_stub
+
+from src.rldk.integrations.trl import utils as trl_utils
+
+
+class DummyTokenizer:
+    eos_token_id = 1
+    pad_token_id = 1
+    bos_token_id = 0
+    pad_token = "<pad>"
+    eos_token = "<eos>"
+
+
+class DummyPolicy:
+    """Minimal causal LM stand-in with preserved weights."""
+
+    def __init__(self, name: str):
+        self.name_or_path = name
+        self.base_model_prefix = "transformer"
+        self.transformer = object()
+        self.is_gradient_checkpointing = False
+        self.custom_tensor = [name]
+        self.generation_config = SimpleNamespace()
+
+    def forward(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:  # pragma: no cover - unused
+        return {}
+
+
+class DummyValueHead:
+    """Simple wrapper mimicking AutoModelForCausalLMWithValueHead behaviour."""
+
+    call_history: List[Dict[str, Any]] = []
+
+    def __init__(self, pretrained_model: DummyPolicy, model_name_or_path: str = ""):
+        self.pretrained_model = pretrained_model
+        self.name_or_path = model_name_or_path or getattr(pretrained_model, "name_or_path", "wrapped")
+        self.base_model_prefix = getattr(pretrained_model, "base_model_prefix", "transformer")
+        if hasattr(pretrained_model, self.base_model_prefix):
+            setattr(self, self.base_model_prefix, getattr(pretrained_model, self.base_model_prefix))
+        self.is_gradient_checkpointing = getattr(pretrained_model, "is_gradient_checkpointing", False)
+        self.generation_config = None
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_name_or_path: str = "",
+        *_,
+        pretrained_model: DummyPolicy = None,
+        **__,
+    ) -> "DummyValueHead":
+        if pretrained_model is None:
+            pretrained_model = DummyPolicy(model_name_or_path)
+        instance = cls(pretrained_model, model_name_or_path)
+        cls.call_history.append(
+            {
+                "model_name_or_path": model_name_or_path,
+                "pretrained_model": pretrained_model,
+            }
+        )
+        return instance
+
+    def to(self, *args: Any, **kwargs: Any) -> "DummyValueHead":  # pragma: no cover - unused helper
+        return self
+
+
+class DummyTrainer:
+    """Minimal PPOTrainer replacement capturing constructor arguments."""
+
+    def __init__(
+        self,
+        *,
+        args: Any,
+        model: DummyValueHead,
+        ref_model: DummyValueHead,
+        processing_class: DummyTokenizer,
+        train_dataset: Any,
+        callbacks: List[Any],
+        **kwargs: Any,
+    ) -> None:
+        self.args = args
+        self.model = model
+        self.ref_model = ref_model
+        self.processing_class = processing_class
+        self.train_dataset = train_dataset
+        self.callbacks = callbacks
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+@pytest.fixture(autouse=True)
+def _reset_call_history() -> None:
+    DummyValueHead.call_history.clear()
+
+
+def _prepare_trl_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configure TRL utilities to use dummy implementations."""
+
+    dummy_trl_module = types.ModuleType("trl")
+    dummy_trl_module.PPOTrainer = DummyTrainer
+    dummy_trl_module.AutoModelForCausalLMWithValueHead = DummyValueHead
+    monkeypatch.setitem(sys.modules, "trl", dummy_trl_module)
+
+    monkeypatch.setattr(trl_utils, "TRL_AVAILABLE", True)
+    monkeypatch.setattr(trl_utils, "AutoModelForCausalLMWithValueHead", DummyValueHead)
+    monkeypatch.setattr(trl_utils, "check_trl_compatibility", lambda: {"version": "0.22.0"})
+
+
+def test_legacy_wrapping_preserves_custom_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Custom policies retain their tensors after legacy TRL wrapping."""
+
+    _prepare_trl_environment(monkeypatch)
+
+    tokenizer = DummyTokenizer()
+    policy = DummyPolicy("policy-model")
+    ref_policy = DummyPolicy("ref-model")
+    reward_model = DummyValueHead.from_pretrained("reward-model")
+
+    trainer = trl_utils.create_ppo_trainer(
+        "base-model",
+        SimpleNamespace(run_name="run"),
+        train_dataset=[{"input_ids": [0]}],
+        tokenizer=tokenizer,
+        model=policy,
+        ref_model=ref_policy,
+        reward_model=reward_model,
+        callbacks=[],
+        validate_setup=True,
+    )
+
+    # Ensure policies were wrapped and original weights preserved
+    assert isinstance(trainer.model, DummyValueHead)
+    assert trainer.model.pretrained_model is policy
+    assert trainer.model.pretrained_model.custom_tensor == policy.custom_tensor
+
+    assert isinstance(trainer.ref_model, DummyValueHead)
+    assert trainer.ref_model.pretrained_model is ref_policy
+
+    # Verify wrapping invoked the pretrained_model shortcut rather than reloading from disk
+    assert DummyValueHead.call_history[1]["pretrained_model"] is policy
+    assert DummyValueHead.call_history[2]["pretrained_model"] is ref_policy
+
+
+def test_validate_setup_rejects_plain_value_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Even when base policies are allowed, value model must have a value head."""
+
+    _prepare_trl_environment(monkeypatch)
+
+    tokenizer = DummyTokenizer()
+    reward_model = DummyValueHead.from_pretrained("reward-model")
+
+    result = trl_utils.validate_ppo_setup(
+        DummyPolicy("policy"),
+        DummyPolicy("ref"),
+        reward_model,
+        DummyPolicy("value"),
+        tokenizer,
+        require_value_model=True,
+        allow_base_models=True,
+    )
+
+    assert not result["valid"]
+    assert any(
+        "value_model is not an AutoModelForCausalLMWithValueHead instance" in issue
+        for issue in result["issues"]
+    )
+
+
+def test_fix_generation_config_errors_without_value_head(monkeypatch: pytest.MonkeyPatch) -> None:
+    """fix_generation_config() raises a clear error when value-head models are unavailable."""
+
+    monkeypatch.setattr(trl_utils, "TRL_AVAILABLE", True)
+    monkeypatch.setattr(trl_utils, "AutoModelForCausalLMWithValueHead", None)
+
+    with pytest.raises(ImportError) as exc_info:
+        trl_utils.fix_generation_config(object(), DummyTokenizer())
+
+    assert "AutoModelForCausalLMWithValueHead" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- load PPO policy and reference models via AutoModelForCausalLM, wrap legacy TRL policies without reloading, and guard fix_generation_config when the value-head class is absent
- keep value/reward heads on AutoModelForCausalLMWithValueHead while allowing validate_ppo_setup to accept base policies only when explicitly permitted
- add integration coverage to ensure legacy policy weights survive wrapping, validation rejects plain value models, and missing value-head classes raise clear errors

## Testing
- pytest tests/integration/test_trl_policy_wrapping.py

------
https://chatgpt.com/codex/tasks/task_e_68decd215e9c832fa7a300a22e818487