### PR TITLE
Ensure TRL value-head models expose warnings registry

### DIFF
--- a/examples/run_grpo_tiny.py
+++ b/examples/run_grpo_tiny.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, Iterable, Optional
 import yaml
 
 from rldk.emit import EventWriter
-from rldk.integrations.trl import EventWriterCallback, create_grpo_config
+from rldk.integrations.trl import EventWriterCallback, create_grpo_config, fix_generation_config
 
 DEFAULT_MODEL_NAME = "sshleifer/tiny-gpt2"
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -168,6 +168,7 @@ def build_grpo_trainer(
 
     # For GRPO, we use the model as both policy and reward function
     model = AutoModelForCausalLMWithValueHead.from_pretrained(model_name)
+    model = fix_generation_config(model, tokenizer)
 
     callback = EventWriterCallback(event_log_path, run_id=getattr(grpo_config, "run_name", None))
 

--- a/src/rldk/integrations/trl/utils.py
+++ b/src/rldk/integrations/trl/utils.py
@@ -258,6 +258,10 @@ def fix_generation_config(
         else:
             model.is_gradient_checkpointing = False  # Default to False
 
+    # Ensure TRL compatibility helpers can track emitted warnings.
+    if not hasattr(model, 'warnings_issued'):
+        model.warnings_issued = {}
+
     return _ensure_value_head_score(model)
 
 

--- a/tests/integration/test_trl_policy_wrapping.py
+++ b/tests/integration/test_trl_policy_wrapping.py
@@ -289,6 +289,24 @@ def test_validate_setup_rejects_plain_value_model(monkeypatch: pytest.MonkeyPatc
     )
 
 
+def test_fix_generation_config_initializes_warning_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """fix_generation_config() ensures TRL models expose a warnings registry."""
+
+    _prepare_trl_environment(monkeypatch)
+
+    tokenizer = DummyTokenizer()
+    model = DummyValueHead.from_pretrained("policy-model")
+
+    assert not hasattr(model, "warnings_issued")
+
+    patched = trl_utils.fix_generation_config(model, tokenizer)
+
+    assert hasattr(patched, "warnings_issued")
+    assert patched.warnings_issued == {}
+
+
 def test_fix_generation_config_errors_without_value_head(monkeypatch: pytest.MonkeyPatch) -> None:
     """fix_generation_config() raises a clear error when value-head models are unavailable."""
 


### PR DESCRIPTION
## Summary
- ensure `fix_generation_config` populates the `warnings_issued` registry expected by TRL
- update the GRPO tiny example to run the generation config shim on the model
- add a regression test that verifies the shim always provides the warning registry

## Testing
- `pytest tests/integration/test_trl_policy_wrapping.py`


------
https://chatgpt.com/codex/tasks/task_e_68df0634129c832f94341d7a4a57e585