### PR TITLE
Add GRPO trainer shim for missing add_model_tags

### DIFF
--- a/examples/run_grpo_tiny.py
+++ b/examples/run_grpo_tiny.py
@@ -7,6 +7,7 @@ import random
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from types import MethodType
 from typing import Any, Dict, Iterable, Optional
 
 import yaml
@@ -169,6 +170,15 @@ def build_grpo_trainer(
     # For GRPO, we use the model as both policy and reward function
     model = AutoModelForCausalLMWithValueHead.from_pretrained(model_name)
     model = fix_generation_config(model, tokenizer)
+
+    if not hasattr(model, "add_model_tags"):
+        # TRL < 0.24.0 does not define ``add_model_tags`` on value-head models.
+        # Newer releases call this method unconditionally during trainer setup.
+        # Provide a no-op shim so the example remains compatible across versions.
+        def _noop_add_model_tags(self, *_args, **_kwargs):
+            return None
+
+        model.add_model_tags = MethodType(_noop_add_model_tags, model)
 
     callback = EventWriterCallback(event_log_path, run_id=getattr(grpo_config, "run_name", None))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ compiled = [
     "datasets==2.16.0",
     "tokenizers==0.20.3",
     "nltk==3.8.1",
-    "trl>=0.7.0,<0.24.0",
+    "trl>=0.7.0,<0.25.0",
     "accelerate>=0.26.0",
     "detoxify==0.5.2",
     "vaderSentiment==3.3.2",

--- a/tests/examples/test_run_grpo_tiny.py
+++ b/tests/examples/test_run_grpo_tiny.py
@@ -1,0 +1,121 @@
+"""Regression tests for :mod:`examples.run_grpo_tiny`."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("numpy", reason="global fixtures require numpy")
+
+
+@pytest.fixture()
+def trl_stub(monkeypatch: pytest.MonkeyPatch):
+    """Provide a minimal TRL stub without ``add_model_tags`` support."""
+
+    stub = types.ModuleType("trl")
+
+    class DummyValueHeadModel:
+        """Model lacking ``add_model_tags`` to mimic older TRL releases."""
+
+        base_model_prefix = "transformer"
+
+        def __init__(self) -> None:
+            self.pretrained_model = types.SimpleNamespace(
+                base_model_prefix="transformer",
+                transformer=object(),
+                is_gradient_checkpointing=False,
+            )
+            self.v_head = object()
+            self.generation_config = None
+            self.name_or_path = "dummy"
+
+        @classmethod
+        def from_pretrained(cls, *_args, **_kwargs):
+            pretrained_model = _kwargs.get("pretrained_model")
+            instance = cls()
+            if pretrained_model is not None:
+                instance.pretrained_model = pretrained_model
+            return instance
+
+    class DummyGRPOTrainer:
+        """Trainer that verifies ``add_model_tags`` is safely available."""
+
+        def __init__(
+            self,
+            *,
+            args,
+            model,
+            reward_funcs,
+            processing_class,
+            train_dataset,
+            callbacks,
+        ) -> None:
+            self.args = args
+            self.model = model
+            self.reward_funcs = reward_funcs
+            self.processing_class = processing_class
+            self.train_dataset = train_dataset
+            self.callbacks = callbacks
+            self._trained = False
+
+            # Newer TRL releases invoke ``add_model_tags`` during setup. Ensure the
+            # shim installed by ``build_grpo_trainer`` prevents AttributeErrors.
+            model.add_model_tags(["grpo"])
+
+        def train(self) -> None:
+            self._trained = True
+
+    stub.AutoModelForCausalLMWithValueHead = DummyValueHeadModel
+    stub.GRPOTrainer = DummyGRPOTrainer
+
+    monkeypatch.setitem(sys.modules, "trl", stub)
+
+    # Reload helper modules so they pick up the stub instead of real TRL.
+    import rldk.integrations.trl.utils as trl_utils
+
+    importlib.reload(trl_utils)
+    import rldk.integrations.trl as trl_integration
+
+    importlib.reload(trl_integration)
+
+    return stub
+
+
+def test_build_grpo_trainer_shims_missing_add_model_tags(trl_stub, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    import examples.run_grpo_tiny as run_grpo_tiny
+
+    importlib.reload(run_grpo_tiny)
+
+    # Avoid importing heavy dependencies that the example expects in production.
+    class DummyCallback:
+        def __init__(self, *args, **kwargs) -> None:  # noqa: D401 - trivial stub
+            self.args = args
+            self.kwargs = kwargs
+
+    monkeypatch.setattr(run_grpo_tiny, "EventWriterCallback", DummyCallback)
+
+    tokenizer = types.SimpleNamespace(
+        eos_token_id=0,
+        pad_token_id=0,
+        bos_token_id=1,
+    )
+    dataset = [{"prompt": "hi", "reference_response": "hello", "accepted": True}]
+    grpo_config = types.SimpleNamespace(run_name="test-run")
+    event_log_path = tmp_path / "events.jsonl"
+
+    trainer = run_grpo_tiny.build_grpo_trainer(
+        model_name="dummy",
+        grpo_config=grpo_config,
+        dataset=dataset,
+        tokenizer=tokenizer,
+        event_log_path=event_log_path,
+    )
+
+    trainer.train()
+
+    assert getattr(trainer, "_trained", False) is True
+


### PR DESCRIPTION
## Summary
- add a MethodType-based shim for `add_model_tags` in `examples/run_grpo_tiny.py` so the example works across TRL releases
- add a regression test that stubs TRL to mimic the newest release and ensures the trainer completes when `add_model_tags` is missing
- relax the TRL upper bound in `pyproject.toml` to allow the upcoming 0.24.x line

## Testing
- `pytest tests/examples/test_run_grpo_tiny.py`

------
https://chatgpt.com/codex/tasks/task_e_68e007d6c310832fbd9fbe6b3439b92a